### PR TITLE
Eliminate or Suppress Linker warnings for Build_SDK

### DIFF
--- a/CLR/Core/dotNetMF.proj
+++ b/CLR/Core/dotNetMF.proj
@@ -23,6 +23,9 @@
     <NoOptForParserTarget>Release</NoOptForParserTarget>
     <PlatformIndependentBuild>true</PlatformIndependentBuild>
     <Version>4.0.0.0</Version>
+    <!--LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library -->
+    <!-- Due to conditional compilation it is entirely plausible that some of the OBJ files are effectively empty -->
+    <LinkIgnore>4221</LinkIgnore>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\Framework\Features\Debugger_CLR.libcatproj" />
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />

--- a/CLR/Jitter/dotNetMF.proj
+++ b/CLR/Jitter/dotNetMF.proj
@@ -8,6 +8,9 @@
     <ProjectGuid>7912281B-4F88-41be-8531-697982965A76</ProjectGuid>
     <HasAuxTargets>true</HasAuxTargets>
     <NoOptForParserTarget>Release</NoOptForParserTarget>
+    <!--LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library -->
+    <!-- Due to conditional compilation it is entirely plausible that some of the OBJ files are effectively empty -->
+    <LinkIgnore>4221</LinkIgnore>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <ItemGroup>

--- a/CLR/Libraries/CorLib/dotNetMF.proj
+++ b/CLR/Libraries/CorLib/dotNetMF.proj
@@ -25,6 +25,9 @@
     <NoOptForParserTarget>Release</NoOptForParserTarget>
     <PlatformIndependentBuild>true</PlatformIndependentBuild>
     <Version>4.0.0.0</Version>
+    <!--LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library -->
+    <!-- Due to conditional compilation it is entirely plausible that some of the OBJ files are effectively empty -->
+    <LinkIgnore>4221</LinkIgnore>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\Framework\Features\Graphics_CLR.libcatproj" />
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />

--- a/CLR/Libraries/SPOT/SPOT_Messaging/dotNetMF.proj
+++ b/CLR/Libraries/SPOT/SPOT_Messaging/dotNetMF.proj
@@ -35,6 +35,9 @@
     <NoOptForParserTarget>Release</NoOptForParserTarget>
     <PlatformIndependentBuild>true</PlatformIndependentBuild>
     <Version>4.0.0.0</Version>
+    <!--LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library -->
+    <!-- Due to conditional compilation it is entirely plausible that some of the OBJ files are effectively empty -->
+    <LinkIgnore>4221</LinkIgnore>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <PropertyGroup />

--- a/CLR/Libraries/SPOT/dotNetMF.proj
+++ b/CLR/Libraries/SPOT/dotNetMF.proj
@@ -23,6 +23,9 @@
     <NoOptForParserTarget>Release</NoOptForParserTarget>
     <PlatformIndependentBuild>true</PlatformIndependentBuild>
     <Version>4.0.0.0</Version>
+    <!--LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library -->
+    <!-- Due to conditional compilation it is entirely plausible that some of the OBJ files are effectively empty -->
+    <LinkIgnore>4221</LinkIgnore>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <PropertyGroup />

--- a/CLR/Libraries/SPOT_TimeService/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_TimeService/dotNetMF.proj
@@ -39,7 +39,6 @@
   <ItemGroup>
     <FastCompileCPPFile Include="Spot_time_fastcompile.cpp" />
     <Compile Include="spot_Time_native.cpp" />
-    <Compile Include="spot_Time_native.h" />
     <Compile Include="spot_Time_native_Microsoft_SPOT_Time_TimeService.cpp" />
     <IncludePaths Include="CLR\libraries\corlib" />
     <IncludePaths Include="CLR\libraries\SPOT" />

--- a/CLR/Tools/BuildHelper/dotNetMF.proj
+++ b/CLR/Tools/BuildHelper/dotNetMF.proj
@@ -12,6 +12,8 @@
     <VCProjName>BuildHelper</VCProjName>
     <ProjectGuid>E0D29432-F26B-44E7-A0FB-6FA21DF258E1</ProjectGuid>
     <Subsystem>CONSOLE</Subsystem>
+    <!--LNK4199: /DELAYLOAD:dllname ignored; no imports found from dllname -->
+    <LinkIgnore>4199</LinkIgnore>   
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="BuildHelper.cpp" />

--- a/CLR/Tools/MetaDataProcessor/dotNetMF.proj
+++ b/CLR/Tools/MetaDataProcessor/dotNetMF.proj
@@ -9,6 +9,8 @@
     <Subsystem>CONSOLE</Subsystem>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <TinyCLR_Platform>Server</TinyCLR_Platform>
+    <!--LNK4199: /DELAYLOAD:dllname ignored; no imports found from dllname -->
+    <LinkIgnore>4199</LinkIgnore>   
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <ItemGroup>

--- a/CLR/Tools/Parser/dotNetMF.proj
+++ b/CLR/Tools/Parser/dotNetMF.proj
@@ -4,6 +4,9 @@
     <Directory>CLR\Tools\Parser</Directory>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <TinyCLR_Platform>Server</TinyCLR_Platform>
+    <!--LNK4221: This object file does not define any previously undefined public symbols, so it will not be used by any link operation that consumes this library -->
+    <!-- Due to conditional compilation it is entirely plausible that some of the OBJ files are effectively empty -->
+    <LinkIgnore>4221</LinkIgnore>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <PropertyGroup>

