### PR TITLE
MCBSTM32F400 v1.2 support ( Issue #13 )

### DIFF
--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/STM32F4_ETH_driver.h
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/STM32F4_ETH_driver.h
@@ -107,8 +107,9 @@ void eth_dmaInterruptHandler();
 // Interrupt handler
 void eth_initReceiveIntHandler(pIntHandler receiveHandler);
 
-// PHY
-void eth_initPhy();
+// For PHY driver to read/write PHY registers
+BOOL eth_readPhyRegister(uint32_t phyAddress, const uint32_t miiAddress, uint16_t *const pMiiData);
+BOOL eth_writePhyRegister(uint32_t phyAddress, const uint32_t miiAddress, const uint16_t miiData);
 
 // Descriptors
 void eth_initTxDescList(uint32_t txAddress);

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/STM32F4_ETH_phy.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/STM32F4_ETH_phy.cpp
@@ -28,76 +28,63 @@
 #include <tinyhal.h>
 
 #include "STM32F4_ETH_phy.h"
+#include "STM32F4_ETH_driver.h"
 
-#define ADVERTISE_10BASET_ONLY 1
+//#define ADVERTISE_10BASET_ONLY 1
 
 //--------------------------------------------------------------------------------------------
 // Constant defines
 //--------------------------------------------------------------------------------------------
+// 
+#define INVALID_PHY_ADDRESS             0xFF
 
-#define PHY_CONTROL_REGISTER            0U              // Control register
-#define PHY_RESET                       0x8000U         // Reset
-#define PHY_ANEGEN                      0x1000U         // Auto-negotiation enable 
-#define PHY_ANEG_RESTART                0x0200U 
-#define PHY_PWRDN                       0x0800U         // Power-down
-#define PHY_STATUS_REGISTER             1U              // Status register
-#define PHY_LINK                        0x0004U         // Link status
-#define PHY_ANEGC                       0x0020U         // Auto-negotiation complete
-#define PHY_RMII_ANEG_ADVERT_REGISTER   04U             // Auto negotiation advertisement register
-#define PHY_RMII_XCNTL_REGISTER         16U
-#define PHY_RMII_RXCFG_IIS_REGISTER     17U             // Receive Configuration and Interrupt Status Register
-#define PHY_DIAGNOSTIC_REGISTER         18U             // Diagnostic register
-#define PHY_ANEGF                       0x1000U         // Auto-negotiation fail indication
-#define PHY_LINK_TIMEOUT                0x0003FFFFU     // PHY link timeout
-#define PHY_RESET_DELAY                 0x000FFFFFU     // PHY reset delay
-#define PHY_AUTO_NEGOTIATION_TIMEOUT    0x00100000U     // Auto negotiation timeout
-#define PHY_RMII_RXCFG_IIS_MODEMASK     (3<<8)          // Speed bit (bit 9 = speed; bit 8 == Duplex )
-#define PHY_IDENTIFIER_REGISTER_1       2U              // Identifier register 1
 
-#define PHY_RMII_ANEG_ADVERT_100BASE_T4  (1<<9)
-#define PHY_RMII_ANEG_ADVERT_100BASE_TXF (1<<8)
-#define PHY_RMII_ANEG_ADVERT_100BASE_TX  (1<<7)
-#define PHY_RMII_ANEG_ADVERT_10BASE_TF   (1<<6)
-#define PHY_RMII_ANEG_ADVERT_10BASE_T    (1<<5)
+static uint32_t g_phyAddress =INVALID_PHY_ADDRESS;
+static uint32_t g_foundPhyAddress =FALSE;
 
-#define PHY_RMII_ANEG_ADVERT_SPEED_MASK ( PHY_RMII_ANEG_ADVERT_100BASE_T4 | PHY_RMII_ANEG_ADVERT_100BASE_TXF | PHY_RMII_ANEG_ADVERT_100BASE_TX | PHY_RMII_ANEG_ADVERT_10BASE_TF | PHY_RMII_ANEG_ADVERT_10BASE_T)
-
-#define PHY_RESPONSE_TIMEOUT            0x0003FFFFU     // PHY response timeout
-#define PHY_TERIDIAN_OUI                0x000EU       // Teridian unique identifier
-#define PHY_ST802RT1X_OUI               0x80E1U // ST802RT1x PHY unique identifier
-#if STM32F4_ETH_PHY_RMII
-#define PHY_OUI PHY_ST802RT1X_OUI
-#else
-#define PHY_TERIRIAN_OUI
-#endif
-
-//--------------------------------------------------------------------------------------------
-// Local declarations
-//--------------------------------------------------------------------------------------------
-
-static BOOL (*readPhyRegister)(const uint32_t miiAddress, uint16_t *const miiData);
-static BOOL (*writePhyRegister)(const uint32_t miiAddress, const uint16_t miiData);
-
-//--------------------------------------------------------------------------------------------
-// Functions definitions
-//--------------------------------------------------------------------------------------------
-/**
- * Save the function to read the PHY.
- * @param pRead pointer to the read PHY callback function.
- */
-void initReadPhyCallback(pRead readCallback)
+static void findPhyAddr()
 {
-    readPhyRegister = readCallback;
+    uint32_t phyAddress = 0;
+    uint16_t value;
+    uint32_t rc = 0xFF;
+    uint32_t cnt = 31;          // 5 bit address
+    uint16_t ret;
+    do
+    {
+        ret = eth_readPhyRegister(phyAddress, PHY_IDENTIFIER_REGISTER_1, &value );
+        if ((value == PHY_KENDIN_OUI_ID1) || (value == PHY_ST802RT1X_OUI_ID1))
+        {
+            rc = phyAddress;
+            debug_printf( "Valid PHY Found: %x (%x)\r\n", rc, value);
+            g_foundPhyAddress = TRUE;
+            g_phyAddress = phyAddress;
+            
+            break;
+        }
+        phyAddress = (phyAddress + 1) & 0x1F;
+
+    }while(--cnt);
+
 }
 
-//--------------------------------------------------------------------------------------------
-/**
- * Save the function to write to the PHY.
- * @param pWrite pointer to the write PHY callback function.
- */
-void initWritePhyCallback(pWrite writeCallback)
+static BOOL readRegister( const uint32_t miiAddress, uint16_t *const miiData)
 {
-    writePhyRegister = writeCallback;
+
+    if (g_phyAddress == INVALID_PHY_ADDRESS) 
+        findPhyAddr();
+    
+    return eth_readPhyRegister(g_phyAddress, miiAddress, miiData);
+    
+}
+
+static BOOL writeRegister( const uint32_t miiAddress, const uint16_t miiData)
+{
+
+    if (g_phyAddress == INVALID_PHY_ADDRESS) 
+        findPhyAddr();
+    
+    return eth_writePhyRegister(g_phyAddress, miiAddress, miiData);
+
 }
 
 //--------------------------------------------------------------------------------------------
@@ -109,33 +96,24 @@ void initWritePhyCallback(pWrite writeCallback)
  */
 BOOL eth_phyReset()
 {
-    volatile uint32_t nWait = 0U;
-    
-    // Check callback
-    if (!writePhyRegister)
-    {
-        return FALSE;
-    }
-    
-    // Perform reset
-    if (!writePhyRegister(PHY_CONTROL_REGISTER, PHY_RESET))
-    {
-        return FALSE;
-    }
-    
-    // Wait for completion
-    while (nWait < PHY_RESET_DELAY)
-    {
-        nWait++;
-    }
+    uint32_t nWait = 0U;
+    uint16_t status ;
 
-#if STM32F4_ETH_PHY_RMII
-    // enable RMII
-    return writePhyRegister(PHY_RMII_XCNTL_REGISTER, 0x1000);
-#else
-    return TRUE;
-#endif
+    // Perform reset
+    if (!writeRegister(PHY_CONTROL_REGISTER, PHY_CR_RESET))
+        return FALSE;
     
+    do 
+    {
+        if( !readRegister(PHY_CONTROL_REGISTER, &status) )
+            return FALSE;
+        
+        nWait++;
+    } 
+    while ( (status & (PHY_CR_RESET | PHY_CR_PWRDN)) && (nWait <PHY_RESET_DELAY));
+
+    return TRUE;
+
 }
 
 //--------------------------------------------------------------------------------------------
@@ -149,27 +127,24 @@ BOOL eth_phyReset()
  */
 BOOL eth_isPhyLinkValid(BOOL isCallBlocking)
 {
-    volatile uint32_t nWait = 0U;
+    uint32_t nWait = 0U;
     uint16_t status = 0U;
-
-    // Check callback
-    if (!readPhyRegister)
-    {
-        return FALSE;
-    }
-    
+    BOOL    result = FALSE;
     // Read status register until a valid link is detected or a timeout is elapsed
     do 
     {
-        readPhyRegister(PHY_STATUS_REGISTER, &status);
+        if( !readRegister(PHY_STATUS_REGISTER, &status) )
+            return FALSE;
+
+        if (status & PHY_SR_LINK)
+        { 
+            result = TRUE;
+            break;  // when link is up exit
+        }
         nWait++;
-    } 
-    while ( isCallBlocking &&
-            ((status & PHY_LINK) != PHY_LINK) &&
-            (nWait++ < PHY_LINK_TIMEOUT) );
+    }while ( isCallBlocking && (nWait < PHY_LINK_TIMEOUT) ); 
     
-    // Check the link
-    return (status & PHY_LINK) == PHY_LINK;
+    return result;
 }
 
  
