### PR TITLE
Move reducesize property before the import of Microsoft.SPOT.System.Settings

### DIFF
--- a/CLR/Tools/PlatformDesigner/ComponentObjectModel/MsBuildWrapper.cs
+++ b/CLR/Tools/PlatformDesigner/ComponentObjectModel/MsBuildWrapper.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections;
 using System.Text;
 using System.IO;
+using System.Linq;
 using XsdInventoryFormatObject;
 using Microsoft.Build.Framework;
 //using Microsoft.Build.BuildEngine;
@@ -3136,6 +3137,13 @@ namespace ComponentObjectModel
                     tbl["Guid"] = "ProjectGuid";
 
                     ProjectPropertyGroupElement bpg = SaveStringProps(proj, mfproj, tbl);
+
+                    if (mfproj.Properties.Any(p => p.Name == "reducesize"))
+                    {
+                        var prop = mfproj.Properties.First(p => p.Name == "reducesize");
+                        bpg.AddProperty("reducesize", prop.Value);
+                    }
+
 
                     ProjectImportElement pi = proj.Xml.AddImport(@"$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings");
 

--- a/CLR/Tools/PlatformDesigner/ComponentObjectModel/MsBuildWrapper.cs
+++ b/CLR/Tools/PlatformDesigner/ComponentObjectModel/MsBuildWrapper.cs
@@ -3138,12 +3138,11 @@ namespace ComponentObjectModel
 
                     ProjectPropertyGroupElement bpg = SaveStringProps(proj, mfproj, tbl);
 
-                    if (mfproj.Properties.Any(p => p.Name == "reducesize"))
+                    var reducesizeProp = mfproj.Properties.FirstOrDefault(p => p.Name == "reducesize");
+                    if (reducesizeProp != null)
                     {
-                        var prop = mfproj.Properties.First(p => p.Name == "reducesize");
-                        bpg.AddProperty("reducesize", prop.Value);
+                        bpg.AddProperty("reducesize", reducesizeProp.Value);
                     }
-
 
                     ProjectImportElement pi = proj.Xml.AddImport(@"$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings");
 

--- a/ProjectTemplates/TinyBooter/TinyBooter.proj
+++ b/ProjectTemplates/TinyBooter/TinyBooter.proj
@@ -16,12 +16,12 @@
     <ProjectPath>$(SPOCLIENT)\ProjectTemplates\TinyBooter\TinyBooter.proj</ProjectPath>
     <MFSettingsFile>
     </MFSettingsFile>
+    <reducesize>true</reducesize>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.Build.Targets" />
   <PropertyGroup>
     <OutputType>Executable</OutputType>
-    <reducesize>true</reducesize>
     <MultipleOutputSections>false</MultipleOutputSections>
     <CustomAssemblyName>TinyBooter</CustomAssemblyName>
 

--- a/ProjectTemplates/TinyBooter/TinyBooterDecompressor.proj
+++ b/ProjectTemplates/TinyBooter/TinyBooterDecompressor.proj
@@ -16,12 +16,12 @@
     <ProjectPath>$(SPOCLIENT)\ProjectTemplates\TinyBooter\TinyBooterDecompressor.proj</ProjectPath>
     <MFSettingsFile>
     </MFSettingsFile>
+    <reducesize>true</reducesize>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.Build.Targets" />
   <PropertyGroup>
     <OutputType>Executable</OutputType>
-    <reducesize>true</reducesize>
     <MultipleOutputSections>false</MultipleOutputSections>
     <ExtraTargets>BuildSigFiles</ExtraTargets>
     <ScatterFileDefinition>scatterfile_bootloader_decompressor_$(COMPILER_TOOL).$(SCATTER_EXT)</ScatterFileDefinition>

--- a/ProjectTemplates/TinyCLR/TinyCLR.proj
+++ b/ProjectTemplates/TinyCLR/TinyCLR.proj
@@ -5,6 +5,7 @@
     <Directory>Solutions\$(PLATFORM)\TinyCLR</Directory>
     <IsClrProject>True</IsClrProject>
     <ProjectPath>$(SPOCLIENT)\ProjectTemplates\TinyCLR\TinyCLR.proj</ProjectPath>
+    <reducesize>false</reducesize>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.Build.Targets" />


### PR DESCRIPTION
The main point of this change is to enable conditional inclusion of settings in a solution settings file based on reducesize property (for example, include CMSIS_RTOS settings for TinyClr but not for TinyBooter)