--- a/CLR/Tools/TFConvert/dotNetMF.proj
+++ b/CLR/Tools/TFConvert/dotNetMF.proj
@@ -4,6 +4,8 @@
     <Directory>CLR\Tools\TFConvert</Directory>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <TinyCLR_Platform>Server</TinyCLR_Platform>
+    <!--LNK4199: /DELAYLOAD:dllname ignored; no imports found from dllname -->
+    <LinkIgnore>4199</LinkIgnore>   
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <PropertyGroup>

--- a/DeviceCode/pal/Diagnostics/dotNetMF.proj
+++ b/DeviceCode/pal/Diagnostics/dotNetMF.proj
@@ -40,7 +40,6 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Native_Profiler.cpp" />
-    <Compile Include="Native_Profiler.h" />
     <IncludePaths Include="DeviceCode\include" />
   </ItemGroup>
   <ItemGroup>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/asn1/dotNetMF2.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/asn1/dotNetMF2.proj
@@ -64,12 +64,6 @@
     <Compile Include="asn_moid.cpp" />
     <Compile Include="a_bytes.cpp" />
     <Compile Include="a_strnid.cpp" />
-    <Compile Include="evp_asn1.cpp" />
-    <Compile Include="asn_pack.cpp" />
-    <Compile Include="p5_pbe.cpp" />
-    <Compile Include="p5_pbev2.cpp" />
-    <Compile Include="p8_pkey.cpp" />
-    <Compile Include="asn_moid.cpp" />
     <IncludePaths Include="DeviceCode\include" />
     <IncludePaths Include="DeviceCode\pal\OpenSSL\OpenSSL_1_0_0\" />
     <IncludePaths Include="DeviceCode\pal\OpenSSL\OpenSSL_1_0_0\include\" />

--- a/Framework/Tools/BuildTasksNativeBuild/link.cs
+++ b/Framework/Tools/BuildTasksNativeBuild/link.cs
@@ -47,7 +47,12 @@ namespace Microsoft.SPOT.Tasks.NativeBuild
             set { debug = value; }
         }
 
-
+        protected string linkIgnore = string.Empty;
+        public string IGNORE
+        {
+            get { return linkIgnore; }
+            set { linkIgnore = value; }
+        }
 
         //  Linker /DEFAULTLIB variables
         protected ITaskItem[] deflibs;
@@ -329,6 +334,11 @@ namespace Microsoft.SPOT.Tasks.NativeBuild
             {
                 builder.AppendSwitch("/DEBUG");
                 builder.AppendSwitch("/ASSEMBLYDEBUG");
+            }
+
+            if( !string.IsNullOrWhiteSpace( linkIgnore ) )
+            {
+                builder.AppendSwitch( string.Format( "/IGNORE:{0}", linkIgnore ) );
             }
 
             if (null != DEFLIBS)

--- a/Solutions/Windows2/TinyCLR/TinyCLR.proj
+++ b/Solutions/Windows2/TinyCLR/TinyCLR.proj
@@ -16,6 +16,8 @@
     <ProjectPath>$(SPOCLIENT)\Solutions\Windows2\TinyCLR\TinyCLR.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
+    <!--LNK4199: /DELAYLOAD:dllname ignored; no imports found from dllname -->
+    <LinkIgnore>4199</LinkIgnore>   
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.Build.Targets" />

--- a/tools/Targets/Microsoft.SPOT.System.x86.Targets
+++ b/tools/Targets/Microsoft.SPOT.System.x86.Targets
@@ -184,6 +184,7 @@
           MANIFESTFILE="$(EmbeddedManifestFile)"
           DELAYSIGN="$(DelaySign)"
           KEYFILE="$(SIGNING_KEY_FILE)"
+          IGNORE="$(LinkIgnore)"
           />
     <Exec Condition="'$(EmbedManifest)'=='true'" Command="mt /outputresource:&quot;$(TargetFile);#1&quot; /manifest $(EmbeddedManifestFile) /nologo $(ManifestFlag)"/>
     <Exec Condition="'$(ManagedCode)'=='true' And '$(SIGNING_KEY_FILE)'!=''" Command="sn /R &quot;$(TargetFile)&quot; $(SPOCLIENT)\Framework\key.snk"/>
@@ -199,6 +200,7 @@
           OUT="$(TargetFile)"
           OBJFILES="@(ObjFiles);@(DriverLibs->'$(LIB_DIR)\%(FileName)%(Extension)', ' ')"
           DEBUG="false"
+          IGNORE="$(LinkIgnore)"
           />
   </Target>
 
@@ -222,6 +224,7 @@
           DELAYSIGN="$(DelaySign)"
           KEYFILE="$(SIGNING_KEY_FILE)"
           ModuleDefinitionFile="@(ModuleDefinitionFile)"
+          IGNORE="$(LinkIgnore)"
           />
     <Exec Condition="'$(EmbedManifest)'=='true'" Command="mt /outputresource:&quot;$(TargetFile);#2&quot; /manifest $(EmbeddedManifestFile) /nologo $(ManifestFlag)"/>
     <Exec Condition="'$(ManagedCode)'=='true' And '$(SIGNING_KEY_FILE)'!=''" Command="sn /R &quot;$(TargetFile)&quot; $(SPOCLIENT)\Framework\key.snk"/>


### PR DESCRIPTION
Partial fix for issue #5 
* Eliminate Linker warning 4022
* Supress Linker warnings 4221, and 4199

- Added IGNORE properly to linker tasks and LinkIgnore project properties to set the warnings to ignore
4022 was due to duplicte C/CPP files in the list of files to compile or inclusino of a header file as a compiled source. These were fixed, the others are real but benign warnings and are no set to suppress.