@@ -182,67 +157,104 @@ BOOL eth_isPhyLinkValid(BOOL isCallBlocking)
  */
 EthMode eth_enableAutoNegotiation()
 {
-    volatile uint32_t nWait = 0U;
-    uint16_t status = 0U;
-
+    uint32_t nWait = 0;
+    uint16_t status = 0;
+    uint16_t phyId = 0;
+    
 #if STM32F4_ETH_PHY_MII
-    uint16_t diagnostic = 0U;
+    uint16_t diagnostic = 0;
 #endif
-
-    // Check callback
-    if (!writePhyRegister || !readPhyRegister)
-    {
+    // accomodate both ST802RTIX and KSZ8081 PHY chip
+    // which have mostly identical register sets.
+    if( !readRegister(PHY_IDENTIFIER_REGISTER_1, &phyId) )
         return ETHMODE_FAIL;
+
+    if( phyId == PHY_ST802RT1X_OUI_ID1 )
+    {
+        // For now, hard code to 10MB as auto negotiate to 100MB doesn't seem to work...
+        // (packets received OK, but unable to transmit valid packets)
+        // most devices don't use 100MB at this point so this is OK for basic testing
+        // we are doing - for a full production port this will need to be resolved...
+        // NOTE: rev 1.2 boards use a different PHY where 100MB works
+        if (!readRegister(PHY_RMII_ANEG_ADVERT_REGISTER, &status))
+            return ETHMODE_FAIL;
+
+        status &= ~PHY_RMII_ANEG_ADVERT_SPEED_MASK;
+        status |= PHY_RMII_ANEG_ADVERT_10BASE_T | PHY_RMII_ANEG_ADVERT_10BASE_TF;
+        if (!writeRegister(PHY_RMII_ANEG_ADVERT_REGISTER, status))
+            return ETHMODE_FAIL;
     }
 
-    eth_isPhyResponding();
-
-#if ADVERTISE_10BASET_ONLY
-    // For now, hard code to 10MB as auto negotiate to 100MB doesn't seem to work... (packets received OK, but unable to transmit valid packets)
-    // most devices don't use 100MB at this point so this is OK for basic testing we are doing - for a full 
-    // production port this will need to be resolved...
-    if (!readPhyRegister(PHY_RMII_ANEG_ADVERT_REGISTER, &status))
-        return ETHMODE_FAIL;
-    
-    status &= ~PHY_RMII_ANEG_ADVERT_SPEED_MASK;
-    status |= PHY_RMII_ANEG_ADVERT_10BASE_T | PHY_RMII_ANEG_ADVERT_10BASE_TF;
-    if (!writePhyRegister(PHY_RMII_ANEG_ADVERT_REGISTER, status))
-        return ETHMODE_FAIL;
-#endif
-
-    if (!readPhyRegister(PHY_CONTROL_REGISTER, &status))
+    if (!readRegister(PHY_CONTROL_REGISTER, &status))
         return ETHMODE_FAIL;
 
-    status = (status & ~(PHY_ANEGEN | PHY_ANEG_RESTART)) | PHY_ANEGEN | PHY_ANEG_RESTART;
-    if (!writePhyRegister(PHY_CONTROL_REGISTER, status))
+#if (DEBUG_TRACE)    
+    debug_printf("PHY CR status 0x%x \n",status);
+#endif 
+
+    // Start Auto Negotiation    
+    status = (status & ~(PHY_CR_ANEGEN | PHY_CR_ANEG_RESTART)) | PHY_CR_ANEGEN | PHY_CR_ANEG_RESTART;
+    if (!writeRegister(PHY_CONTROL_REGISTER, status))
         return ETHMODE_FAIL;
     
     // Wait for completion
     do
     {
-        readPhyRegister(PHY_STATUS_REGISTER, &status);
+        if( !readRegister(PHY_STATUS_REGISTER, &status) )
+            status = 0;
+
         nWait++;
     }
-    while ( ((status & PHY_ANEGC) != PHY_ANEGC) &&
-            (nWait++ < PHY_AUTO_NEGOTIATION_TIMEOUT) );
+    while ( (!(status & PHY_SR_ANEGC) ) && (nWait < PHY_AUTO_NEGOTIATION_TIMEOUT) );
     
     // Check auto negotiation completed
-    if ((status & PHY_ANEGC) != PHY_ANEGC)
+    if ((status & PHY_SR_ANEGC) != PHY_SR_ANEGC)
+    {
+        debug_printf("autonegotiate failed. Status: %x\n", status);    
         return ETHMODE_FAIL;
+
+    }
+    
+#if (DEBUG_TRACE)
+    debug_printf("Autonegotiate Complete SR:%x\n", status);
+#endif
 
 #if STM32F4_ETH_PHY_MII
     // Check common technology found
-    readPhyRegister(PHY_DIAGNOSTIC_REGISTER, &diagnostic);
+    readRegister(PHY_DIAGNOSTIC_REGISTER, &diagnostic);
     if ((diagnostic & PHY_ANEGF) == PHY_ANEGF)
         return ETHMODE_FAIL;
 
     // TODO: find specs on the MII PHY to determine negotiated speed
     return ETHMODE_FAIL;
 #else
-    readPhyRegister(PHY_RMII_RXCFG_IIS_REGISTER, &status);
-    return (EthMode)(status & PHY_RMII_RXCFG_IIS_MODEMASK);
+
+    // determine the negotiated speed of PHY chip. 
+    if( PHY_ST802RT1X_OUI_ID1 == phyId )
+    {
+        readRegister(PHY_RMII_RXCFG_IIS_REGISTER, &status);
+        return (EthMode)(status & PHY_RMII_RXCFG_IIS_MODEMASK);
+    }
+    else if( PHY_KENDIN_OUI_ID1 == phyId )
+    {
+        uint16_t speedStatus = 0U;
+
+        readRegister(PHY_CTRL1_REG, &speedStatus);
+
+        // convert speed settings to common form
+        speedStatus =  speedStatus & PHY_CTRL1_MASK;
+        status = 0;
+        if (speedStatus & PHY_KSZ_100TB)
+            status |= ETHMODE_100MPS_BIT;
+        
+        if (speedStatus & PHY_KSZ_FULLDUPLEX) 
+            status |= ETHMODE_FULLDPX_BIT;
+        
+        return (EthMode)status;
+    }
 #endif
-    
+
+    return ETHMODE_FAIL;
 }
 
 //--------------------------------------------------------------------------------------------
@@ -259,32 +271,24 @@ BOOL eth_powerUpPhy(BOOL isPowerUp)
 {
     uint16_t ctrlReg;
 
-    // Check callback
-    if (!writePhyRegister || !readPhyRegister)
-    {
-        return FALSE;
-    }
-    
     // Read the current value of the PHY control register
-    if (!readPhyRegister(PHY_CONTROL_REGISTER, &ctrlReg))
-    {
+    if (!readRegister(PHY_CONTROL_REGISTER, &ctrlReg))
         return FALSE;
-    }
     
     // Update the PWRDN bit
     if (isPowerUp)
     {
         // Power up the PHY
-        ctrlReg &= ~PHY_PWRDN;
+        ctrlReg &= ~PHY_CR_PWRDN;
     }
     else
     {
         // Power down the PHY
-        ctrlReg |= PHY_PWRDN;
+        ctrlReg |= PHY_CR_PWRDN;
     }
     
     // Write the updated PHY control register
-    if (!writePhyRegister(PHY_CONTROL_REGISTER, ctrlReg))
+    if (!writeRegister(PHY_CONTROL_REGISTER, ctrlReg))
     {
         return FALSE;
     }
@@ -301,26 +305,19 @@ BOOL eth_powerUpPhy(BOOL isPowerUp)
  */
 BOOL eth_isPhyResponding(void)
 {
-    volatile uint32_t nWait = 0U;
-    uint16_t status = 0U;
-
-    // Check callback
-    if (!readPhyRegister)
-    {
-        return FALSE;
-    }
-    
     // Read identifier register until OUI can be read or a timeout is elapsed
-    do 
+    for( uint32_t nWait = 0U; nWait < PHY_RESPONSE_TIMEOUT; ++nWait )   
     {
-        readPhyRegister(PHY_IDENTIFIER_REGISTER_1, &status);
-        nWait++;
-    } 
-    while ( (status == PHY_OUI) &&
-            (nWait++ < PHY_RESPONSE_TIMEOUT) );
-    
-    // Check the link
-    return status == PHY_OUI;
+        uint16_t status = 0U;
+
+        if( !readRegister( PHY_IDENTIFIER_REGISTER_1, &status ) )
+            return FALSE;
+        
+        if( ( status == PHY_ST802RT1X_OUI ) || ( status == PHY_KENDIN_OUI ) )
+            return TRUE;
+    }
+
+    return FALSE;
 }
 
 //--------------------------------------------------------------------------------------------

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/STM32F4_ETH_phy.h
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/STM32F4_ETH_phy.h
@@ -40,13 +40,73 @@ extern "C" {
 #include "..\stm32f2xx.h"
 #endif
 
+
+// The first 8 registers are standard for all PHY chips
+// control register
+#define PHY_CONTROL_REGISTER                0U              // Control register
+#define PHY_CR_RESET                        0x8000U         // Reset
+#define PHY_CR_SPEED_SELECT                 0x2000U         
+#define PHY_CR_ANEGEN                       0x1000U         // Auto-negotiation enable 
+#define PHY_CR_PWRDN                        0x0800U         // Power-down
+#define PHY_CR_ISOLATE                      0x0400U
+#define PHY_CR_ANEG_RESTART                 0x0200U 
+#define PHY_CR_DUPLEX_MODE                  0x0100U
+
+// status register
+#define PHY_STATUS_REGISTER                 1U              // Status register
+#define PHY_SR_ANEGC                        0x0020U         // Auto-negotiation complete
+#define PHY_SR_LINK                         0x0004U         // Link status
+
+// ID register
+#define PHY_IDENTIFIER_REGISTER_1           2U              // Identifier register 1
+
+#define PHY_IDENTIFIER_REGISTER_2           3U              // Identifier register 2
+
+
+#define PHY_RMII_ANEG_ADVERT_REGISTER       04U             // Auto negotiation advertisement register
+#define PHY_RMII_ANEG_ADVERT_NEXTPAGE       (1<<15)
+
+#define PHY_RMII_ANEG_ADVERT_100BASE_T4     (1<<9)
+#define PHY_RMII_ANEG_ADVERT_100BASE_TXF    (1<<8)
+#define PHY_RMII_ANEG_ADVERT_100BASE_TX     (1<<7)
+#define PHY_RMII_ANEG_ADVERT_10BASE_TF      (1<<6)
+#define PHY_RMII_ANEG_ADVERT_10BASE_T       (1<<5)
+
+#define PHY_RMII_ANEG_ADVERT_SPEED_MASK     ( PHY_RMII_ANEG_ADVERT_100BASE_T4 | PHY_RMII_ANEG_ADVERT_100BASE_TXF | PHY_RMII_ANEG_ADVERT_100BASE_TX | PHY_RMII_ANEG_ADVERT_10BASE_TF | PHY_RMII_ANEG_ADVERT_10BASE_T)
+
+#define PHY_AUTO_NEGOTIATION_TIMEOUT        0x00100000U     // Auto negotiation timeout
+#define PHY_ST802RT1X_OUI               0x80E1U         // ST802RT1x PHY unique identifier
+#define PHY_ST802RT1X_OUI_ID1           0x0203U         // the value directly read out from ID1
+
+#define PHY_RMII_XCNTL_REGISTER         16U
+#define PHY_RMII_RXCFG_IIS_REGISTER     17U             // Receive Configuration and Interrupt Status Register
+#define PHY_DIAGNOSTIC_REGISTER         18U             // Diagnostic register
+#define PHY_ANEGF                       0x1000U         // Auto-negotiation fail indication
+#define PHY_RMII_RXCFG_IIS_MODEMASK     (3<<8)          // Speed bit (bit 9 = speed; bit 8 == Duplex )
+
+
+#define PHY_LINK_TIMEOUT                0x0004FFFFU     // PHY link timeout
+#define PHY_RESET_DELAY                 0x000FFFFFU     // PHY reset delay
+#define PHY_RESPONSE_TIMEOUT            0x0004FFFFU     // PHY response timeout
+#define PHY_TERIDIAN_OUI                0x000EU         // Teridian unique identifier
+// for KSZ8081RNB
+#define PHY_KENDIN_OUI                  0x10A1U
+#define PHY_KENDIN_OUI_ID1              0x0022U
+
+#define PHY_CTRL1_MASK                  0x07
+#define PHY_CTRL1_REG                   0x1E
+
+#define PHY_KSZ_100TB 0x2
+#define PHY_KSZ_FULLDUPLEX 0x4
+#define ETHMODE_100MPS_BIT 0x0200
+#define ETHMODE_FULLDPX_BIT 0x0100
 enum EthMode
 {
     ETHMODE_FAIL = 0xFFFF,
-    ETHMODE_10MBPS_HDPX = 0x0000,
-    ETHMODE_10MBPS_FDPX = 0x0100,
-    ETHMODE_100MBPS_HDPX = 0x0200,
-    ETHMODE_100MBPS_FDPX = 0x0300,
+    ETHMODE_10MBPS_HDPX  = 0,
+    ETHMODE_10MBPS_FDPX  = ETHMODE_FULLDPX_BIT,
+    ETHMODE_100MBPS_HDPX = ETHMODE_100MPS_BIT,
+    ETHMODE_100MBPS_FDPX = ETHMODE_100MPS_BIT | ETHMODE_FULLDPX_BIT,
 };
 
 //--------------------------------------------------------------------------------------------

--- a/Solutions/MCBSTM32F400/netmfdbg/netmfdbg.uvoptx
+++ b/Solutions/MCBSTM32F400/netmfdbg/netmfdbg.uvoptx
@@ -75,7 +75,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>1</IsCurrentTarget>
+        <IsCurrentTarget>0</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <Books>
@@ -157,7 +157,7 @@
         <tDllPa></tDllPa>
         <tDlgDll></tDlgDll>
         <tDlgPa></tDlgPa>
-        <tIfile></tIfile>
+        <tIfile>.\STM32_SWO.ini</tIfile>
         <pMon>BIN\ULP2CM3.DLL</pMon>
       </DebugOpt>
       <TargetDriverDllRegistry>
@@ -184,7 +184,7 @@
         <SetRegEntry>
           <Number>0</Number>
           <Key>ULP2CM3</Key>
-          <Name>-UP1209218 -O2255 -S14 -C0 -P00 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO19 -TC168000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIEFFFFFFFF -TIP8 -FO23 -FD20000000 -FC1000 -FN2 -FF0STM32F4xx_1024.FLM -FS08000000 -FL0100000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM) -FF1M29W640FB -FS160000000 -FL1800000</Name>
+          <Name>-UP1209218 -O2255 -S14 -C0 -P00 -N00("ARM CoreSight SW-DP") -D00(2BA01477) -L00(0) -TO19 -TC168000000 -TP18 -TDX0 -TDD0 -TDS8000 -TDT0 -TDC1F -TIE80000001 -TIP9 -FO23 -FD20000000 -FC1000 -FN2 -FF0STM32F4xx_1024.FLM -FS08000000 -FL0100000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM) -FF1M29W640FB -FS160000000 -FL1800000</Name>
         </SetRegEntry>
         <SetRegEntry>
           <Number>0</Number>
