### PR TITLE
Add support for internal ADC channels

### DIFF
--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
@@ -55,8 +55,8 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
 	// init this channel if it's listed in the STM32F4_AD_CHANNELS array
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum) {
-	  	   // valid channel
-    	   if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
+		// valid channel
+			if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
                RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
                ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
                ADCx->SQR1 = 0; // 1 conversion
@@ -64,14 +64,14 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
                ADCx->CR2 = ADC_CR2_ADON; // AD on
                ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
                ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
-    	   }
+		}
 
-	   	   // set pin as analog input if channel is not one of the internally connected
-           if(chNum <= 15) {
-              CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
-           }
+			// set pin as analog input if channel is not one of the internally connected
+			if(chNum <= 15) {
+				CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
+			}
 
-	   	   return TRUE;
+			return TRUE;
 		}
     }
 

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
@@ -27,10 +27,10 @@
 #if STM32F4_ADC == 1
     #define ADCx ADC1
     #define RCC_APB2ENR_ADCxEN RCC_APB2ENR_ADC1EN
-	// ADC1 pins plus two internally connected channels thus the 0 for 'no pin'
-	// Vsense for temperature sensor @ ADC1_IN16
-	// Vrefubt for internal voltage reference (1.21V) @ ADC1_IN17
-	// to access the internal channels need to include '16' and/or '17' at the STM32F4_AD_CHANNELS array in 'platform_selector.h' 
+    // ADC1 pins plus two internally connected channels thus the 0 for 'no pin'
+    // Vsense for temperature sensor @ ADC1_IN16
+    // Vrefubt for internal voltage reference (1.21V) @ ADC1_IN17
+    // to access the internal channels need to include '16' and/or '17' at the STM32F4_AD_CHANNELS array in 'platform_selector.h' 
     #define STM32F4_ADC_PINS {0,1,2,3,4,5,6,7,16,17,32,33,34,35,36,37,0,0} 
 #elif STM32F4_ADC == 3
     #define ADCx ADC3
@@ -52,10 +52,10 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
 {
     int chNum = g_STM32F4_AD_Channel[channel];
 
-	// init this channel if it's listed in the STM32F4_AD_CHANNELS array
+    // init this channel if it's listed in the STM32F4_AD_CHANNELS array
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum) {
-		// valid channel
+			// valid channel
 			if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
                RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
                ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
@@ -64,17 +64,16 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
                ADCx->CR2 = ADC_CR2_ADON; // AD on
                ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
                ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
-		}
-
-			// set pin as analog input if channel is not one of the internally connected
-			if(chNum <= 15) {
-				CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
 			}
 
-			return TRUE;
+            // set pin as analog input if channel is not one of the internally connected
+            if(chNum <= 15) {
+                CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
+                return TRUE;        
+            }
 		}
-    }
-
+	}
+	
     // channel not available
     return FALSE;
 }
@@ -97,26 +96,26 @@ INT32 AD_Read( ANALOG_CHANNEL channel )
     // check if this channel is listed in the STM32F4_AD_CHANNELS array
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum ) {
-       	    // valid channel
-	    	int x = ADCx->DR; // clear EOC flag
+            // valid channel
+            int x = ADCx->DR; // clear EOC flag
 
-	    	ADCx->SQR3 = chNum; // select channel
-	    
-		    // need to enable internal reference at ADC->CCR register to work with internally connected channels 
-		    if(chNum == 16 || chNum == 17) {
-				ADC->CCR |= ADC_CCR_TSVREFE; // Enable internal reference to work with temperature sensor and VREFINT channels
-		    }
-	
-		    ADCx->CR2 |= ADC_CR2_SWSTART; // start AD
-		    while (!(ADCx->SR & ADC_SR_EOC)); // wait for completion
-	
-		    // disable internally reference
-		    if(chNum == 16 || chNum == 17) {
-				ADC->CCR &= ~(1 << ADC_CCR_TSVREFE); 
-		    }
-	
-		    return ADCx->DR; // read result
-		}
+            ADCx->SQR3 = chNum; // select channel
+        
+            // need to enable internal reference at ADC->CCR register to work with internally connected channels 
+            if(chNum == 16 || chNum == 17) {
+                ADC->CCR |= ADC_CCR_TSVREFE; // Enable internal reference to work with temperature sensor and VREFINT channels
+            }
+    
+            ADCx->CR2 |= ADC_CR2_SWSTART; // start AD
+            while (!(ADCx->SR & ADC_SR_EOC)); // wait for completion
+    
+            // disable internally reference
+            if(chNum == 16 || chNum == 17) {
+                ADC->CCR &= ~(1 << ADC_CCR_TSVREFE); 
+            }
+    
+            return ADCx->DR; // read result
+        }
     }
 
     // channel not available
