### PR TITLE
Fix for issue #30 and issue #33

### DIFF
--- a/BuildEnv.props
+++ b/BuildEnv.props
@@ -2,6 +2,9 @@
   
   <!-- Provide properties for Environment variables normally set by setenvbase.cmd -->
   <PropertyGroup>
+    <FLAVOR Condition="'$(FLAVOR)'==''">Release</FLAVOR>
+    <Configuration Condition="'$(Configuration)'=='' AND '$(FLAVOR)'!='RTM'">$(FLAVOR)</Configuration>
+    <Configuration Condition="'$(Configuration)'=='' AND '$(FLAVOR)'!='RTM'">Release</Configuration>
     <SPOCLIENT Condition="'$(SPOCLIENT)'==''">$(MsBuildThisFileDirectory.TrimEnd('\'))</SPOCLIENT>
     <CLRROOT Condition="'$(CLRROOT)'==''">$(SPOCLIENT)</CLRROOT>
     <SPOROOT Condition="'$(SPOROOT)'==''">$([System.IO.Path]::GetDirectoryName('$(SPOCLIENT)'))</SPOROOT>
@@ -10,13 +13,15 @@
     <BUILD_ROOT_BASE Condition="'$(BUILD_ROOT_BASE)'==''">$(COMMON_BUILD_ROOT)\BuildOutput</BUILD_ROOT_BASE>
     <BUILD_ROOT Condition="'$(BUILD_ROOT)'==''">$(BUILD_ROOT_BASE)\Public</BUILD_ROOT>
     <BUILD_TREE Condition="'$(BUILD_TREE)'==''">$(BUILD_ROOT)\$(Configuration)</BUILD_TREE>
-    <BUILD_TREE_CLIENT Condition="'$(BUILD_TREE_CLIENT)'==''">$(BUILD_TREE)\Client</BUILD_TREE_CLIENT>
-    <BUILD_TREE_SERVER Condition="'$(BUILD_TREE_SERVER)'==''">$(BUILD_TREE)\Server</BUILD_TREE_SERVER>
+    <BUILD_TREE_CLIENT>$(BUILD_TREE)\Client</BUILD_TREE_CLIENT>
+    <BUILD_TREE_SERVER>$(BUILD_TREE)\Server</BUILD_TREE_SERVER>
     <BHL_EXE Condition="'$(BHL_EXE)'==''">$(BUILD_TREE_SERVER)\dll\BuildHelper.exe</BHL_EXE>
     <MDP_EXE Condition="'$(MDP_EXE)'==''">$(BUILD_TREE_SERVER)\dll\MetadataProcessor.exe</MDP_EXE>
     <NetMfTargetsBaseDir Condition="'$(NetMfTargetsBaseDir)'==''">$(SPOCLIENT)\Framework\IDE\Targets\</NetMfTargetsBaseDir>
-    <FLAVOR_DAT Condition="'$(FLAVOR_DAT)'==''">$(Configuration)</FLAVOR_DAT>
-    <FLAVOR_WIN Condition="'$(FLAVOR_WIN)'==''">$(Configuration)</FLAVOR_WIN>
+    <FLAVOR_DAT Condition="'$(FLAVOR_DAT)'=='' AND '$(Configuration)'=='Debug'" >Debug</FLAVOR_DAT>
+    <FLAVOR_DAT Condition="'$(FLAVOR_DAT)'=='' AND '$(Configuration)'!='Debug'" >Release</FLAVOR_DAT>
+    <FLAVOR_WIN Condition="'$(FLAVOR_WIN)'=='' AND '$(Configuration)'=='Debug'" >Debug</FLAVOR_WIN>
+    <FLAVOR_WIN Condition="'$(FLAVOR_WIN)'=='' AND '$(Configuration)'!='Debug'" >Release</FLAVOR_WIN>
     <FLAVOR_MEMORY Condition="'$(FLAVOR_MEMORY)'==''">FLASH</FLAVOR_MEMORY>
     <CLRLIB Condition="'$(CLRLIB)'==''">$(SPOCLIENT)\Tools\Libraries</CLRLIB>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)'==''" >12.0</VisualStudioVersion>

--- a/Framework/CorDebug/vs11/CorDebug.csproj
+++ b/Framework/CorDebug/vs11/CorDebug.csproj
@@ -1,17 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
-    <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
-    <Configuration Condition="'$(Configuration)'=='' and '$(FLAVOR)'!=''">$(FLAVOR)</Configuration>
-    <Configuration Condition="'$(Configuration)'==''">Debug</Configuration>
   </PropertyGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-  <!-- Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/ -->
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <SchemaVersion>2.0</SchemaVersion>
@@ -31,7 +26,9 @@
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>11.0</MinimumVisualStudioVersion>
     <NetMFBuildVsSdkVersion>11</NetMFBuildVsSdkVersion>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL\</OutDir>
   </PropertyGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
@@ -44,8 +41,8 @@
     <Reference Include="Microsoft.VisualStudio.AppDesigner, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Editors, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.ManagedInterfaces, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
-    <Reference Include="Microsoft.VisualStudio.Shell.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" >
-        <SpecificVersion>true</SpecificVersion>
+    <Reference Include="Microsoft.VisualStudio.Shell.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+      <SpecificVersion>true</SpecificVersion>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="Microsoft.VisualStudio.Shell.Immutable.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
@@ -173,9 +170,14 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Debugger\Debugger.csproj">
+      <Project>{d9dca6fb-680f-4355-abef-128db02721e6}</Project>
+      <Name>Debugger</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
-  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Framework/CorDebug/vs11/NetmfVS2012.csproj
+++ b/Framework/CorDebug/vs11/NetmfVS2012.csproj
@@ -1,105 +1,99 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup>
-        <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
-        <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
-        <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-        <SccProjectName>SAK</SccProjectName>
-        <SccLocalPath>SAK</SccLocalPath>
-        <SccAuxPath>SAK</SccAuxPath>
-        <SccProvider>SAK</SccProvider>
-    </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-    <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
-    <PropertyGroup>
-        <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-        <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-        <SchemaVersion>2.0</SchemaVersion>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL</OutDir>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL</OutDir>
+  </PropertyGroup>
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <SchemaVersion>2.0</SchemaVersion>
         <ProjectGuid>{A4E5FFED-D422-4895-BC62-116EDC4F3FF2}</ProjectGuid>
-        <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <OutputType>Library</OutputType>
-        <AppDesignerFolder>Properties</AppDesignerFolder>
+    <ProjectTypeGuids>{82b43b9b-a64c-4715-b499-d71e9ca2bd60};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
         <RootNamespace>NetmfVS2012</RootNamespace>
         <AssemblyName>NetmfVS2012</AssemblyName>
-        <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-        <GeneratePkgDefFile>false</GeneratePkgDefFile>
-        <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
-        <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
-        <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
-        <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
-        <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
-        <Prefer32Bit>false</Prefer32Bit>
-        <DeployExtension Condition=" '$(AUTOMATED_BUILD)' == 'true' ">False</DeployExtension>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>false</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>false</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+    <Prefer32Bit>false</Prefer32Bit>
+    <DeployExtension Condition=" '$(AUTOMATED_BUILD)' == 'true' ">False</DeployExtension>
         <NetMFBuildVsSdkVersion>11</NetMFBuildVsSdkVersion>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-        <DebugSymbols>true</DebugSymbols>
-        <DebugType>full</DebugType>
-        <Optimize>false</Optimize>
-        <OutputPath Condition="$(OutputPath)==''">bin\Debug\</OutputPath>
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath Condition="$(OutputPath)==''">bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
     <DeployExtension>$(BuildingInsideVisualStudio)</DeployExtension>
-    </PropertyGroup>
-    <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-        <DebugType>pdbonly</DebugType>
-        <Optimize>true</Optimize>
-        <OutputPath Condition="$(OutputPath)==''">bin\Release\</OutputPath>
-        <DefineConstants>TRACE</DefineConstants>
-        <ErrorReport>prompt</ErrorReport>
-        <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath Condition="$(OutputPath)==''">bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
     <DeployExtension>$(BuildingInsideVisualStudio)</DeployExtension>
-    </PropertyGroup>
-    <ItemGroup>
-        <Compile Include="Properties\AssemblyInfo.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="source.extension.vsixmanifest">
-            <SubType>Designer</SubType>
-        </None>
-    </ItemGroup>
-    
-    <ItemGroup>
-        <Content Include="..\Resources\NetMFLogo.png">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>NetMFLogo.png</Link>
-        </Content>
-        <Content Include="$(SPOCLIENT)\Setup\ProductSDK\Micro Framework SDK Release notes.txt">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>Micro Framework SDK Release notes.txt</Link>
-        </Content>
-        <Content Include="$(SPOCLIENT)\Setup\ProductSDK\License.rtf">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>License.rtf</Link>
-        </Content>
-
-        <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.dll">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>Microsoft.SPOT.Debugger.dll</Link>
-        </Content>
-        <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Tasks.dll">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>Microsoft.SPOT.Tasks.dll</Link>
-        </Content>
-        <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.dll">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>Microsoft.SPOT.Debugger.CorDebug.dll</Link>
-        </Content>
-        <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.pkgdef">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>Microsoft.SPOT.Debugger.CorDebug.pkgdef</Link>
-        </Content>
-        <Content Include="$(BUILD_TREE_DLL)\WinUsbInvoke.dll">
-            <IncludeInVSIX>true</IncludeInVSIX>
-            <Link>WinUsbInvoke.dll</Link>
-        </Content>
-        
-    </ItemGroup>
-    
-    <!-- Project and item template content -->
-  <ItemGroup >
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="source.extension.vsixmanifest">
+      <SubType>Designer</SubType>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="..\Resources\NetMFLogo.png">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>NetMFLogo.png</Link>
+    </Content>
+    <Content Include="$(SPOCLIENT)\Setup\ProductSDK\Micro Framework SDK Release notes.txt">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Micro Framework SDK Release notes.txt</Link>
+    </Content>
+    <Content Include="$(SPOCLIENT)\Setup\ProductSDK\License.rtf">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>License.rtf</Link>
+    </Content>
+    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.dll">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Microsoft.SPOT.Debugger.dll</Link>
+    </Content>
+    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Tasks.dll">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Microsoft.SPOT.Tasks.dll</Link>
+    </Content>
+    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.dll">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Microsoft.SPOT.Debugger.CorDebug.dll</Link>
+    </Content>
+    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.pkgdef">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>Microsoft.SPOT.Debugger.CorDebug.pkgdef</Link>
+    </Content>
+    <Content Include="$(BUILD_TREE_DLL)\WinUsbInvoke.dll">
+      <IncludeInVSIX>true</IncludeInVSIX>
+      <Link>WinUsbInvoke.dll</Link>
+    </Content>
+  </ItemGroup>
+  <!-- Project and item template content -->
+  <ItemGroup>
     <ProjectReference Include="..\..\..\Product\AllSDK\ItemTemplates\CSharp\AssemblyInfo\AssemblyInfoTemplateProject.csproj">
       <Project>{422d820b-8b80-4ff1-9828-3ab113c2abc0}</Project>
       <Name>AssemblyInfoTemplateProject</Name>
@@ -188,6 +182,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Framework/CorDebug/vs12/NetmfVS2013.csproj
+++ b/Framework/CorDebug/vs12/NetmfVS2013.csproj
@@ -1,19 +1,18 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL</OutDir>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL</OutDir>
   </PropertyGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{010ECE4D-7E10-4879-B596-A460CC36ECBD}</ProjectGuid>
@@ -32,8 +31,8 @@
     <Prefer32Bit>false</Prefer32Bit>
     <DeployExtension Condition=" '$(AUTOMATED_BUILD)' == 'true' ">False</DeployExtension>
     <NetMFBuildVsSdkVersion>12</NetMFBuildVsSdkVersion>
-
   </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -185,6 +184,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Framework/CorDebug/vs12/Properties/AssemblyInfo.cs
+++ b/Framework/CorDebug/vs12/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription( "" )]
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "" )]
-[assembly: AssemblyProduct( "NetmfVS2012" )]
+[assembly: AssemblyProduct( "NetmfVS2013" )]
 [assembly: AssemblyCopyright( "" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]

--- a/Framework/CorDebug/vs12/cordebugvs12.csproj
+++ b/Framework/CorDebug/vs12/cordebugvs12.csproj
@@ -1,17 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
-    <TargetFrameworkProfile />
   </PropertyGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-  <!-- Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/ -->
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <SchemaVersion>2.0</SchemaVersion>
@@ -28,11 +25,12 @@
     <DirectoryRef>ToolsDir</DirectoryRef>
     <InstrumentForCoverage>true</InstrumentForCoverage>
     <PlatformTarget>x86</PlatformTarget>
-    <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <NetMFBuildVsSdkVersion>12</NetMFBuildVsSdkVersion>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL\</OutDir>
   </PropertyGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
@@ -188,6 +186,5 @@
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
-  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/Framework/CorDebug/vs14/NetmfVS14.csproj
+++ b/Framework/CorDebug/vs14/NetmfVS14.csproj
@@ -1,19 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
   </PropertyGroup>
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{F15F8516-14E8-4CE2-8810-59CB869E1C38}</ProjectGuid>
@@ -31,7 +28,9 @@
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <Prefer32Bit>false</Prefer32Bit>
     <DeployExtension Condition=" '$(AUTOMATED_BUILD)' == 'true' ">False</DeployExtension>
+    <NetMFBuildVsSdkVersion>14</NetMFBuildVsSdkVersion>
   </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -80,13 +79,13 @@
       <IncludeInVSIX>true</IncludeInVSIX>
       <Link>Microsoft.SPOT.Tasks.dll</Link>
     </Content>
-    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.12.dll">
+    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.14.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
-      <Link>Microsoft.SPOT.Debugger.CorDebug.12.dll</Link>
+      <Link>Microsoft.SPOT.Debugger.CorDebug.14.dll</Link>
     </Content>
-    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.12.pkgdef">
+    <Content Include="$(BUILD_TREE_DLL)\Microsoft.SPOT.Debugger.CorDebug.14.pkgdef">
       <IncludeInVSIX>true</IncludeInVSIX>
-      <Link>Microsoft.SPOT.Debugger.CorDebug.12.pkgdef</Link>
+      <Link>Microsoft.SPOT.Debugger.CorDebug.14.pkgdef</Link>
     </Content>
     <Content Include="$(BUILD_TREE_DLL)\WinUsbInvoke.dll">
       <IncludeInVSIX>true</IncludeInVSIX>
@@ -183,6 +182,7 @@
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
   </ItemGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/Framework/CorDebug/vs14/Properties/AssemblyInfo.cs
+++ b/Framework/CorDebug/vs14/Properties/AssemblyInfo.cs
@@ -9,7 +9,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyDescription( "" )]
 [assembly: AssemblyConfiguration( "" )]
 [assembly: AssemblyCompany( "" )]