@@ -198,7 +198,7 @@
           <Type>0</Type>
           <LineNumber>203</LineNumber>
           <EnabledFlag>1</EnabledFlag>
-          <Address>134235266</Address>
+          <Address>134235254</Address>
           <ByteObject>0</ByteObject>
           <HtxType>0</HtxType>
           <ManyObjects>0</ManyObjects>
@@ -306,7 +306,7 @@
       <OPTFL>
         <tvExp>1</tvExp>
         <tvExpOptDlg>0</tvExpOptDlg>
-        <IsCurrentTarget>0</IsCurrentTarget>
+        <IsCurrentTarget>1</IsCurrentTarget>
       </OPTFL>
       <CpuCode>18</CpuCode>
       <Books>
@@ -423,24 +423,7 @@
           <Name>UL2CM3(-S0 -C0 -P0 -FD20000000 -FC1000 -FN1 -FF0STM32F4xx_1024 -FS08000000 -FL0100000 -FP0($$Device:STM32F407IGHx$CMSIS\Flash\STM32F4xx_1024.FLM))</Name>
         </SetRegEntry>
       </TargetDriverDllRegistry>
-      <Breakpoint>
-        <Bp>
-          <Number>0</Number>
-          <Type>0</Type>
-          <LineNumber>203</LineNumber>
-          <EnabledFlag>1</EnabledFlag>
-          <Address>0</Address>
-          <ByteObject>0</ByteObject>
-          <HtxType>0</HtxType>
-          <ManyObjects>0</ManyObjects>
-          <SizeOfObject>0</SizeOfObject>
-          <BreakByAccess>0</BreakByAccess>
-          <BreakIfRCount>0</BreakIfRCount>
-          <Filename>S:\GitHub\smaillet-ms\netmf-interpreter\Solutions\MCBSTM32F400\TinyBooter\TinyBooterEntry.cpp</Filename>
-          <ExecCommand></ExecCommand>
-          <Expression></Expression>
-        </Bp>
-      </Breakpoint>
+      <Breakpoint/>
       <MemoryWindow1>
         <Mm>
           <WinNumber>1</WinNumber>

--- a/Solutions/MCBSTM32F400/netmfdbg/netmfdbg.uvprojx
+++ b/Solutions/MCBSTM32F400/netmfdbg/netmfdbg.uvprojx
@@ -160,7 +160,7 @@
             <CpuDllArguments></CpuDllArguments>
             <PeripheralDll></PeripheralDll>
             <PeripheralDllArguments></PeripheralDllArguments>
-            <InitializationFile></InitializationFile>
+            <InitializationFile>.\STM32_SWO.ini</InitializationFile>
             <Driver>BIN\ULP2CM3.DLL</Driver>
           </TargetDlls>
         </DebugOption>


### PR DESCRIPTION
Fix for issue #13 
Updated Ethernet driver to support the new PHY used on MCBSTM32F400 v1.2 boards This now supports both revisions of the board.