@@ -131,13 +130,13 @@ UINT32 AD_ADChannels()
 GPIO_PIN AD_GetPinForChannel( ANALOG_CHANNEL channel )
 {
     // return GPIO pin
-	// for internally connected channels this is GPIO_PIN_NONE as these don't take any GPIO pins
+    // for internally connected channels this is GPIO_PIN_NONE as these don't take any GPIO pins
     int chNum = g_STM32F4_AD_Channel[channel];
 
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum) {
             return (GPIO_PIN)g_STM32F4_AD_Pins[chNum];
-		}
+        }
     }
 
     // channel not available
@@ -148,16 +147,16 @@ BOOL AD_GetAvailablePrecisionsForChannel( ANALOG_CHANNEL channel, INT32* precisi
 {
     int chNum = g_STM32F4_AD_Channel[channel];
 
-	// check if this channel is listed in the STM32F4_AD_CHANNELS array
+    // check if this channel is listed in the STM32F4_AD_CHANNELS array
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum) {
-	    	precisions[0] = 12;
-	    	size = 1;
-	    	return TRUE;
-		}
+            precisions[0] = 12;
+            size = 1;
+            return TRUE;
+        }
     }
 
-	// channel not available
+    // channel not available
     size = 0;
     return FALSE;
 }

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
@@ -56,7 +56,7 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum) {
             // valid channel
-	        if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
+            if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
                 RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
                 ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
                 ADCx->SQR1 = 0; // 1 conversion
@@ -64,8 +64,8 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
                 ADCx->CR2 = ADC_CR2_ADON; // AD on
                 ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
                 ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
-	        }
-	        
+            }
+            
             // set pin as analog input if channel is not one of the internally connected
             if(chNum <= 15) {
                 CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
@@ -27,7 +27,11 @@
 #if STM32F4_ADC == 1
     #define ADCx ADC1
     #define RCC_APB2ENR_ADCxEN RCC_APB2ENR_ADC1EN
-    #define STM32F4_ADC_PINS {0,1,2,3,4,5,6,7,16,17,32,33,34,35,36,37} // ADC1 pins
+	// ADC1 pins plus two internally connected channels thus the 0 for 'no pin'
+	// Vsense for temperature sensor @ ADC1_IN16
+	// Vrefubt for internal voltage reference (1.21V) @ ADC1_IN17
+	// to access the internal channels need to include '16' and/or '17' at the STM32F4_AD_CHANNELS array in 'platform_selector.h' 
+    #define STM32F4_ADC_PINS {0,1,2,3,4,5,6,7,16,17,32,33,34,35,36,37,0,0} 
 #elif STM32F4_ADC == 3
     #define ADCx ADC3
     #define RCC_APB2ENR_ADCxEN RCC_APB2ENR_ADC3EN
@@ -46,34 +50,77 @@ static const BYTE g_STM32F4_AD_Pins[] = STM32F4_ADC_PINS;
 
 BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
 {
-    if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
-        RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
-        ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
-        ADCx->SQR1 = 0; // 1 conversion
-        ADCx->CR1 = 0;
-        ADCx->CR2 = ADC_CR2_ADON; // AD on
-        ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
-        ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
+    int chNum = g_STM32F4_AD_Channel[channel];
+
+	// init this channel if it's listed in the STM32F4_AD_CHANNELS array
+    for (int i = 0; i < STM32F4_AD_NUM ; i++) {
+        if (g_STM32F4_AD_Channel[i] == chNum) {
+	  	   // valid channel
+    	   if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
+               RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
+               ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
+               ADCx->SQR1 = 0; // 1 conversion
+               ADCx->CR1 = 0;
+               ADCx->CR2 = ADC_CR2_ADON; // AD on
+               ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
+               ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
+    	   }
+
+	   	   // set pin as analog input if channel is not one of the internally connected
+           if(chNum <= 15) {
+              CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
+           }
+
+	   	   return TRUE;
+		}
     }
-    // set pin as analog input
-    CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
-    return TRUE;
+
+    // channel not available
+    return FALSE;
 }
 
 void AD_Uninitialize( ANALOG_CHANNEL channel )
 {
-    // free pin
-    CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_PRIMARY);
+    int chNum = g_STM32F4_AD_Channel[channel];
+
+    // free GPIO pin if this channel is listed in the STM32F4_AD_CHANNELS array 
+    // and if it's not one of the internally connected ones as these channels don't take any GPIO pins
+    if(chNum <= 15) {
+        CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
+    }
 }
 
 INT32 AD_Read( ANALOG_CHANNEL channel )
 {
-    if ((UINT32)channel >= STM32F4_AD_NUM) return 0;
-    int x = ADCx->DR; // clear EOC flag
-    ADCx->SQR3 = g_STM32F4_AD_Channel[channel]; // select channel
-    ADCx->CR2 |= ADC_CR2_SWSTART; // start AD
-    while (!(ADCx->SR & ADC_SR_EOC)); // wait for completion
-    return ADCx->DR; // read result
+    int chNum = g_STM32F4_AD_Channel[channel];
+  
+    // check if this channel is listed in the STM32F4_AD_CHANNELS array
+    for (int i = 0; i < STM32F4_AD_NUM ; i++) {
+        if (g_STM32F4_AD_Channel[i] == chNum ) {
+       	    // valid channel
+	    	int x = ADCx->DR; // clear EOC flag
+
+	    	ADCx->SQR3 = chNum; // select channel
+	    
+		    // need to enable internal reference at ADC->CCR register to work with internally connected channels 
+		    if(chNum == 16 || chNum == 17) {
+				ADC->CCR |= ADC_CCR_TSVREFE; // Enable internal reference to work with temperature sensor and VREFINT channels
+		    }
+	
+		    ADCx->CR2 |= ADC_CR2_SWSTART; // start AD
+		    while (!(ADCx->SR & ADC_SR_EOC)); // wait for completion
+	
+		    // disable internally reference
+		    if(chNum == 16 || chNum == 17) {
+				ADC->CCR &= ~(1 << ADC_CCR_TSVREFE); 
+		    }
+	
+		    return ADCx->DR; // read result
+		}
+    }
+
+    // channel not available
+    return 0;
 }
 
 UINT32 AD_ADChannels()
