### PR TITLE
Fix collisions in GUIDs of libraries

### DIFF
--- a/DeviceCode/Drivers/Display/TD022SHEB2/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TD022SHEB2/dotNetMF.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>TD022SHEB2</AssemblyName>
-    <ProjectGuid>{eac50a10-364f-489e-a9a3-6b0a3c740c4d}</ProjectGuid>
+    <ProjectGuid>{42883606-7F97-4B30-9673-50BAFA09C511}</ProjectGuid>
     <Size>
     </Size>
     <Description>TD022SHEB2 display driver</Description>

--- a/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF_loader.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF_loader.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <AssemblyName>MCBSTM32F400_initialization_hal_loader</AssemblyName>
-    <ProjectGuid>{c37646ed-b790-4420-b165-65e86b4031cd}</ProjectGuid>
+    <ProjectGuid>{8977FA77-FFD4-4D13-966D-E62E5E654D9F}</ProjectGuid>
     <Size>
     </Size>
     <Description>System initialization library for MCBSTM32F400 (for boot loaders)</Description>

--- a/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF.proj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <PropertyGroup>
         <AssemblyName>MCBSTM32F400_tinyhal</AssemblyName>
-        <ProjectGuid>{b65a0478-f1a0-417a-9c5e-88d4424a1696}</ProjectGuid>
+        <ProjectGuid>{4700A10C-F4E9-4D12-B0E7-B941E80BB402}</ProjectGuid>
         <Size>
         </Size>
         <Description>MCBSTM32F400 tinyhal library</Description>


### PR DESCRIPTION
Each library should have a unique GUID, but some libraries have same GUIDs (probably due to manual modifications of dotNetMF.proj files). This commit fixes a few collisions between library GUIDs.