-[assembly: AssemblyProduct( "NetmfVS2012" )]
+[assembly: AssemblyProduct( "NetmfVS2015" )]
 [assembly: AssemblyCopyright( "" )]
 [assembly: AssemblyTrademark( "" )]
 [assembly: AssemblyCulture( "" )]

--- a/Framework/CorDebug/vs14/cordebugvs14.csproj
+++ b/Framework/CorDebug/vs14/cordebugvs14.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">12.0</VisualStudioVersion>
-    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
@@ -27,7 +26,6 @@
     <DirectoryRef>ToolsDir</DirectoryRef>
     <InstrumentForCoverage>true</InstrumentForCoverage>
     <PlatformTarget>x86</PlatformTarget>
-    <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
     <NetMFBuildVsSdkVersion>14</NetMFBuildVsSdkVersion>
@@ -185,9 +183,14 @@
       <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\Debugger\Debugger.csproj">
+      <Project>{d9dca6fb-680f-4355-abef-128db02721e6}</Project>
+      <Name>Debugger</Name>
+    </ProjectReference>
+  </ItemGroup>
   <PropertyGroup>
     <UseCodebase>true</UseCodebase>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
-  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="'$(VSToolsPath)' != ''" />
 </Project>

--- a/build_sdk.cmd
+++ b/build_sdk.cmd
@@ -60,5 +60,5 @@ GOTO :EOF
 goto :EOF
 
 :MissingVSSDK
