### PR TITLE
Fixed check for CMSIS install (wasn't updated to new CMSIS location)

### DIFF
--- a/CMSIS/CMSIS_RTX/dotNetMF.proj
+++ b/CMSIS/CMSIS_RTX/dotNetMF.proj
@@ -85,12 +85,8 @@
     <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Targets" />
     <Target Name="CheckPreRquisitesInstalled">
         <Error Code="NETMFBLD"
-               Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\Include')"
-               Text="Missing CMSIS-CORE installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\"
-               />
-        <Error Code="NETMFBLD"
-               Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX\SRC')"
-               Text="Missing CMSIS-RTX installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS_RTX"
+               Condition="!EXISTS('$(SPOCLIENT)\CMSIS\ARM.CMSIS.pdsc')"
+               Text="Missing CMSIS installation at: $(SPOCLIENT)\CMSIS\*"
                />
     </Target>
 </Project>

--- a/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
+++ b/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
@@ -36,8 +36,8 @@
     </ItemGroup>
     <Target Name="CheckPreRquisitesInstalled">
         <Error Code="NETMFBLD"
-               Condition="!EXISTS('$(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\Include')"
-               Text="Missing CMSIS-CORE installation at: $(SPOCLIENT)\DeviceCode\Cores\arm\CMSIS\"
+               Condition="!EXISTS('$(SPOCLIENT)\CMSIS\ARM.CMSIS.pdsc')"
+               Text="Missing CMSIS installation at: $(SPOCLIENT)\CMSIS\*"
                />
     </Target>
 </Project>

--- a/DeviceCode/Targets/OS/CMSIS_RTOS/CMSIS_RTOS.settings
+++ b/DeviceCode/Targets/OS/CMSIS_RTOS/CMSIS_RTOS.settings
@@ -1,4 +1,4 @@
-﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="4.0" InitialTargets="CheckPreRquisitesInstalled" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Name>CMSIS_RTOS</Name>
     <DefaultISA>Thumb2</DefaultISA>
@@ -17,11 +17,17 @@
     <IsSolutionWizardVisible>false</IsSolutionWizardVisible>
   </PropertyGroup>
   <ItemGroup>
-    <IncludePaths Include="CMSIS\CMSIS\Include" />    
+    <IncludePaths Include="CMSIS\CMSIS\Include" />
     <IncludePaths Include="CMSIS\CMSIS_RTX" />
     <IncludePaths Include="CMSIS\CMSIS_RTX\INC" />
   </ItemGroup>
   <ItemGroup Condition="'$(TCP_IP_STACK)'=='LWIP_1_4_1_OS'">
     <IncludePaths Include="DeviceCode\Targets\OS\CMSIS_RTOS\DeviceCode\lwip_1_4_1_os"/>
   </ItemGroup>
+    <Target Name="CheckPreRquisitesInstalled">
+        <Error Code="NETMFBLD"
+               Condition="!EXISTS('$(SPOCLIENT)\CMSIS\ARM.CMSIS.pdsc')"
+               Text="Missing CMSIS installation at: $(SPOCLIENT)\CMSIS\*"
+               />
+    </Target>
 </Project>


### PR DESCRIPTION
Fixed InitialTargets to test for ARM.CMSIS.pdsc file in the CMSIS root location (which was recently moved but the checks were still looking in the old location)