### PR TITLE
fixed the tinybooter erase itself if the Configuratoin block is corrupted...

### DIFF
--- a/Application/TinyBooter/Commands.cpp
+++ b/Application/TinyBooter/Commands.cpp
@@ -343,8 +343,11 @@ struct BitFieldManager
                                     if(iAbsBlock <= blockIndex && blockIndex <= (iAbsBlock + rangeBlocks))
                                     {
                                         ByteAddress eraseAddress = pRegion->BlockAddress(blockIndex - iAbsBlock);
-                                        
-                                        device->EraseBlock( eraseAddress );
+
+                                        if (CheckFlashSectorPermission(device, eraseAddress))
+                                            device->EraseBlock( eraseAddress );
+                                        else
+                                            debug_printf(" BOOTER BLOCK IS Dirty ??? !!! ");
 
                                         found = true;
                                         break;

--- a/tools/Targets/Microsoft.Spot.system.mdk.targets
+++ b/tools/Targets/Microsoft.Spot.system.mdk.targets
@@ -197,7 +197,6 @@
 
     <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) @(CC_CPP_Defines->'-D%(filename)',' ')</CC_CPP_COMMON_FLAGS>
 
-    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(RVCT31INC)</CC_CPP_INCS>
     <CC_CPP_INCS>$(CC_CPP_INCS) -I$(CLRROOT)\$(Directory)</CC_CPP_INCS>
     <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\DeviceCode\include</CC_CPP_INCS>
     <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\DeviceCode\Cores\arm</CC_CPP_INCS>
@@ -212,6 +211,8 @@
     <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\SPOT_Net_Security</CC_CPP_INCS>
     <CC_CPP_INCS>$(CC_CPP_INCS) @(IncludePaths->'-I$(CLRROOT)\%(relativedir)%(filename)',' ')</CC_CPP_INCS>
     <CC_CPP_INCS>$(CC_CPP_INCS) @(DirectIncludePaths->'-I%(FullPath)',' ')</CC_CPP_INCS>
+        <CC_CPP_INCS>$(CC_CPP_INCS) -I$(RVCT31INC)</CC_CPP_INCS>
+
 
     <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) $(AS_CC_CPP_COMMON_FLAGS) $(CC_CPP_TARGETTYPE_FLAGS) $(CC_CPP_INCS) $(ExtraFlags)</CC_CPP_COMMON_FLAGS>
   </PropertyGroup>


### PR DESCRIPTION
...d. Do not allow tinybooter erase itself if the corresponding dirty bit is set.

fixed the build break if the Keil_v5\ARM\RV31\INC\RTX_Config.h is included in the toolchain, reorder the included directory search order.