### PR TITLE
Eliminate need to manually set FLAVOR_WIN 

### DIFF
--- a/BuildEnv.props
+++ b/BuildEnv.props
@@ -15,7 +15,6 @@
     <BHL_EXE Condition="'$(BHL_EXE)'==''">$(BUILD_TREE_SERVER)\dll\BuildHelper.exe</BHL_EXE>
     <MDP_EXE Condition="'$(MDP_EXE)'==''">$(BUILD_TREE_SERVER)\dll\MetadataProcessor.exe</MDP_EXE>
     <NetMfTargetsBaseDir Condition="'$(NetMfTargetsBaseDir)'==''">$(SPOCLIENT)\Framework\IDE\Targets\</NetMfTargetsBaseDir>
-    <FLAVOR_ARM Condition="'$(FLAVOR_ARM)'==''">$(Configuration)</FLAVOR_ARM>
     <FLAVOR_DAT Condition="'$(FLAVOR_DAT)'==''">$(Configuration)</FLAVOR_DAT>
     <FLAVOR_WIN Condition="'$(FLAVOR_WIN)'==''">$(Configuration)</FLAVOR_WIN>
     <FLAVOR_MEMORY Condition="'$(FLAVOR_MEMORY)'==''">FLASH</FLAVOR_MEMORY>

--- a/PK.proj
+++ b/PK.proj
@@ -10,7 +10,7 @@
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />	
 
   <ItemGroup>
-    <RequiredProjects        Include="$(SPOCLIENT)\Framework\Tools\BuildTasks.dirproj"                   Condition="!EXISTS('$(BUILD_ROOT)\$(FLAVOR)\Server\DLL\Microsoft.SPOT.Tasks')"/>
+    <RequiredProjects        Include="$(SPOCLIENT)\Framework\Tools\BuildTasks.dirproj"                   Condition="!EXISTS('$(BUILD_ROOT)\$(FLAVOR)\Server\DLL\Microsoft.SPOT.Tasks.dll')"/>
     <RequiredProjects        Include="$(SPOCLIENT)\Framework\Tools\CreateCLRDefines.proj"                Condition="!EXISTS('$(PLATFORM_INDEPENDENT_LIB_DIR)\TinyCLR_Defines.h')"/>
     <RequiredProjects        Include="$(SPOCLIENT)\clr\tools\dotnetmf.proj"                              Condition="!EXISTS('$(BUILD_ROOT)\$(FLAVOR)\Server\DLL\MetaDataProcessor.exe')"/>
     <RequiredManagedProjects Include="$(SPOCLIENT)\clr\tools\EmulatorInterface\EmulatorInterface.csproj" Condition="!EXISTS('$(BUILD_ROOT)\$(FLAVOR)\Server\DLL\Microsoft.SPOT.Emulator.Interface.dll')"/>

--- a/Solutions/Windows2/Windows2.settings
+++ b/Solutions/Windows2/Windows2.settings
@@ -11,7 +11,7 @@
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
     <ENDIANNESS>le</ENDIANNESS>
     <MEMORY>RAM</MEMORY>
-    <FLAVOR Condition="'$(FLAVOR)'==''">Debug</FLAVOR>
+    <FLAVOR Condition="'$(FLAVOR)'==''">Release</FLAVOR>
   </PropertyGroup>
   <ItemGroup>
     <IncludePaths Include="Solutions\Windows2" />

--- a/tools/Targets/Microsoft.SPOT.Build.Configuration.Settings
+++ b/tools/Targets/Microsoft.SPOT.Build.Configuration.Settings
@@ -13,8 +13,8 @@
   <PropertyGroup>
     <Platform     Condition="'$(Platform)'==''" >AnyCPU</Platform>
     <FLAVOR       Condition="'$(FLAVOR)'=='' And '$(Configuration)'!=''">$(Configuration)</FLAVOR>
-    <FLAVOR       Condition="'$(FLAVOR)'=='' And '$(Configuration)'==''">Debug</FLAVOR>
-    <MEMORY       Condition="'$(MEMORY)'==''"   >RAM</MEMORY>
+    <FLAVOR       Condition="'$(FLAVOR)'=='' And '$(Configuration)'==''">Release</FLAVOR>
+    <MEMORY       Condition="'$(MEMORY)'==''"   >FLASH</MEMORY>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == '' ">

