### PR TITLE
Eliminated build_sdk compiler warnings (partial fix for issue #5)

### DIFF
--- a/CLR/Messaging/Messaging.cpp
+++ b/CLR/Messaging/Messaging.cpp
@@ -347,7 +347,7 @@ void CLR_Messaging::Initialize(
     m_Lookup_Replies[ 1 ].owner = owner;
     m_Lookup_Replies[ 1 ].size  = replyLookupCount;
 
-    m_fDebuggerInitialized = DebuggerPort_Initialize( port );
+    m_fDebuggerInitialized = (DebuggerPort_Initialize( port ) != FALSE);
 
     m_fInitialized = true;
 

--- a/DeviceCode/Drivers/FS/FAT/FAT_FileHandle.cpp
+++ b/DeviceCode/Drivers/FS/FAT/FAT_FileHandle.cpp
@@ -361,7 +361,7 @@ HRESULT FAT_FileHandle::Seek( INT64 offset, UINT32 origin, INT64* position )
     {
         if (m_dataIndex >= (-1 * offset)) // Unless we're still staying in the same cluster
         {
-            m_dataIndex += offset; // offset is < 0
+            m_dataIndex = (UINT32)(m_dataIndex + offset); // offset is < 0
             m_position  += offset; // offset is < 0
 
             if(position) *position = m_position;

--- a/DeviceCode/pal/BlockStorage/blockstoragelist.cpp
+++ b/DeviceCode/pal/BlockStorage/blockstoragelist.cpp
@@ -608,7 +608,7 @@ BOOL BlockStorageStream::IsErased( UINT32 length )
         }
     }
 
-    while(len >= this->BlockLength)
+    while(len >= (INT32)this->BlockLength)
     {
         if(!this->Device->IsBlockErased(this->BaseAddress + this->CurrentIndex, this->BlockLength)) return FALSE;
 

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/bio/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/bio/dotNetMF.proj
@@ -22,7 +22,10 @@
     <Version>4.0.0.0</Version>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4065: switch statement contains 'default' but no 'case' labels -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4065</ExtraFlags>
+  </PropertyGroup>
   <!--
   <ItemGroup>
     <SubDirectories Include="Stubs"/>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/dotNetMF.proj
@@ -22,7 +22,10 @@
     <Version>4.0.0.0</Version>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4996: '<apiname>': was declared deprecated -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4996</ExtraFlags>
+  </PropertyGroup>
   <ItemGroup>
     <SubDirectories Include="aes" />
     <SubDirectories Include="asn1" />

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/evp/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/evp/dotNetMF.proj
@@ -22,7 +22,10 @@
     <Version>4.0.0.0</Version>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4065: switch statement contains 'default' but no 'case' labels -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4065</ExtraFlags>
+  </PropertyGroup>
   <!--
   <ItemGroup>
     <SubDirectories Include="Stubs"/>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/rand/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/rand/dotNetMF.proj
@@ -22,7 +22,10 @@
     <Version>4.0.0.0</Version>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4996: '<apiname>': was declared deprecated -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4996</ExtraFlags>
+  </PropertyGroup>
   <!--
   <ItemGroup>
     <SubDirectories Include="Stubs"/>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/ssl/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/ssl/dotNetMF.proj
@@ -22,7 +22,10 @@
     <Version>4.0.0.0</Version>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4390: ';' : empty controlled statement found; is this the intent? -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4390</ExtraFlags>
+  </PropertyGroup>
   <!--
   <ItemGroup>
     <SubDirectories Include="Stubs"/>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/tinyclr/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/tinyclr/dotNetMF.proj
@@ -35,7 +35,10 @@
     <Version>4.0.0.0</Version>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4018: '>' : signed/unsigned mismatch -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4018</ExtraFlags>
+  </PropertyGroup>
   <ItemGroup>
     <IncludePaths Include="DeviceCode\PAL" />
     <IncludePaths Include="DeviceCode\PAL\OpenSSL" />

--- a/DeviceCode/pal/PKCS11/Tokens/OpenSSL/dotNetMF.proj
+++ b/DeviceCode/pal/PKCS11/Tokens/OpenSSL/dotNetMF.proj
@@ -26,7 +26,10 @@
     </LibraryCategory>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
-  <PropertyGroup />
+  <PropertyGroup>
+    <!-- warning C4018: '>' : signed/unsigned mismatch -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4018</ExtraFlags>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="OpenSSL_PKCS11_Config.cpp" />
     <Compile Include="OpenSSL_PKCS11_digest.cpp" />

--- a/DeviceCode/pal/TouchPanel/touchpanel_driver.cpp
+++ b/DeviceCode/pal/TouchPanel/touchpanel_driver.cpp
@@ -325,9 +325,9 @@ TouchPoint* TouchPanel_Driver::AddTouchPoint(UINT16 source, UINT16 x, UINT16 y, 
         if (lastAddedX != 0xFFFF)
         {
             /// dist2 is distance squared.
-            UINT32 dx = abs(x - lastAddedX);
-            UINT32 dy = abs(y - lastAddedY);
-            UINT32 dist2 = dx * dx + dy * dy;
+            INT32 dx = abs(x - lastAddedX);
+            INT32 dy = abs(y - lastAddedY);
+            INT32 dist2 = dx * dx + dy * dy;
 
             /// Ignore this point if it is too far from last point.
             if (dist2 > g_TouchPanel_Sampling_Settings.MaxFilterDistance) return NULL; 
@@ -335,10 +335,10 @@ TouchPoint* TouchPanel_Driver::AddTouchPoint(UINT16 source, UINT16 x, UINT16 y, 
 
         if(g_PAL_RunningAvg_Buffer_Size > 1)
         {
-            if (m_runavgIndex >= g_PAL_RunningAvg_Buffer_Size)
+            if (m_runavgIndex >= (INT32)g_PAL_RunningAvg_Buffer_Size)
                 m_runavgIndex = 0;
 
-            if (m_runavgCount >= g_PAL_RunningAvg_Buffer_Size)
+            if (m_runavgCount >= (INT32)g_PAL_RunningAvg_Buffer_Size)
             {
                 m_runavgTotalX -= g_PAL_RunningAvg_Buffer[m_runavgIndex].sx;
                 m_runavgTotalY -= g_PAL_RunningAvg_Buffer[m_runavgIndex].sy;            
@@ -387,13 +387,13 @@ TouchPoint* TouchPanel_Driver::AddTouchPoint(UINT16 source, UINT16 x, UINT16 y, 
     {
         m_tail ++;
 
-        if(m_tail >= g_PAL_TouchPointBufferSize) m_tail = 0;
+        if(m_tail >= (INT32)g_PAL_TouchPointBufferSize) m_tail = 0;
 
         if (m_tail == m_head)
         {
             m_head++;
 
-            if(m_head >= g_PAL_TouchPointBufferSize) m_head = 0;
+            if(m_head >= (INT32)g_PAL_TouchPointBufferSize) m_head = 0;
         }
     }
 

--- a/DeviceCode/pal/TouchPanel/touchpanel_driver.cpp
+++ b/DeviceCode/pal/TouchPanel/touchpanel_driver.cpp
@@ -460,8 +460,11 @@ HRESULT TouchPanel_Driver::GetSetTouchInfo(UINT32 flags, INT32* param1, INT32* p
             // Touch Move events are queued up and sent at the given time frequency (StylusMoveFrequency)
             // We should not set the move frequency to be less than the sample frequency, otherwise there
             // would be no data available occassionally.
-            else if(ticks < min_ms_per_touchsample) return CLR_E_OUT_OF_RANGE;
-            else                                    ticks = TOUCH_PANEL_SAMPLE_MS_TO_TICKS(ms_per_touchmove_event);
+            else
+            {
+              ticks = TOUCH_PANEL_SAMPLE_MS_TO_TICKS(ms_per_touchmove_event);
+              if(ticks < min_ms_per_touchsample) return CLR_E_OUT_OF_RANGE;
+            }
 
             g_TouchPanel_Sampling_Settings.SampleRate.MaxTimeForMoveEvent_ticks = ticks;
         }

--- a/Solutions/Windows2/TinyCLR/Analog.cpp
+++ b/Solutions/Windows2/TinyCLR/Analog.cpp
@@ -73,7 +73,7 @@ BOOL AD_GetAvailablePrecisionsForChannel( ANALOG_CHANNEL channel, INT32* precisi
     // let's simulate 3 channels
     INT32 precisionStart = 8;
     INT32 precisionIncr = 4;
-    INT32 channelIdx = 0;
+    UINT32 channelIdx = 0;
     for( ; channelIdx < 3 && channelIdx < size; ++channelIdx)
     {
         precisions[channelIdx] = precisionStart + channelIdx * precisionIncr;
@@ -153,7 +153,7 @@ BOOL DA_GetAvailablePrecisionsForChannel( DA_CHANNEL channel, INT32* precisions,
     // let's simulate 3 channels
     INT32 precisionStart = 8;
     INT32 precisionIncr = 4;
-    INT32 channelIdx = 0;
+    UINT32 channelIdx = 0;
     for( ; channelIdx < 3 && channelIdx < size; ++channelIdx)
     {
         precisions[channelIdx] = precisionStart + channelIdx * precisionIncr;

--- a/Solutions/Windows2/TinyCLR/Serial.cpp
+++ b/Solutions/Windows2/TinyCLR/Serial.cpp
@@ -133,7 +133,7 @@ BOOL CPU_USART_IsBaudrateSupported( int ComPortNum, UINT32 & BaudrateHz )
 
 BOOL USART_ConnectEventSink( int ComPortNum, int EventType, void* pContext, PFNUsartEvent pfnUsartEvtHandler, void** ppArg )
 {
-    if(ComPortNum < 0 || ComPortNum >= ARRAYSIZE(s_EmuUsartState) || ComPortNum >= CPU_USART_PortsCount()) return FALSE;
+    if(ComPortNum < 0 || ComPortNum >= ARRAYSIZE(s_EmuUsartState) || ComPortNum >= (int)CPU_USART_PortsCount()) return FALSE;
 
     s_EmuUsartState[ComPortNum].PortIndex = ComPortNum;
     
@@ -165,7 +165,7 @@ BOOL USART_ConnectEventSink( int ComPortNum, int EventType, void* pContext, PFNU
 
 void USART_SetEvent( int ComPortNum, unsigned int event )
 {
-    if((ComPortNum < 0) || (ComPortNum >= ARRAYSIZE(s_EmuUsartState)) ||(ComPortNum >= CPU_USART_PortsCount())) return;
+    if((ComPortNum < 0) || (ComPortNum >= ARRAYSIZE(s_EmuUsartState)) ||(ComPortNum >= (int)CPU_USART_PortsCount())) return;
 
     // Inorder to reduce the number of methods, we combine Error events and Data events in native code
     // and the event codes go from 0 to 6 (0-4 for error events and 5-6 for data events).

--- a/Solutions/Windows2/TinyCLR/Various.cpp
+++ b/Solutions/Windows2/TinyCLR/Various.cpp
@@ -437,6 +437,8 @@ void HAL_Windows_FastSleep( INT64 ticks )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
+#pragma unmanaged
+
 void debug_printf( char const* format, ... )
 {
     va_list arg_ptr;
@@ -535,6 +537,8 @@ int hal_vsnprintf( char* buffer, size_t len, const char* format, va_list arg )
 {
     return _vsnprintf_s( buffer, len, len-1/* force space for trailing zero*/, format, arg );
 }
+
+#pragma managed
 
 ///////////////////////////////////////////////////////////////
 

--- a/Solutions/Windows2/TinyCLR/Various.cpp
+++ b/Solutions/Windows2/TinyCLR/Various.cpp
@@ -437,7 +437,7 @@ void HAL_Windows_FastSleep( INT64 ticks )
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 
-#pragma unmanaged
+#pragma managed(push, off)
 
 void debug_printf( char const* format, ... )
 {
@@ -538,7 +538,7 @@ int hal_vsnprintf( char* buffer, size_t len, const char* format, va_list arg )
     return _vsnprintf_s( buffer, len, len-1/* force space for trailing zero*/, format, arg );
 }
 
-#pragma managed
+#pragma managed(pop)
 
 ///////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Partial fix for issue #5

Supressed in OpenSSL
`warning C4018: '>' : signed/unsigned mismatch`
`warning C4065: switch statement contains 'default' but no 'case' labels`
`warning C4390: ';' : empty controlled statement found; is this the intent?`
`warning C4996: '<apiname>': was declared deprecated`

Fixed
`warning C4018: '<op>' : signed/unsigned mismatch`
`warning C4244: '+=' : conversion from 'INT64' to 'UINT32', possible loss of data`
`warning C4700: uninitialized local variable '<var>' used`
`warning C4793: '<func>' : function compiled as native`
`warning C4800: 'BOOL' : forcing value to bool 'true' or 'false' (performance warning)`