-@ECHO ERROR: Visual Studio 2012 SDK (VSSDK) was not detected, this SDK is required to build the .NET Micro Framework SDK source code
+@ECHO ERROR: Visual Studio 2013 SDK (VSSDK) was not detected, this SDK is required to build the .NET Micro Framework SDK source code
 goto :EOF

--- a/build_sdk.cmd
+++ b/build_sdk.cmd
@@ -9,6 +9,9 @@ if "%1" == "-?" goto :ShowUsage
 if /i "%1" == "/h" goto :ShowUsage
 if /i "%1" == "-h" goto :ShowUsage
 
+if /i "%VSSDK120Install%"=="" goto :MissingVSSDK
+if NOT EXIST "%VSSDK120Install%" goto :MissingVSSDK
+
 SET BUILD_VERSION=%1
 if "%BUILD_VERSION%"=="" set BUILD_VERSION=0
 SET BUILD_SHARE=%2
@@ -54,3 +57,8 @@ GOTO :EOF
 @ECHO     RELEASE_NAME = Name for the release [ Default = "(%%USERNAME%%)"]
 @echo example:
 @ECHO     build_sdk.cmd 1234 \\NETMFBLD02\Builds\69423 client_vNext "(RC1)"
+goto :EOF
+
+:MissingVSSDK
+@ECHO ERROR: Visual Studio 2012 SDK (VSSDK) was not detected, this SDK is required to build the .NET Micro Framework SDK source code
+goto :EOF