@@ -83,16 +130,34 @@ UINT32 AD_ADChannels()
 
 GPIO_PIN AD_GetPinForChannel( ANALOG_CHANNEL channel )
 {
-    if ((UINT32)channel >= STM32F4_AD_NUM) return GPIO_PIN_NONE;
+    // return GPIO pin
+	// for internally connected channels this is GPIO_PIN_NONE as these don't take any GPIO pins
     int chNum = g_STM32F4_AD_Channel[channel];
-    return (GPIO_PIN)g_STM32F4_AD_Pins[chNum];
+
+    for (int i = 0; i < STM32F4_AD_NUM ; i++) {
+        if (g_STM32F4_AD_Channel[i] == chNum) {
+            return (GPIO_PIN)g_STM32F4_AD_Pins[chNum];
+		}
+    }
+
+    // channel not available
+    return GPIO_PIN_NONE;
 }
 
 BOOL AD_GetAvailablePrecisionsForChannel( ANALOG_CHANNEL channel, INT32* precisions, UINT32& size )
 {
+    int chNum = g_STM32F4_AD_Channel[channel];
+
+	// check if this channel is listed in the STM32F4_AD_CHANNELS array
+    for (int i = 0; i < STM32F4_AD_NUM ; i++) {
+        if (g_STM32F4_AD_Channel[i] == chNum) {
+	    	precisions[0] = 12;
+	    	size = 1;
+	    	return TRUE;
+		}
+    }
+
+	// channel not available
     size = 0;
-    if (precisions == NULL || (UINT32)channel >= STM32F4_AD_NUM) return FALSE;
-    precisions[0] = 12;
-    size = 1;
-    return TRUE;
+    return FALSE;
 }

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
@@ -55,24 +55,24 @@ BOOL AD_Initialize( ANALOG_CHANNEL channel, INT32 precisionInBits )
     // init this channel if it's listed in the STM32F4_AD_CHANNELS array
     for (int i = 0; i < STM32F4_AD_NUM ; i++) {
         if (g_STM32F4_AD_Channel[i] == chNum) {
-			// valid channel
-			if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
-               RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
-               ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
-               ADCx->SQR1 = 0; // 1 conversion
-               ADCx->CR1 = 0;
-               ADCx->CR2 = ADC_CR2_ADON; // AD on
-               ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
-               ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
-			}
-
+            // valid channel
+	        if (!(RCC->APB2ENR & RCC_APB2ENR_ADCxEN)) { // not yet initialized
+                RCC->APB2ENR |= RCC_APB2ENR_ADCxEN; // enable AD clock
+                ADC->CCR = 0; // ADCCLK = PB2CLK / 2;
+                ADCx->SQR1 = 0; // 1 conversion
+                ADCx->CR1 = 0;
+                ADCx->CR2 = ADC_CR2_ADON; // AD on
+                ADCx->SMPR1 = 0x01249249 * STM32F4_AD_SAMPLE_TIME;
+                ADCx->SMPR2 = 0x09249249 * STM32F4_AD_SAMPLE_TIME;
+	        }
+	        
             // set pin as analog input if channel is not one of the internally connected
             if(chNum <= 15) {
                 CPU_GPIO_DisablePin(AD_GetPinForChannel(channel), RESISTOR_DISABLED, 0, GPIO_ALT_MODE_1);
                 return TRUE;        
             }
-		}
-	}
+        }
+    }
 	
     // channel not available
     return FALSE;

