### PR TITLE
Provide user feddback instead of indecipherable errors when CMSIS support files are missing

### DIFF
--- a/DeviceCode/Cores/arm/CMSIS_RTX/dotNetMF.proj
+++ b/DeviceCode/Cores/arm/CMSIS_RTX/dotNetMF.proj
@@ -90,7 +90,7 @@
                />
         <Error Code="NETMFBLD"
                Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX\SRC')"
-               Text="Missing CMSIS-CORE installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX"
+               Text="Missing CMSIS-RTX installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX"
                />
     </Target>
 </Project>

--- a/DeviceCode/Cores/arm/CMSIS_RTX/dotNetMF.proj
+++ b/DeviceCode/Cores/arm/CMSIS_RTX/dotNetMF.proj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" InitialTargets="CheckPreRquisitesInstalled" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <AssemblyName>CMSIS_RTX</AssemblyName>
         <Size>
@@ -82,5 +82,15 @@
         <Compile Condition="$(AS_SUBDIR) == 'RVD_S'" Include="SRC\ARM\HAL_CM3.c" />
         <Compile Condition="$(AS_SUBDIR) == 'GNU_S'" Include="SRC\GCC\HAL_CM3.c" />
     </ItemGroup>
-	<Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Targets" />
+    <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Targets" />
+    <Target Name="CheckPreRquisitesInstalled">
+        <Error Code="NETMFBLD"
+               Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\Include')"
+               Text="Missing CMSIS-CORE installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\"
+               />
+        <Error Code="NETMFBLD"
+               Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX\SRC')"
+               Text="Missing CMSIS-CORE installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX"
+               />
+    </Target>
 </Project>

--- a/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
+++ b/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
@@ -1,4 +1,4 @@
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" InitialTargets="CheckPreRquisitesInstalled" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <Name>STM32F4</Name>
         <CpuName>Cortex-M4</CpuName>
@@ -31,7 +31,13 @@
 
     <ItemGroup>
         <IncludePaths Include="Devicecode\Targets\Native\STM32F4" />
-	    <IncludePaths Include="DeviceCode\Targets\Native\STM32F4\DeviceCode" />
+        <IncludePaths Include="DeviceCode\Targets\Native\STM32F4\DeviceCode" />
         <IncludePaths Include="DeviceCode\Cores\ARM\CMSIS\Include" />
     </ItemGroup>
+    <Target Name="CheckPreRquisitesInstalled">
+        <Error Code="NETMFBLD"
+               Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\Include')"
+               Text="Missing CMSIS-CORE installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\"
+               />
+    </Target>
 </Project>


### PR DESCRIPTION
Added InitialTargets to project files to check for CMSIS-Core and CMSIS-RTX pre-requsites for the CMSIS-RTX project (and therefore any solution that requires it) and the STM32F4.settings (and therefore any solutions that require it)