--- a/setup/build.dirproj
+++ b/setup/build.dirproj
@@ -11,9 +11,6 @@
         UI\FrameworkSetupUI.wixproj"
         />
     <!-- <Project Include="Docs\build.dirproj" Condition=" '$(Configuration)' != 'Debug' " /> -->
-    <!-- For unofficial/local dev builds generate the MSI, otherwise wait for the later stage after the binaries are signed -->
-    <Project Include="ProductSDK\Product.wixproj" Condition=" '$(SignBuild)' != 'true' "/>
-    <Project Include="ProductSDK\VsixPackages.dirproj" Condition="'$(SignBuild)' != 'true' "/>
 </ItemGroup>
 
 </Project>

--- a/tools/Targets/Microsoft.SPOT.CSharp.Host.Targets
+++ b/tools/Targets/Microsoft.SPOT.CSharp.Host.Targets
@@ -16,16 +16,19 @@
   
   <PropertyGroup Condition="'$(NetMFBuildVsSdkVersion)'=='11'">
     <VSSDKINSTALLDIR>$(VSSDK11INSTALLDIR)</VSSDKINSTALLDIR>
+    <VSToolsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v11.0</VSToolsPath>
     <!-- Additional VS SDK version specific properties go here -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetMFBuildVsSdkVersion)'=='12'">
     <VSSDKINSTALLDIR>$(VSSDK12INSTALLDIR)</VSSDKINSTALLDIR>