--- a/DeviceCode/Targets/Native/STM32F4/STM32F4_template_selector.h
+++ b/DeviceCode/Targets/Native/STM32F4/STM32F4_template_selector.h
@@ -96,10 +96,10 @@
 
 // AD CHANNELS (ADC1 or ADC3)
 #define STM32F4_ADC 1
-// channel:   0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15
+// channel:   0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17
 // AD pins: PA0,PA1,PA2,PA3,PA4,PA5,PA6,PA7,PB0,PB1,PC0,PC1,PC2,PC3,PC4,PC5
 //#define STM32F4_ADC 3
-// channel:   0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15
+// channel:   0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15, 16, 17
 // AD pins: PA0,PA1,PA2,PA3,PF6,PF7,PF8,PF9,F10,PF3,PC0,PC1,PC2,PC3,PF4,PF5
 #define STM32F4_AD_CHANNELS {10,11,12,13} // PC0-PC3
 


### PR DESCRIPTION
Added support for internal ADC channels ADC1_IN16 and ADC1_IN17. These
channels allow reading the temperature sensor and the internal voltage
reference.
Having the capability of measuring the internal voltage reference
(1.21V) is very important when using Vcc as ADC Vref. Being able to read
Vref before taking an ADC sample allows accurate ADC calculations.
Being able to read the temperature can be relevant for some
applications.

Also improved the checking of ADC channel availability. The current
checking was very simplistic and kind of 'lazy' because it checked only
the length of the channels array not if the requested channel was
actually available in the Solution.