### PR TITLE
Remove unnecessary managed code crash from TristatePort

### DIFF
--- a/CLR/Libraries/SPOT_Hardware/spot_hardware_native_Microsoft_SPOT_Hardware_TristatePort.cpp
+++ b/CLR/Libraries/SPOT_Hardware/spot_hardware_native_Microsoft_SPOT_Hardware_TristatePort.cpp
@@ -43,10 +43,6 @@ HRESULT Library_spot_hardware_native_Microsoft_SPOT_Hardware_TristatePort::set_A
     {
         TINYCLR_CHECK_HRESULT(Library_spot_hardware_native_Microsoft_SPOT_Hardware_Port::ChangeState( pThis, port, activate ));
     }
-    else
-    {
-        TINYCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);
-    }
     
     TINYCLR_NOCLEANUP();
 }


### PR DESCRIPTION
There's no need to artificially increase the learning curve by throwing a managed code exception here.  If .Active is being set to its current value, the existing code will avoid changing the port without the need for a crash.