### PR TITLE
Import LCD_HAL libcatproj from TinyCRT proj

### DIFF
--- a/DeviceCode/pal/tinycrt/dotNetMF.proj
+++ b/DeviceCode/pal/tinycrt/dotNetMF.proj
@@ -48,5 +48,6 @@
   <ItemGroup>
     <ExtraProjects Include="dotNetMF_loader.proj" />
   </ItemGroup>
+  <Import Project="$(SPOCLIENT)\Framework\Features\LCD_HAL.libcatproj" />
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Targets" />
 </Project>

--- a/DeviceCode/pal/tinycrt/dotNetMF_loader.proj
+++ b/DeviceCode/pal/tinycrt/dotNetMF_loader.proj
@@ -45,5 +45,6 @@
     <IncludePaths Include="DeviceCode\include" />
   </ItemGroup>
   <ItemGroup />
+  <Import Project="$(SPOCLIENT)\Framework\Features\LCD_HAL.libcatproj" />
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Targets" />
 </Project>


### PR DESCRIPTION
LCD_WriteFormattedChar is referenced from tinycrt.cpp. This fix makes sure that at least the stub for LCD gets included during the creation of a solution using SolutionWizard.