--- a/tools/Targets/Microsoft.SPOT.Support.Settings
+++ b/tools/Targets/Microsoft.SPOT.Support.Settings
@@ -98,10 +98,10 @@
 
     <BUILD_FLAVOR_RTM Condition="'$(rtm)'=='true'">1</BUILD_FLAVOR_RTM>
 
-    <FLAVOR_TMP Condition="'$(FLAVOR)'=='Debug' OR '$(FLAVOR)'=='Instrumented'>Debug</FLAVOR_TMP>
+    <FLAVOR_TMP Condition="'$(FLAVOR)'=='Debug' OR '$(FLAVOR)'=='Instrumented'">Debug</FLAVOR_TMP>
 
     <FLAVOR_DAT Condition="'$(FLAVOR_TMP)'=='Debug'" >Debug</FLAVOR_DAT>
-    <FLAVOR_DAT Condition="'$(FLAVOR_TMP)'!='Debug'" >Release</FLAVOR_WIN>
+    <FLAVOR_DAT Condition="'$(FLAVOR_TMP)'!='Debug'" >Release</FLAVOR_DAT>
     <FLAVOR_WIN Condition="'$(FLAVOR_TMP)'=='Debug'" >Debug</FLAVOR_WIN>
     <FLAVOR_WIN Condition="'$(FLAVOR_TMP)'!='Debug'" >Release</FLAVOR_WIN>
 

--- a/tools/Targets/Microsoft.SPOT.System.Settings
+++ b/tools/Targets/Microsoft.SPOT.System.Settings
@@ -39,7 +39,7 @@
     <profile Condition="'$(profile)'==''"           >false</profile>
     <sampleprof Condition="'$(sampleprof)'==''"     >false</sampleprof>
     <latencyprof Condition="'$(latencyprof)'==''"   >false</latencyprof>
-    <FLAVOR Condition="'$(FLAVOR)'==''"             >Debug</FLAVOR>
+    <FLAVOR Condition="'$(FLAVOR)'==''"             >Release</FLAVOR>
     <MEMORY Condition="'$(MEMORY)'==''"             >FLASH</MEMORY>
     <ENABLE_FASTCOMPILE Condition="'$(ENABLE_FASTCOMPILE)'==''"   >true</ENABLE_FASTCOMPILE>
     <FourByteCrytoLib>false</FourByteCrytoLib>

--- a/tools/Targets/Microsoft.SPOT.System.Targets
+++ b/tools/Targets/Microsoft.SPOT.System.Targets
@@ -266,7 +266,7 @@
 
         <Exec Command="IF EXIST @(TargetLib->'%(FullPath)','') del /q @(TargetLib->'%(FullPath)', ' ')" Condition ="@(TargetLib)!=''" ContinueOnError="true"/>
         <Exec Command="IF EXIST @(TargetLib->'%(FullPath).manifest','') del /q @(TargetLib->'%(FullPath).manifest', ' ')" Condition ="@(TargetLib)!=''" ContinueOnError="true"/>
-        <Exec Command="IF EXIST @(FileExist->'$(OBJ_DIR)\%(Filename).*','') del /q @(FilesExist->'$(OBJ_DIR)\%(Filename).*', ' ')"  ContinueOnError="true"/>
+        <Exec Command="IF EXIST @(FilesExist->'$(OBJ_DIR)\%(Filename).*','') del /q @(FilesExist->'$(OBJ_DIR)\%(Filename).*', ' ')"  ContinueOnError="true"/>
     </Target>
 
 

--- a/tools/Targets/Microsoft.Spot.system.gcc.targets
+++ b/tools/Targets/Microsoft.Spot.system.gcc.targets
@@ -302,13 +302,13 @@
   </Target>
 
   <Target Name="ArmAssemble" Condition="'@(AssemblyFiles)'!=''" Inputs="@(AssemblyFiles)" Outputs="@(AssemblyFiles->'$(OBJ_DIR)\%(FileName).$(OBJ_EXT)')">