+    <VSToolsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v12.0</VSToolsPath>
     <!-- Additional VS SDK version specific properties go here -->
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(NetMFBuildVsSdkVersion)'=='14'">
     <VSSDKINSTALLDIR>$(VSSDK14INSTALLDIR)</VSSDKINSTALLDIR>
+    <VSToolsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v14.0</VSToolsPath>
     <!-- Additional VS SDK version specific properties go here -->
   </PropertyGroup>
     


### PR DESCRIPTION
- Fixed vs14 vsix package project to use proper dependencies so it can work against VS2015
- fixed location of import to spot.csharp.host.targets file so that it picks up the NetMFBuildVsSdkVersion property to override VSSDK paths and settings
- updated build_sdk.cmd to include a check for VS2012 SDK as that is required to build the templates in the sdk.dirproj phase of the build.
- Fixed vsix package projects to get proper OutDir setting so input and output files come from the correct location.
- updated BuildEnv.props to set a default FLAVOR value
- updated buildenv.props to set configuration based on FLAVOR (unless FLAVOR==RTM in which case Configuration should be Release)
- updated BuildEnv.props to set BUILD_TREE_CLIENT and BUILD_TREE_SERVER unconditionally based on BUILD_TREE, which will be set based on Configuration. Otherwise the BUILD_TREE_XXX and derived paths will always have the value hardcoded into setenv_base/init.cmd as a default
- removed redundant build of MSI and VSIX packages from setup\build.dirproj as build_sdk itself can be used for developer builds of the SDK
- updated BuildEnv.Props to include changes from @cw2 (pull request #36) to handle setting flavor_win