### PR TITLE
Fix warning in Configuration

### DIFF
--- a/DeviceCode/pal/configuration/ConfigHelper.cpp
+++ b/DeviceCode/pal/configuration/ConfigHelper.cpp
@@ -15,7 +15,9 @@
 #undef  DEBUG_TRACE
 #define DEBUG_TRACE (TRACE_ALWAYS)
 
+#ifndef HAL_REDUCESIZE
 const size_t ConfigLengthCookie = offsetof( ConfigurationSector, FirstConfigBlock );
+#endif
 
 BOOL HAL_CONFIG_BLOCK::IsGoodBlock() const
 {


### PR DESCRIPTION
Fixing the following warning:

 "...\DeviceCode\PAL\Configuration\ConfigHelper.cpp", line 18: Warning:  #177 -D: variable "ConfigLengthCookie" was declared but never referenced
   const size_t ConfigLengthCookie = offsetof( ConfigurationSector, FirstConfigBlock );
                