### PR TITLE
Fixing targets files to remove duplicate import warnings

### DIFF
--- a/Test/Platform/Tests/CLR/DPWS/WSDL/DpwsTestFixtures.dpwsproj
+++ b/Test/Platform/Tests/CLR/DPWS/WSDL/DpwsTestFixtures.dpwsproj
@@ -10,8 +10,8 @@
   CSharpFiles - optional list of C# files to add to the generated project.
     
   -->
-  
-  <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.Build.Setup.Targets"/>
+
+  <Import Condition="'$(Microsoft_SPOT_Build_Setup_Targts_Imported)'==''" Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.Build.Setup.Targets"/>
 
   <ItemGroup>
     <!--Removed Alarm.wsdl:  Test case need to be able to properly handle 

--- a/tools/Targets/Microsoft.SPOT.Build.Common.Targets
+++ b/tools/Targets/Microsoft.SPOT.Build.Common.Targets
@@ -14,7 +14,7 @@
     <CommonAssemblyInfoFile Condition="'$(CommonAssemblyInfoFile)'==''"
         >$(SPOCLIENT)\tools\targets\Microsoft.SPOT.CommonAssemblyInfo.Targets</CommonAssemblyInfoFile>
   </PropertyGroup>
-  <Import Project="$(CommonAssemblyInfoFile)" />
+  <Import Condition="'$(Microsoft_SPOT_CommonAssemblyInfo_Targets)'!='true'" Project="$(CommonAssemblyInfoFile)" />
 
   <Import Project="Microsoft.SPOT.SDK.Targets" />
 

--- a/tools/Targets/Microsoft.SPOT.CSharp.Host.Targets
+++ b/tools/Targets/Microsoft.SPOT.CSharp.Host.Targets
@@ -57,7 +57,7 @@
     </AssemblySearchPaths>
   </PropertyGroup>
 
-  <Import Project="Microsoft.SPOT.Build.Setup.Targets" />
+  <Import Condition="'$(Microsoft_SPOT_Build_Setup_Targts_Imported)'==''" Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.Build.Setup.Targets"/>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSHARP.Targets" />
   <Import Project="Microsoft.SPOT.Build.Host.Targets" />
 

--- a/tools/Targets/Microsoft.SPOT.Common.Targets
+++ b/tools/Targets/Microsoft.SPOT.Common.Targets
@@ -5,7 +5,7 @@
     <AssemblyName>BogusAssemblyName</AssemblyName>
   </PropertyGroup>
 
-  <Import Project="Microsoft.SPOT.Build.Setup.Targets" />
+  <Import Condition="'$(Microsoft_SPOT_Build_Setup_Targts_Imported)'==''" Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.Build.Setup.Targets"/>
   <Import Project="$(MSBuildBinPath)\Microsoft.Common.Targets" />
   <Import Project="Microsoft.SPOT.Build.Targets" />
 

--- a/tools/Targets/Microsoft.SPOT.CommonAssemblyInfo.Targets
+++ b/tools/Targets/Microsoft.SPOT.CommonAssemblyInfo.Targets
@@ -1,8 +1,12 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"  ToolsVersion="4.0">
 
+    <PropertyGroup>
+        <Microsoft_SPOT_CommonAssemblyInfo_Targets>true</Microsoft_SPOT_CommonAssemblyInfo_Targets>
+    </PropertyGroup>
+    
     <!-- You can override in your project the file that contains your ReleaseInfo settings if you need to. You can
          even avoid having such a file entirely by defining the standard release info and setting the property
-         _Microsoft_SPOT_CommonAssemblyInfo_Targets__Included_ to 'true'
+         _ReleaseInfo__Included_ to 'true'
          -->
     <PropertyGroup>
         <ReleaseInfo             Condition="'$(ReleaseInfo)'==''"             >$(SPOCLIENT)\ReleaseInfo.settings</ReleaseInfo>

--- a/tools/Targets/Microsoft.SPOT.System.Manifest.Targets
+++ b/tools/Targets/Microsoft.SPOT.System.Manifest.Targets
@@ -2,7 +2,7 @@
 
     <!-- You can override in your project the file that contains your ReleaseInfo settings if you need to. You can
          even avoid having such a file entirely by defining the standard release info and setting the property
-         _Microsoft_SPOT_CommonAssemblyInfo_Targets__Included_ to 'true'
+         _ReleaseInfo__Included_ to 'true'
          -->
     <PropertyGroup>
         <ReleaseInfo Condition="'$(ReleaseInfo)'==''" >$(SPOCLIENT)\ReleaseInfo.settings</ReleaseInfo>

--- a/tools/Targets/Microsoft.SPOT.System.x86.Targets
+++ b/tools/Targets/Microsoft.SPOT.System.x86.Targets
@@ -36,7 +36,7 @@
     <CommonAssemblyInfoFile Condition="'$(CommonAssemblyInfoFile)'==''"
         >$(SPOCLIENT)\tools\targets\Microsoft.SPOT.CommonAssemblyInfo.Targets</CommonAssemblyInfoFile>
   </PropertyGroup>
-  <Import Project="$(CommonAssemblyInfoFile)" />
+  <Import Condition="'$(Microsoft_SPOT_CommonAssemblyInfo_Targets)'!='true'" Project="$(CommonAssemblyInfoFile)" />
 
   <ItemGroup Condition="'$(IgnoreNetMFStandardLibs)' != 'true'">
     <ExtraLibs       Include="dbghelp.lib" />

--- a/tools/Targets/Microsoft.SPOT.Targets
+++ b/tools/Targets/Microsoft.SPOT.Targets
@@ -10,7 +10,7 @@
     </Project>
   </ItemDefinitionGroup>
 
-  <Import Project="Microsoft.SPOT.Build.Setup.Targets" />
+  <Import Condition="'$(Microsoft_SPOT_Build_Setup_Targts_Imported)'==''" Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.Build.Setup.Targets"/>
   <Import Project="$(MSBuildToolsPath)\Microsoft.Common.Targets" />
   <Import Project="Microsoft.SPOT.Build.Common.Targets" />
   <Target Name="CreateManifestResourceNames" />

--- a/tools/Targets/Microsoft.SPOT.VisualBasic.Targets
+++ b/tools/Targets/Microsoft.SPOT.VisualBasic.Targets
@@ -1,6 +1,6 @@
 ﻿<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
 
-  <Import Project="Microsoft.SPOT.Build.Setup.Targets" />
+  <Import Condition="'$(Microsoft_SPOT_Build_Setup_Targts_Imported)'==''" Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.Build.Setup.Targets"/>
   <Import Project="$(MSBuildBinPath)\Microsoft.VisualBasic.Targets" />
   <Import Project="Microsoft.SPOT.Build.Targets" />
 


### PR DESCRIPTION
Another partial fix for issue #5. This fix updates the targets files to prevent duplicate MSBUILD file imports.