### PR TITLE
Fixed MMP error MMP0000: 0x80131700. Fixes #12

### DIFF
--- a/CLR/Tools/MetaDataProcessor/MetaDataProcessor.vcproj
+++ b/CLR/Tools/MetaDataProcessor/MetaDataProcessor.vcproj
@@ -67,7 +67,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions="/DEBUGTYPE:cv,fixup /nxcompat"
-				AdditionalDependencies="dbghelp.lib crypto.lib "
+				AdditionalDependencies="dbghelp.lib crypto.lib mscoree.lib"
 				OutputFile="$(OutDir)/MetaDataProcessor.exe"
 				LinkIncremental="0"
 				AdditionalLibraryDirectories="$(SolutionDir)Crypto\lib\x86"
@@ -157,7 +157,7 @@
 			<Tool
 				Name="VCLinkerTool"
 				AdditionalOptions="/DEBUGTYPE:cv,fixup /nxcompat"
-				AdditionalDependencies="crypto.lib"
+				AdditionalDependencies="crypto.lib mscoree.lib"
 				OutputFile="$(OutDir)/MetaDataProcessor.exe"
 				LinkIncremental="1"
 				AdditionalLibraryDirectories="$(SolutionDir)Crypto\lib\x86"

--- a/CLR/Tools/MetaDataProcessor/dotNetMF.proj
+++ b/CLR/Tools/MetaDataProcessor/dotNetMF.proj
@@ -19,6 +19,7 @@
     <IncludePaths Include="Support\include" />
     <IncludePaths Include="DeviceCode\include" />
     <IncludePaths Include="CLR\Tools\include" />
+    <ExtraLibs Include="mscoree.lib" />
   </ItemGroup>
   <ItemGroup>
     <HFiles Include="$(SPOCLIENT)\clr\graphics\gif\giffile.h" />

--- a/CLR/Tools/Parser/AssemblyParser.cpp
+++ b/CLR/Tools/Parser/AssemblyParser.cpp
@@ -2299,6 +2299,9 @@ HRESULT MetaData::Parser::ParseByteCode( MethodDef& db )
 }
 
 //--//
+_COM_SMRT_PTR(ICLRMetaHost);
+_COM_SMRT_PTR(ICLRRuntimeInfo);
+
 
 HRESULT MetaData::Parser::Analyze( LPCWSTR szFileName )
 {
@@ -2317,7 +2320,11 @@ HRESULT MetaData::Parser::Analyze( LPCWSTR szFileName )
 
     m_pe.OpenAndDecode( szFileName );
 
-    TINYCLR_CHECK_HRESULT(::CoCreateInstance( CLSID_CorMetaDataDispenser, NULL, CLSCTX_INPROC_SERVER, IID_IMetaDataDispenserEx, (void **)&m_pDisp ));
+    ICLRMetaHostPtr spMetaHost;
+    ICLRRuntimeInfoPtr spRuntimeInfo;
+    TINYCLR_CHECK_HRESULT(CLRCreateInstance(CLSID_CLRMetaHost, IID_PPV_ARGS(&spMetaHost)));
+    TINYCLR_CHECK_HRESULT(spMetaHost->GetRuntime(L"v4.0.30319", IID_PPV_ARGS(&spRuntimeInfo)));
+    TINYCLR_CHECK_HRESULT(spRuntimeInfo->GetInterface(CLSID_CorMetaDataDispenser, IID_IMetaDataDispenserEx, (LPVOID*)&m_pDisp));
 
     TINYCLR_CHECK_HRESULT(m_pDisp->OpenScope( szFileName, ofRead, IID_IMetaDataImport, (IUnknown**)&m_pImport ));
     

--- a/CLR/Tools/Parser/stdafx.h
+++ b/CLR/Tools/Parser/stdafx.h
@@ -15,3 +15,4 @@
 
 #include <WinBase.h>
 
+#include <MetaHost.h>


### PR DESCRIPTION
This is a fix for issue #12.

Used .NET Framework 4.0 CLR Hosting Interfaces; NETMF does not require .NET 2.0/3.5 anymore.