### PR TITLE
Fix Deploy failures on MCBSTM32F400

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@
 *.suo
 *.vspscc
 *.vssscc
+*.user
 [Bb]in/
 [Oo]bj/
 ipch/

--- a/Framework/CorDebug/MessageCentre.cs
+++ b/Framework/CorDebug/MessageCentre.cs
@@ -231,7 +231,7 @@ namespace Microsoft.SPOT.Debugger
                     pane.OutputStringThreadSafe(msg + "\r\n");
                 }
             }
-            catch (InvalidOperationException)
+            catch( InvalidComObjectException )
             {
             }
 

--- a/Framework/Debugger/DebuggerEventSource.cs
+++ b/Framework/Debugger/DebuggerEventSource.cs
@@ -32,6 +32,13 @@ namespace Microsoft.SPOT.Debugger
             WriteEvent( 3, ( int )state );
         }
 
+        [Event(4)]
+        public void EngineEraseMemory( uint address, uint length )
+        {
+            Trace.TraceInformation( "EreaseMemory: @{0:X08}; LEN={1:X08}", address, length );
+            WriteEvent( 4, ( int )address, ( int )length );
+        }
+
         private DebuggerEventSource()
         {
         }

--- a/Framework/Debugger/WireProtocol/Engine.cs
+++ b/Framework/Debugger/WireProtocol/Engine.cs
@@ -1690,6 +1690,7 @@ namespace Microsoft.SPOT.Debugger
 
         public bool EraseMemory( uint address, uint length )
         {
+            DebuggerEventSource.Log.EngineEraseMemory( address, length );
             var cmd = new Commands.Monitor_EraseMemory
                     {
                         m_address = address,
@@ -3146,6 +3147,7 @@ namespace Microsoft.SPOT.Debugger
             {
                 if( mh != null )
                     mh( string.Format( "Deployment storage (size: {0} bytes) was not large enough to fit deployment assemblies (size: {1} bytes)", status.m_storageLength, deployLength ) );
+                
                 return false;
             }
 
@@ -3239,6 +3241,9 @@ namespace Microsoft.SPOT.Debugger
                     {
                         if( !EraseMemory( sector.m_start, sector.m_length ) )
                         {
+                            if( mh != null )
+                                mh( string.Format( "FAILED to erase device memory @0x{0:X8} with Length=0x{1:X8}", sector.m_start, sector.m_length ) );
+
                             return false;
                         }
 
@@ -3256,6 +3261,9 @@ namespace Microsoft.SPOT.Debugger
 
                         if( !WriteMemory( sector.m_start, sectorData, 0, ( int )iSectorIndex ) )
                         {
+                            if( mh != null )
+                                mh( string.Format( "FAILED to write device memory @0x{0:X8} with Length={1:X8}", sector.m_start, ( int )iSectorIndex ) );
+
                             return false;
                         }
 #if DEBUG

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/M29W640FB_BlConfig.cpp
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/M29W640FB_BlConfig.cpp
@@ -18,17 +18,17 @@
 #define FLASH_BLOCK_ERASE_ACTUAL_TIME_USEC   800000 // not used
 #define FLASH_BLOCK_ERASE_MAX_TIME_USEC      6000000 // not used
 
-#define FLASH_ADDRESS1						0x60000000
-#define FLASH_BLOCK1_COUNT					8
-#define FLASH_BLOCK1_BYTES_PER_BLOCK		8192
+#define FLASH_ADDRESS1                       0x60000000
+#define FLASH_BLOCK1_COUNT                   8
+#define FLASH_BLOCK1_BYTES_PER_BLOCK         8192
 
-#define FLASH_ADDRESS2						0x60010000
-#define FLASH_BLOCK2_COUNT					127
-#define FLASH_BLOCK2_BYTES_PER_BLOCK		65536
+#define FLASH_ADDRESS2                       0x60010000
+#define FLASH_BLOCK2_COUNT                   127
+#define FLASH_BLOCK2_BYTES_PER_BLOCK         65536
 
 // EBIU Information
 
-#define M29W640FB__SIZE_IN_BYTES     0x00800000	// 8MB
+#define M29W640FB__SIZE_IN_BYTES     0x00800000    // 8MB
 #define M29W640FB__WP_GPIO_PIN       GPIO_PIN_NONE
 #define M29W640FB__WP_ACTIVE         FALSE
 
@@ -43,14 +43,12 @@
 
 const BlockRange g_M29W640FB_BlockRange1[] =
 {
-    { BlockRange::BLOCKTYPE_CODE,   0,  7 },    // 64KB
+    { BlockRange::BLOCKTYPE_CODE,   0,  7 },    // 8x8KB=64KB
 };
 
 const BlockRange g_M29W640FB_BlockRange2[] =
 {
-    { BlockRange::BLOCKTYPE_CODE,   0,  1 }, 	// 64KB
-
-    { BlockRange::BLOCKTYPE_DEPLOYMENT,   1,  126 }, 	// 8064KB
+    { BlockRange::BLOCKTYPE_DEPLOYMENT,   0,  126 },  // 128x64KB = 8128KB
 };
 
 
@@ -58,15 +56,15 @@ const BlockRegionInfo  g_M29W640FB_BlkRegion[M29W640FB__NUM_REGIONS] =
 {
     {
         FLASH_ADDRESS1,                 // ByteAddress  Start;         // Starting Sector address
-        FLASH_BLOCK1_COUNT,     		// UINT32       NumBlocks;     // total number of blocks in this region
-        FLASH_BLOCK1_BYTES_PER_BLOCK, 	// UINT32       BytesPerBlock; // Total number of bytes per block
+        FLASH_BLOCK1_COUNT,             // UINT32       NumBlocks;     // total number of blocks in this region
+        FLASH_BLOCK1_BYTES_PER_BLOCK,     // UINT32       BytesPerBlock; // Total number of bytes per block
         ARRAYSIZE_CONST_EXPR(g_M29W640FB_BlockRange1),
         g_M29W640FB_BlockRange1,
     },
-	{
+    {
         FLASH_ADDRESS2,                 // ByteAddress  Start;         // Starting Sector address
-        FLASH_BLOCK2_COUNT,     		// UINT32       NumBlocks;     // total number of blocks in this region
-        FLASH_BLOCK2_BYTES_PER_BLOCK, 	// UINT32       BytesPerBlock; // Total number of bytes per block
+        FLASH_BLOCK2_COUNT,             // UINT32       NumBlocks;     // total number of blocks in this region
+        FLASH_BLOCK2_BYTES_PER_BLOCK,     // UINT32       BytesPerBlock; // Total number of bytes per block
         ARRAYSIZE_CONST_EXPR(g_M29W640FB_BlockRange2),
         g_M29W640FB_BlockRange2,
     }

--- a/Solutions/MCBSTM32F400/DeviceCode/TinyHal/tinyhal.cpp
+++ b/Solutions/MCBSTM32F400/DeviceCode/TinyHal/tinyhal.cpp
@@ -293,9 +293,11 @@ void HAL_UnReserveAllGpios()
 // is located correctly but the fixed up pointer stored
 // in the literal pool that this code loads for the address
 // of the load base (src) is off by some factor. In initial
-// testing it was always 144, unfortunately it turns out
-// not to be consistent and is now at 0xED0...
-const UINT32 ArmLinkerLoadRegionOffsetHack = 0x00000ED0;
+// testing it was always 0x90, unfortunately it turns out
+// not to be consistent and bumped up to 0xED0, and is now
+// back at 0x90... Sigh... Hope to hear back from ARM support
+// on this soon.
+const UINT32 ArmLinkerLoadRegionOffsetHack = 0x00000090;
 
 void LwipRegionInit()
 {


### PR DESCRIPTION
- Updated Debug engine to provide useful messages on flash erase/write errors during deployment.
- Added Debug engine trace event for erase memory
- Fixed MCBSTM32F400 Blck config for the external FLASH to use the whole flash for Deployment, which is waht the scatterfile.xml is set up to assume. (this caused the device to NACK the sector erase which was reported with little more detail than E_FAIL in the IDE :( )
- Fixed the ArmLinkerOffset bug for the LoadRegion to reflect current imperically determined offset value. (Awaiting full fix from ARM linker team to eliminate this hack)
- added *.user to the .gitignore