-    <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="del /q  $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
+    <Delete Condition="Exists('$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)')" Files="$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
     <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="$(AS) $(AS_FLAGS) -a=$(OBJ_DIR)\%(AssemblyFiles.Filename).txt -o $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT) %(AssemblyFiles.FullPath)"/>
   </Target>
 
   <Target Name="DelBuildLib" Condition="'$(OutputType)'=='Library'" Inputs="@(FastCompileCPPFile);@(CPPFiles);@(FastCompileCFile);@(CFiles);@(AssemblyFiles);@(HFiles)" Outputs="@(TargetLib)">
-    <Exec Condition="'@(FilesExist)'!='' " Command="del /q  @(TargetLib)" ContinueOnError="true" />
-    <Exec Condition="'@(FilesExist)'!='' " Command="del /q  @(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath)', ' '))" Files="@(TargetLib->'%(FullPath)', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath).manifest', ' '))" Files="@(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
  </Target>
 
   <Target Name="ArmBuildLib" Condition="'$(OutputType)'=='Library'" DependsOnTargets="FindCompileFilesExistence;FindFastCompileFilesExistence;DelBuildLib;ArmCompileC;ArmCompileCPP;ArmAssemble;CreateLibManifest;$(ExtraTargets);" Inputs="@(ObjFiles)" Outputs="@(TargetLib);@(TargetLib->'%(FullPath).manifest')">

--- a/tools/Targets/Microsoft.Spot.system.mdk.targets
+++ b/tools/Targets/Microsoft.Spot.system.mdk.targets
@@ -295,13 +295,13 @@
 
   <Target Name="ArmAssemble" Condition="'@(AssemblyFiles)'!=''" Inputs="@(AssemblyFiles);@(HFiles)" Outputs="@(AssemblyFiles->'$(OBJ_DIR)\%(FileName).$(OBJ_EXT)')">
     <!-- has to delete the obj manually, as the armas won't delete the old one -->
-    <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="del /q  $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
+    <Delete Condition="Exists('$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)')" Files="$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
     <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="$(AS) $(AS_PLATFORM_FLAGS) $(AS_FLAGS) $(SWTC)LIST $(OBJ_DIR)\%(AssemblyFiles.Filename).txt $(SWTC)xref -o $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT) %(AssemblyFiles.FullPath)"/>
   </Target>
 
   <Target Name="DelBuildLib" Condition="'$(OutputType)'=='Library'" Inputs="@(FastCompileCPPFile);@(CPPFiles);@(FastCompileCFile);@(CFiles);@(AssemblyFiles);@(HFiles)" Outputs="@(TargetLib)">
-    <Exec Condition="'@(FilesExist)'!='' " Command="del /q  @(TargetLib->'%(FullPath)', ' ')" ContinueOnError="true" />
-    <Exec Condition="'@(FilesExist)'!='' " Command="del /q  @(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath)', ' '))" Files="@(TargetLib->'%(FullPath)', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath).manifest', ' '))" Files="@(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
   </Target>
 
   <Target Name="ArmBuildLib" Condition="'$(OutputType)'=='Library'" DependsOnTargets="FindCompileFilesExistence;FindFastCompileFilesExistence;DelBuildLib;ArmCompileC;ArmCompileCPP;ArmAssemble;CreateLibManifest;$(ExtraTargets);" Inputs="@(ObjFiles);@(LIB_FIRSTENTRY_OBJ);@(OEM_TARGETS);@(OEM_TARGETS_OBJ);@(PlatformIndependentLibs->'$(PLATFORM_INDEPENDENT_LIB_DIR)\%(FileName)%(Extension)')" Outputs="@(TargetLib);@(TargetLib->'%(FullPath).manifest')">

--- a/tools/Targets/Microsoft.Spot.system.rvds.Targets
+++ b/tools/Targets/Microsoft.Spot.system.rvds.Targets
@@ -317,13 +317,13 @@
 
   <Target Name="ArmAssemble" Condition="'@(AssemblyFiles)'!=''" Inputs="@(AssemblyFiles);@(HFiles)" Outputs="@(AssemblyFiles->'$(OBJ_DIR)\%(FileName).$(OBJ_EXT)')">
     <!-- has to delete the obj manually, as the armas won't delete the old one -->
-    <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="del /q  $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
+    <Delete Condition="Exists('$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)')" Files="$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
     <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="$(AS) $(AS_PLATFORM_FLAGS) $(AS_FLAGS) $(SWTC)LIST $(OBJ_DIR)\%(AssemblyFiles.Filename).txt $(SWTC)xref -o $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT) %(AssemblyFiles.FullPath)"/>
   </Target>
 
   <Target Name="DelBuildLib" Condition="'$(OutputType)'=='Library'" Inputs="@(FastCompileCPPFile);@(CPPFiles);@(FastCompileCFile);@(CFiles);@(AssemblyFiles);@(HFiles)" Outputs="@(TargetLib)">
-    <Exec Condition="'@(FilesExist)'!='' " Command="del /q  @(TargetLib->'%(FullPath)', ' ')" ContinueOnError="true" />
-    <Exec Condition="'@(FilesExist)'!='' " Command="del /q  @(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath)', ' '))" Files="@(TargetLib->'%(FullPath)', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath).manifest', ' '))" Files="@(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
   </Target>
 
   <Target Name="ArmBuildLib" Condition="'$(OutputType)'=='Library'" DependsOnTargets="FindCompileFilesExistence;FindFastCompileFilesExistence;DelBuildLib;ArmCompileC;ArmCompileCPP;ArmAssemble;CreateLibManifest;$(ExtraTargets);" Inputs="@(ObjFiles);@(LIB_FIRSTENTRY_OBJ);@(OEM_TARGETS);@(OEM_TARGETS_OBJ);@(DriverLibs->'$(LIB_DIR)\%(FileName)%(Extension)',' ');@(PlatformIndependentLibs->'$(PLATFORM_INDEPENDENT_LIB_DIR)\%(FileName)%(Extension)')" Outputs="@(TargetLib);@(TargetLib->'%(FullPath).manifest')">

--- a/tools/scripts/init.cmd
+++ b/tools/scripts/init.cmd
@@ -12,16 +12,10 @@ cd %PREVCD%
 
 @rem - CONFIGURATION OF DEBUG vs RELEASE FOR FIRMWARE, TOOLS, AND ASSEMBLIES
 
-if /I "%FLAVOR_WIN%"   == "Debug"   set FLAVOR_WIN=Debug
-if /I "%FLAVOR_WIN%"   == "Release" set FLAVOR_WIN=Release
-if    "%FLAVOR_WIN%"   == ""        set FLAVOR_WIN=Release
-
 if /I "%FLAVOR_DAT%"   == "Debug"   set FLAVOR_DAT=Debug
 if /I "%FLAVOR_DAT%"   == "Release" set FLAVOR_DAT=Release
 if    "%FLAVOR_DAT%"   == ""        set FLAVOR_DAT=Release
 
-if "%FLAVOR_ARM%"      == "" set FLAVOR_ARM=release
-if "%FLAVOR_PLATFORM%" == "" set FLAVOR_PLATFORM=iMXS
 if "%FLAVOR_MEMORY%"   == "" set FLAVOR_MEMORY=Flash
 
 if "%OEM_NAME%"        == "" set OEM_NAME=Microsoft
@@ -61,12 +55,6 @@ set BUILD_TEST_TREE_SERVER=%BUILD_TEST_ROOT%\server
 
 set OEM_PATH=%OEM_ROOT%\%OEM_NAME%
 set CLRLIB=%CLRROOT%\Tools\Libraries
-
-@rem ################################################################################
-
-set TARGETCURRENT=%CLRROOT%_BUILD\arm\%FLAVOR_MEMORY%\%FLAVOR_ARM%\%FLAVOR_PLATFORM%\bin
-
-@rem ################################################################################
 
 set PREVCD=
 set TEMPTOOLPATH=


### PR DESCRIPTION
- Set default for solution builds to Release
- Fixed build so manually setting FLAVOR_WIN isn't needed anymore
- set default MEMORY type to FLASH as that's more common with smaller micro nowadays
- fixed syntax errors in Microsoft.SPOT.Support.Settings (which seems to be unused...)
- Silenced message about not finding lib and manifest files (the conditions for detecting the existence of files to delete were wrong; This is a minor tweak to the pull request #23 from @cw2)