### PR TITLE
Fix whitespace issues in CLR and TinyBooter.

### DIFF
--- a/Application/TinyBooter/Commands.h
+++ b/Application/TinyBooter/Commands.h
@@ -78,9 +78,9 @@ struct Loader_Engine
         UINT32 m_dataAddress;
         UINT32 m_dataLength;
         UINT32 m_sectorType;
-		BlockStorageDevice *m_pDevice ;		
-		
-    public:                
+        BlockStorageDevice *m_pDevice ;
+
+    public:
         bool CheckDirty          (                                 );
         void Reset               (                                 );
         void EraseMemoryAndReset (                                 );

--- a/CLR/Core/CLR_RT_HeapBlock_Array.cpp
+++ b/CLR/Core/CLR_RT_HeapBlock_Array.cpp
@@ -213,25 +213,25 @@ HRESULT CLR_RT_HeapBlock_Array::IndexOf( CLR_RT_HeapBlock_Array* array, CLR_RT_H
                         TINYCLR_SET_AND_LEAVE(S_OK);
                     }
 #else
-					CLR_UINT64 refNum;
+                    CLR_UINT64 refNum;
 
                     switch(sizeElem)
-					{
-					case 1:
-						refNum = matchPtr->NumericByRef().u1;
-						break;
-					case 2:
-						refNum = matchPtr->NumericByRef().u2;
-						break;
-					case 4:
-						refNum = matchPtr->NumericByRef().u4;
-						break;
-					case 8:
-						refNum = matchPtr->NumericByRef().u8;
-						break;
-					}
-					if(memcmp( data, &refNum, sizeElem ) == 0)
-					{
+                    {
+                    case 1:
+                        refNum = matchPtr->NumericByRef().u1;
+                        break;
+                    case 2:
+                        refNum = matchPtr->NumericByRef().u2;
+                        break;
+                    case 4:
+                        refNum = matchPtr->NumericByRef().u4;
+                        break;
+                    case 8:
+                        refNum = matchPtr->NumericByRef().u8;
+                        break;
+                    }
+                    if(memcmp( data, &refNum, sizeElem ) == 0)
+                    {
                         index = pos;
                         TINYCLR_SET_AND_LEAVE(S_OK);
                     }

--- a/CLR/Core/Execution.cpp
+++ b/CLR/Core/Execution.cpp
@@ -3078,10 +3078,10 @@ void CLR_RT_ExecutionEngine::StopOnBreakpoint( CLR_DBG_Commands::Debugging_Execu
                 CLR_Messaging::SwapEndianPattern( data, sizeof(UINT32), 8 ); //all other fields
 
                 CLR_EE_DBG_EVENT_SEND(CLR_DBG_Commands::c_Debugging_Execution_BreakpointHit,sizeof(s_breakpoint),&s_breakpoint,WP_Flags::c_NonCritical);
-#else	
+#else
                 CLR_EE_DBG_EVENT_SEND(CLR_DBG_Commands::c_Debugging_Execution_BreakpointHit,sizeof(CLR_DBG_Commands::Debugging_Execution_BreakpointDef),&m_breakpointsActive[ 0 ],WP_Flags::c_NonCritical);
 #endif
-            }            
+            }
         }
         else
         {

--- a/CLR/Core/FileStore_Win32.cpp
+++ b/CLR/Core/FileStore_Win32.cpp
@@ -118,8 +118,8 @@ void CLR_RT_FileStore::ExtractTokens( const CLR_RT_Buffer& buf, CLR_RT_StringVec
     LPCWSTR      src;
     size_t       len;
 
-	if (buf.size() == 0) { return; }
-	else if(buf.size() >= 2 && buf[ 0 ] == 0xFF && buf[ 1 ] == 0xFE)
+    if (buf.size() == 0) { return; }
+    else if(buf.size() >= 2 && buf[ 0 ] == 0xFF && buf[ 1 ] == 0xFE)
     {
         len = (buf.size() - 2) / sizeof(WCHAR);
 

--- a/CLR/Core/I2C/CLR_RT_HeapBlock_I2CXAction.cpp
+++ b/CLR/Core/I2C/CLR_RT_HeapBlock_I2CXAction.cpp
@@ -11,7 +11,7 @@ CLR_RT_DblLinkedList CLR_RT_HeapBlock_I2CXAction::m_i2cPorts; //FIX ME -change l
 void CLR_RT_HeapBlock_I2CXAction::HandlerMethod_Initialize()
 {
     NATIVE_PROFILE_CLR_I2C();
-	CLR_RT_HeapBlock_I2CXAction::m_i2cPorts.DblLinkedList_Initialize();
+    CLR_RT_HeapBlock_I2CXAction::m_i2cPorts.DblLinkedList_Initialize();
 }
 
 void CLR_RT_HeapBlock_I2CXAction::HandlerMethod_RecoverFromGC()
@@ -27,7 +27,7 @@ void CLR_RT_HeapBlock_I2CXAction::HandlerMethod_RecoverFromGC()
 void CLR_RT_HeapBlock_I2CXAction::HandlerMethod_CleanUp()
 {
     NATIVE_PROFILE_CLR_I2C();
-	 CLR_RT_HeapBlock_I2CXAction* i2cPort;
+     CLR_RT_HeapBlock_I2CXAction* i2cPort;
 
         while(NULL != (i2cPort = (CLR_RT_HeapBlock_I2CXAction*)CLR_RT_HeapBlock_I2CXAction::m_i2cPorts.FirstValidNode()))
         {

--- a/CLR/Core/RPC/CLR_RT_HeapBlock_EndPoint.cpp
+++ b/CLR/Core/RPC/CLR_RT_HeapBlock_EndPoint.cpp
@@ -11,7 +11,7 @@ CLR_RT_DblLinkedList CLR_RT_HeapBlock_EndPoint::m_endPoints;
 
 void CLR_RT_HeapBlock_EndPoint::HandlerMethod_Initialize()
 {
-	CLR_RT_HeapBlock_EndPoint::m_endPoints.DblLinkedList_Initialize();
+    CLR_RT_HeapBlock_EndPoint::m_endPoints.DblLinkedList_Initialize();
 }
 
 void CLR_RT_HeapBlock_EndPoint::HandlerMethod_RecoverFromGC()
@@ -31,7 +31,7 @@ CLR_RT_HeapBlock_EndPoint* CLR_RT_HeapBlock_EndPoint::FindEndPoint( const CLR_RT
 {
     TINYCLR_FOREACH_NODE(CLR_RT_HeapBlock_EndPoint,endPoint,CLR_RT_HeapBlock_EndPoint::m_endPoints)
     {
-		if((endPoint->m_addr.m_type == port.m_type) && (endPoint->m_addr.m_id == port.m_id)) return endPoint; //eliminate the need for another func. call; member variables are public
+        if((endPoint->m_addr.m_type == port.m_type) && (endPoint->m_addr.m_id == port.m_id)) return endPoint; //eliminate the need for another func. call; member variables are public
     }
     TINYCLR_FOREACH_NODE_END();
 

--- a/CLR/Core/Various.cpp
+++ b/CLR/Core/Various.cpp
@@ -9,10 +9,10 @@
 void CLR_RT_GetVersion( UINT16* pMajor, UINT16* pMinor, UINT16* pBuild, UINT16* pRevision )
 {
     NATIVE_PROFILE_CLR_CORE();
-	if (pMajor) *pMajor = VERSION_MAJOR;
-	if (pMinor) *pMinor = VERSION_MINOR;
-	if (pBuild) *pBuild = VERSION_BUILD;
-	if (pRevision) *pRevision = VERSION_REVISION;
+    if (pMajor) *pMajor = VERSION_MAJOR;
+    if (pMinor) *pMinor = VERSION_MINOR;
+    if (pBuild) *pBuild = VERSION_BUILD;
+    if (pRevision) *pRevision = VERSION_REVISION;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/CLR/Diagnostics/Profiler.cpp
+++ b/CLR/Diagnostics/Profiler.cpp
@@ -18,7 +18,7 @@ HRESULT CLR_PRF_Profiler::CreateInstance()
     g_CLR_PRF_Profiler.m_lastTimestamp = (CLR_UINT32)((CLR_UINT64)(Time_GetMachineTime() + ((1ull << CLR_PRF_CMDS::Bits::TimestampShift) - 1))
         >> CLR_PRF_CMDS::Bits::TimestampShift);
     g_CLR_PRF_Profiler.m_currentAssembly = 0;
-	g_CLR_PRF_Profiler.m_currentThreadPID = 0;
+    g_CLR_PRF_Profiler.m_currentThreadPID = 0;
     TINYCLR_CHECK_HRESULT(CLR_RT_HeapBlock_MemoryStream::CreateInstance(g_CLR_PRF_Profiler.m_stream, NULL, 0));
     
     TINYCLR_NOCLEANUP();
@@ -563,7 +563,7 @@ HRESULT CLR_PRF_Profiler::RecordFunctionCall(CLR_RT_Thread* th, CLR_RT_MethodDef
             TINYCLR_CHECK_HRESULT(RecordContextSwitch( th ));
         }
         else
-        {			        
+        {
             Timestamp();
         }
 
@@ -603,7 +603,7 @@ HRESULT CLR_PRF_Profiler::RecordFunctionReturn(CLR_RT_Thread* th, CLR_PROF_Count
             TINYCLR_CHECK_HRESULT(RecordContextSwitch( th ));
         }
         else
-        {			        
+        {
             Timestamp();
         }
 

--- a/CLR/Graphics/Gif/lzw.h
+++ b/CLR/Graphics/Gif/lzw.h
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) Microsoft Corporation.  All rights reserved.
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////#ifndef _LZW_H_
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 #ifndef _LZW_H_
 
 #define _LZW_H_
@@ -14,63 +14,63 @@
 #define __int8  char
 
 /*****************************************************************************
-	A class which holds the information which is shared between LZW (GIF)
-	compression and decompression.
+    A class which holds the information which is shared between LZW (GIF)
+    compression and decompression.
 ******************************************************************* JohnBo **/
 struct LZW
-	{
-protected:
-	inline void LZWInit(unsigned int bcodeSize)
     {
-		m_bcodeSize = LZW_B8(bcodeSize);
-		
-		LZW_ASSERT(bcodeSize >= 2 && bcodeSize <= 8);
-	}
-	
-	/* METHODS */
-	/* Standard GIF definitions. */
-	inline unsigned __int16 WClear(void) const
-		{
-		return LZW_B16(1U<<m_bcodeSize);
-		}
-	inline unsigned __int16 WEOD(void) const
-		{
-		return LZW_B16(1U+(1U<<m_bcodeSize));
-		}
+protected:
+    inline void LZWInit(unsigned int bcodeSize)
+    {
+        m_bcodeSize = LZW_B8(bcodeSize);
+        
+        LZW_ASSERT(bcodeSize >= 2 && bcodeSize <= 8);
+    }
+    
+    /* METHODS */
+    /* Standard GIF definitions. */
+    inline unsigned __int16 WClear(void) const
+        {
+        return LZW_B16(1U<<m_bcodeSize);
+        }
+    inline unsigned __int16 WEOD(void) const
+        {
+        return LZW_B16(1U+(1U<<m_bcodeSize));
+        }
 
-	/* DATA TYPES */
-	/* Basic types. */
-	typedef unsigned __int32 TokenValue;
-	typedef unsigned __int16 TokenIndex;
+    /* DATA TYPES */
+    /* Basic types. */
+    typedef unsigned __int32 TokenValue;
+    typedef unsigned __int16 TokenIndex;
 
-	/* Constants. */
-	enum
-		{
-		ctokenBits = 12,
-		ctokens = (1U<<ctokenBits),
-		};
+    /* Constants. */
+    enum
+        {
+        ctokenBits = 12,
+        ctokens = (1U<<ctokenBits),
+        };
 
-	/* DATA */
-	unsigned char  m_bcodeSize;    // The LZW initial code size
-	};
+    /* DATA */
+    unsigned char  m_bcodeSize;    // The LZW initial code size
+    };
 
 
 /*****************************************************************************
-	A class which also holds the current token size.
+    A class which also holds the current token size.
 ******************************************************************* JohnBo **/
 struct LZWState : protected LZW
-	{
-protected:
-	inline void LZWStateInit(unsigned int bcodeSize)
     {
-		m_ibitsToken = LZW_B8(bcodeSize+1);
-		m_itokenLast = WEOD();
+protected:
+    inline void LZWStateInit(unsigned int bcodeSize)
+    {
+        m_ibitsToken = LZW_B8(bcodeSize+1);
+        m_itokenLast = WEOD();
 
         LZWInit(bcodeSize);
     }
 
-	unsigned char  m_ibitsToken; // The (current) number of bits in a token
-	TokenIndex       m_itokenLast; // The last token to be allocated
-	};
+    unsigned char  m_ibitsToken; // The (current) number of bits in a token
+    TokenIndex       m_itokenLast; // The last token to be allocated
+    };
 
 #endif

--- a/CLR/Include/TinyCLR_Interop.h
+++ b/CLR/Include/TinyCLR_Interop.h
@@ -50,21 +50,21 @@ extern HRESULT TINYCLR_DEBUG_PROCESS_EXCEPTION( HRESULT hr, LPCSTR szFunc, LPCST
 
 
 //    Correspondence between CLR C# and C++ native types:
-//    CLR Type	        C/C++ type	    C/C++ Ref Type
+//    CLR Type          C/C++ type	    C/C++ Ref Type
 
-//    System.Byte	    UINT8 	        UINT8&
-//    System.UInt16	    UINT16	        UINT16&
-//    System.UInt32	    UINT32	        UINT32&
-//    System.UInt64	    UINT64	        UINT64&
-//    System.Char	    CHAR 	        CHAR &
-//    System.SByte	    INT8 	        INT8 &
-//    System.Int16	    INT16	        INT16&
-//    System.Int32	    INT32	        INT32&
-//    System.Int64	    INT64	        INT64&
-//    System.Single	    float	        float&
-//    System.Double	    double	        double&
-//    System.String	    const CHAR *	CHAR *
-//    System.Byte[]	    UINT8 *	        Same as C/C++ type
+//    System.Byte       UINT8           UINT8&
+//    System.UInt16     UINT16          UINT16&
+//    System.UInt32     UINT32          UINT32&
+//    System.UInt64     UINT64          UINT64&
+//    System.Char       CHAR            CHAR &
+//    System.SByte      INT8            INT8 &
+//    System.Int16      INT16           INT16&
+//    System.Int32      INT32           INT32&
+//    System.Int64      INT64           INT64&
+//    System.Single     float           float&
+//    System.Double     double          double&
+//    System.String     const CHAR *    CHAR *
+//    System.Byte[]     UINT8 *         Same as C/C++ type
 
 // Forward declaration for managed stack frame.
 // This is internal CLR type, reference to managed stack frame is exposed to marshaling code.

--- a/CLR/Include/TinyCLR_Profiling.h
+++ b/CLR/Include/TinyCLR_Profiling.h
@@ -20,22 +20,22 @@ pointer  = 32BIT
 datatype = 8BIT
 typedef-idx = 32BIT
 method-idx  = 32BIT
-	TinyCLR Method_Idx value for identifying a specific function
+    TinyCLR Method_Idx value for identifying a specific function
 
 stream-packet = sequence-id length stream-payload
-	A chunk of data sent out over the WireProtocol.
+    A chunk of data sent out over the WireProtocol.
 
 sequence-id = short
-	Number used to order the packets
+    Number used to order the packets
 
 length = short
-	Number in bits in stream-payload
+    Number in bits in stream-payload
 
 stream-payload = *profiler-packet
-	Payload is a sequence of profiler packets.
+    Payload is a sequence of profiler packets.
 
 profiling-stream = *stream-payload
-	The reconstructed stream of data to be processed.
+    The reconstructed stream of data to be processed.
 
 profiler-packet = timestamp-packet / memory-layout-packet heapdump-start-packet / heapdump-root-packet /
                   heapdump-object-packet / heapdump-stop-packet
@@ -43,22 +43,22 @@ profiler-packet = timestamp-packet / memory-layout-packet heapdump-start-packet 
 timestamp-header = "0000001"
 timestamp-time = long
 timestamp-packet = timestamp-header timestamp-time
-	Marks time intervals to allow object lifetime estimates and histograms
+    Marks time intervals to allow object lifetime estimates and histograms
 
 memory-layout-packet = memory-layout-header memory-layout-heap-address memory-layout-heap-length
 memory-layout-header = "00000010"
 memory-layout-heap-address = pointer
 memory-layout-heap-length = int
-	Contains heap layout information useful for showing memory usage statistics.
+    Contains heap layout information useful for showing memory usage statistics.
 
 heapdump = heapdump-start-packet *heapdump-root-packet *heapdump-object-packet heapdump-stop-packet
-	Heapdumps always occur in this form. All roots are listed before all objects, and both roots and objects fall between
+    Heapdumps always occur in this form. All roots are listed before all objects, and both roots and objects fall between
     a pair of 'start' and 'stop' packets. Heap dumps may be split up across stream-payload boundaries, but they may not be
     nested, and packets may not be sent in any other order.
 
 heapdump-start-header = "00000011"
 heapdump-start-packet = heapdump-start-header
-	Marks the beginning of a heap dump. Multiple <heapdump-start-packets> can exist in the same profiling-stream
+    Marks the beginning of a heap dump. Multiple <heapdump-start-packets> can exist in the same profiling-stream
     if and only if there is a heapdump-stop-packet between every pair of heapdump-start-packets.
 
 heapdump-root-packet = heapdump-root-header ( heapdump-root-stack / heapdump-root-other )
@@ -77,7 +77,7 @@ heapdump-object-packet = heapdump-object-header  heapdump-object-type heapdump-o
 heapdump-object-header = heapdump-object-address heapdump-object-size
 heapdump-object-address = pointer
 heapdump-object-size = short
-	Size is the number of HeapBlock chunks used, not the number of bytes used.
+    Size is the number of HeapBlock chunks used, not the number of bytes used.
 
 heapdump-object-type = heapdump-object-classvaluetype / heapdump-object-array / heapdump-object-other
 
@@ -89,11 +89,11 @@ heapdump-object-array = heapdump-object-array-header heapdump-object-array-datat
 heapdump-object-array-header = "00010011"
 heapdump-object-array-typedef = typedef-idx
 heapdump-object-array-levels = short
-	Rank of the array
+    Rank of the array
 
 heapdump-object-special-cases = heapdump-object-classvaluetype-header / heapdump-object-array-header
 heapdump-object-other = datatype
-	datatype must not be one of <heapdump-object-special-cases>; If it is, the appropriate special case should be used instead.
+    datatype must not be one of <heapdump-object-special-cases>; If it is, the appropriate special case should be used instead.
 
 heapdump-object-references = *heapdump-object-reference heapdump-object-end-of-references
 heapdump-object-reference = "1" pointer
@@ -105,7 +105,7 @@ heapdump-stop-packet = heapdump-stop-header heapdump-stop-blocks-used
 
 heapdump-stop-header = "00000110"
 heapdump-stop-blocks-used = int
-	Reports how many heap-blocks were used by objects, including objects that might have been filtered out from reporting.
+    Reports how many heap-blocks were used by objects, including objects that might have been filtered out from reporting.
 
  */
 

--- a/CLR/Include/TinyCLR_Runtime.h
+++ b/CLR/Include/TinyCLR_Runtime.h
@@ -2868,7 +2868,7 @@ struct CLR_RT_ExecutionEngine
     {   EXECUTION_COUNTER_MAXIMUM    = 0x70000000, // Threshold value when we increase all execution counters to avoid overflow
         EXECUTION_COUNTER_ADJUSTMENT = 0x60000000  // The update ( increase ) value for all executioin counters after threshold is reached.
     };
-	////////////////////////////////////////////////////////////////////////////////////////////////
+    ////////////////////////////////////////////////////////////////////////////////////////////////
 
 #if defined(TINYCLR_ENABLE_SOURCELEVELDEBUGGING)
     static const int                    c_MaxBreakpointsActive               = 5;
@@ -2982,7 +2982,7 @@ struct CLR_RT_ExecutionEngine
     
     CLR_INT64                           m_currentMachineTime;
     CLR_INT64                           m_currentLocalTime;
-	CLR_INT64                           m_startTime;  
+    CLR_INT64                           m_startTime;  
     CLR_INT32                           m_lastTimeZoneOffset;
     CLR_INT64                           m_currentNextActivityTime;
     bool                                m_timerCache;

--- a/CLR/Libraries/CorLib/corlib_native_System_Threading_Thread.cpp
+++ b/CLR/Libraries/CorLib/corlib_native_System_Threading_Thread.cpp
@@ -403,7 +403,7 @@ HRESULT Library_corlib_native_System_Threading_Thread::get_CurrentThread___STATI
     CLR_RT_HeapBlock* pRes;
 
 #if defined(TINYCLR_ENABLE_SOURCELEVELDEBUGGING)
-	//If we are a thread spawned by the debugger to perform evaluations,
+    //If we are a thread spawned by the debugger to perform evaluations,
     //return the thread object that correspond to thread that has focus in debugger.
     thread = thread->m_realThread;
 #endif //#if defined(TINYCLR_ENABLE_SOURCELEVELDEBUGGING)
@@ -540,7 +540,7 @@ HRESULT Library_corlib_native_System_Threading_Thread::Join( CLR_RT_StackFrame& 
 
     TINYCLR_CHECK_HRESULT(GetThread( stack, th, true, false ));
 
-	//Don't let programs join from system threads like interrupts or finalizers
+    //Don't let programs join from system threads like interrupts or finalizers
     if ( stack.m_owningThread->m_flags & CLR_RT_Thread::TH_F_System )
     {
         TINYCLR_SET_AND_LEAVE(CLR_E_INVALID_OPERATION);

--- a/CLR/Libraries/SPOT_Graphics/spot_graphics_native_Microsoft_SPOT_Bitmap.cpp
+++ b/CLR/Libraries/SPOT_Graphics/spot_graphics_native_Microsoft_SPOT_Bitmap.cpp
@@ -733,11 +733,12 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::TileImage___VOID__I4
 
     if (bitmap != bitmapSrc)
     {
-	int xDst = pArgs[0].NumericByRef().s4;
-	int yDst = pArgs[1].NumericByRef().s4;
-	int widthDst = pArgs[3].NumericByRef().s4;
-	int heightDst = pArgs[4].NumericByRef().s4;
-	unsigned short opacity = pArgs[5].NumericByRef().u2;
+        int xDst = pArgs[0].NumericByRef().s4;
+        int yDst = pArgs[1].NumericByRef().s4;
+        int widthDst = pArgs[3].NumericByRef().s4;
+        int heightDst = pArgs[4].NumericByRef().s4;
+        unsigned short opacity = pArgs[5].NumericByRef().u2;
+
         int widthSrc  = bitmapSrc->m_bm.m_width;
         int heightSrc = bitmapSrc->m_bm.m_height;
         int x, y, w, h;
@@ -766,7 +767,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::TileImage___VOID__I4
                 dst.right  = dst.left + w - 1;
                 dst.bottom = dst.top + h - 1;
 
-     	        bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
             }
         }
     } 
@@ -793,20 +794,22 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
 
     if (bitmap != bitmapSrc)
     {
-	int xDst = pArgs[0].NumericByRef().s4;
-	int yDst = pArgs[1].NumericByRef().s4;
-	int widthDst = pArgs[2].NumericByRef().s4;
-	int heightDst = pArgs[3].NumericByRef().s4;
-	int leftBorder = pArgs[5].NumericByRef().s4;
-	int topBorder = pArgs[6].NumericByRef().s4;
-	int rightBorder = pArgs[7].NumericByRef().s4;
-	int bottomBorder = pArgs[8].NumericByRef().s4;
-	unsigned short opacity = pArgs[9].NumericByRef().u2;
+    int xDst = pArgs[0].NumericByRef().s4;
+    int yDst = pArgs[1].NumericByRef().s4;
+    int widthDst = pArgs[2].NumericByRef().s4;
+
+    int heightDst = pArgs[3].NumericByRef().s4;
+    int leftBorder = pArgs[5].NumericByRef().s4;
+    int topBorder = pArgs[6].NumericByRef().s4;
+    int rightBorder = pArgs[7].NumericByRef().s4;
+    int bottomBorder = pArgs[8].NumericByRef().s4;
+    unsigned short opacity = pArgs[9].NumericByRef().u2;
+
         int widthSrc  = bitmapSrc->m_bm.m_width;
         int heightSrc = bitmapSrc->m_bm.m_height;
  
         if (widthDst >= leftBorder && heightDst >= topBorder)
-	{
+    {
             int centerWidthSrc = widthSrc - (leftBorder + rightBorder);
             int centerHeightSrc = heightSrc - (topBorder + bottomBorder);
             int centerWidthDst = widthDst - (leftBorder + rightBorder);
@@ -824,7 +827,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = 0;
                     src.right  = src.left + leftBorder - 1;
                     src.bottom = src.top + topBorder - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst, yDst, leftBorder, topBorder, bitmap, 0, 0, leftBorder, topBorder, opacity);
             
             //top-right
@@ -838,7 +841,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = 0;
                     src.right  = src.left + rightBorder - 1;
                     src.bottom = src.top + topBorder - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst + widthDst - rightBorder, yDst, rightBorder, topBorder, bitmap,
                     //                     widthSrc - rightBorder, 0, rightBorder, topBorder, opacity);
             }
@@ -853,7 +856,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = heightSrc - bottomBorder;
                     src.right  = src.left + leftBorder - 1;
                     src.bottom = src.top + bottomBorder - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst, yDst + heightDst - bottomBorder, leftBorder, bottomBorder, bitmap,
                     //                     0, heightSrc - bottomBorder, leftBorder, bottomBorder, opacity);
             }
@@ -868,7 +871,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = heightSrc - bottomBorder;
                     src.right  = src.left + rightBorder - 1;
                     src.bottom = src.top + bottomBorder - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst + widthDst - rightBorder, yDst + heightDst - bottomBorder, rightBorder, bottomBorder, bitmap,
                     //                     widthSrc - rightBorder, heightSrc - bottomBorder, rightBorder, bottomBorder, opacity);
             }
@@ -883,7 +886,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = topBorder;
                     src.right  = src.left + leftBorder - 1;
                     src.bottom = src.top + centerHeightSrc - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst, yDst + topBorder, leftBorder, centerHeightDst, bitmap,
                     //                     0, topBorder, leftBorder, centerHeightSrc, opacity);
             }
@@ -898,7 +901,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = 0;
                     src.right  = src.left + centerWidthSrc - 1;
                     src.bottom = src.top + topBorder - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst + leftBorder, yDst, centerWidthDst, topBorder, bitmap,
                     //                     leftBorder, 0, centerWidthSrc, topBorder, opacity);
             }
@@ -915,7 +918,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = topBorder;
                     src.right  = src.left + rightBorder - 1;
                     src.bottom = src.top + centerHeightSrc - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst + widthDst - rightBorder, yDst + topBorder, rightBorder, centerHeightDst, bitmap,
                     //                     widthSrc - rightBorder, topBorder, rightBorder,  centerHeightSrc, opacity);
             }
@@ -930,7 +933,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = heightSrc - bottomBorder;
                     src.right  = src.left + centerWidthSrc - 1;
                     src.bottom = src.top + bottomBorder - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst + leftBorder, yDst + heightDst - bottomBorder, centerWidthDst, bottomBorder, bitmap,
                     //                 leftBorder, heightSrc - bottomBorder, centerWidthSrc, bottomBorder, opacity);
             }
@@ -945,7 +948,7 @@ HRESULT Library_spot_graphics_native_Microsoft_SPOT_Bitmap::Scale9Image___VOID__
                     src.top    = topBorder;
                     src.right  = src.left + centerWidthSrc - 1;
                     src.bottom = src.top + centerHeightSrc - 1;
-     	            bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
+                    bitmap->DrawImage( dst, *bitmapSrc, src, opacity );
                     //bmpDest.StretchImage(xDst + leftBorder, yDst + topBorder, centerWidthDst, centerHeightDst, bitmap,
                     //                     leftBorder, topBorder, centerWidthSrc, centerHeightSrc, opacity);
             }

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire.cpp
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire.cpp
@@ -11,47 +11,47 @@ using namespace Microsoft::SPOT::Hardware;
 INT32 OneWire::TouchReset( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
- 	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owTouchReset(pin);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owTouchReset(pin);
   return retVal;
 }
 
 INT32 OneWire::TouchBit( CLR_RT_HeapBlock* pMngObj, INT32 param0, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owTouchBit(pin, param0);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owTouchBit(pin, param0);
   return retVal;
 }
 
 INT32 OneWire::TouchByte( CLR_RT_HeapBlock* pMngObj, INT32 param0, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owTouchByte(pin, param0);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owTouchByte(pin, param0);
   return retVal;
 }
 
 INT32 OneWire::WriteByte( CLR_RT_HeapBlock* pMngObj, INT32 param0, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owWriteByte(pin, param0);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owWriteByte(pin, param0);
   return retVal;
 }
 
 INT32 OneWire::ReadByte( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owReadByte(pin);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owReadByte(pin);
   return retVal;
 }
 
 INT32 OneWire::AcquireEx( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
+    UINT32 pin = Get__pin(pMngObj); 
   retVal = owAcquire(pin, "\\\\OneWire\\");
   return retVal;
 }
@@ -59,32 +59,32 @@ INT32 OneWire::AcquireEx( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 INT32 OneWire::Release( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	owRelease(pin);
+    UINT32 pin = Get__pin(pMngObj); 
+    owRelease(pin);
   return retVal;
 }
 
 INT32 OneWire::First( CLR_RT_HeapBlock* pMngObj, INT8 param0, INT8 param1, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owFirst(pin, param0, param1);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owFirst(pin, param0, param1);
   return retVal;
 }
 
 INT32 OneWire::Next( CLR_RT_HeapBlock* pMngObj, INT8 param0, INT8 param1, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	retVal = owNext(pin, param0, param1);
+    UINT32 pin = Get__pin(pMngObj); 
+    retVal = owNext(pin, param0, param1);
   return retVal;
 }
 
 INT32 OneWire::SerialNum( CLR_RT_HeapBlock* pMngObj, CLR_RT_TypedArray_UINT8 param0, INT8 param1, HRESULT &hr )
 {
   INT32 retVal = 0; 
-	UINT32 pin = Get__pin(pMngObj); 
-	owSerialNum(pin, param0.GetBuffer(), param1);
+    UINT32 pin = Get__pin(pMngObj); 
+    owSerialNum(pin, param0.GetBuffer(), param1);
   return retVal;
 }
 

--- a/CLR/Libraries/SPOT_IO/spot_io_native.h
+++ b/CLR/Libraries/SPOT_IO/spot_io_native.h
@@ -111,7 +111,7 @@ struct Library_spot_io_native_Microsoft_SPOT_IO_RemovableMedia
 {
     static const int FIELD_STATIC__Insert   = 4;
     static const int FIELD_STATIC__Eject    = 5;
-    static const int FIELD_STATIC___volumes = 6;	
+    static const int FIELD_STATIC___volumes = 6;
     static const int FIELD_STATIC___events  = 7;
 
     TINYCLR_NATIVE_DECLARE(MountRemovableVolumes___STATIC__VOID);

--- a/CLR/Libraries/SPOT_IO/spot_io_native_Microsoft_SPOT_IO_NativeFileStream.cpp
+++ b/CLR/Libraries/SPOT_IO/spot_io_native_Microsoft_SPOT_IO_NativeFileStream.cpp
@@ -114,7 +114,7 @@ HRESULT Library_spot_io_native_Microsoft_SPOT_IO_NativeFileStream::ReadWriteHelp
         //
         if(stack.m_customState == 1)
         {
-	        stack.PushValueI4( 0 );
+            stack.PushValueI4( 0 );
             
             switch(fs->GetBufferingStrategy())
             {
@@ -130,9 +130,9 @@ HRESULT Library_spot_io_native_Microsoft_SPOT_IO_NativeFileStream::ReadWriteHelp
                 break;
             }
 
-	        stack.m_customState = 2;
+            stack.m_customState = 2;
         }
-    	
+
         bytesProcessed = stack.m_evalStack[ 1 ].NumericByRef().s4;
 
         buffer += bytesProcessed;

--- a/CLR/Libraries/SPOT_Net/spot_net_native_Microsoft_SPOT_Net_NetworkInformation_NetworkInterface.cpp
+++ b/CLR/Libraries/SPOT_Net/spot_net_native_Microsoft_SPOT_Net_NetworkInformation_NetworkInterface.cpp
@@ -110,7 +110,7 @@ HRESULT Library_spot_net_native_Microsoft_SPOT_Net_NetworkInformation_NetworkInt
 
             UINT32 dataFlag = WIRELESS_FLAG_DATA__value(wirelessConfig.wirelessFlags);
             if (dataFlag & WIRELESS_FLAG_DATA_ENCRYPTED)
-            {
+            {
                 ASSERT(FALSE);  // TODO: ADD SUPPORT FOR ENCRYPTION
                 //key = RetrieveWirelessEncryptionKey();
             }

--- a/CLR/StartupLib/CLRStartup.cpp
+++ b/CLR/StartupLib/CLRStartup.cpp
@@ -698,7 +698,7 @@ void ClrStartup( CLR_SETTINGS params )
                 s_ClrSettings.Cleanup();
 
                 HAL_Uninitialize();
-							
+
                 SmartPtr_IRQ::ForceDisabled();
 
                 //re-init the hal for the reboot (initially it is called in bootentry)

--- a/Framework/Core/Native_Hardware/LargeBuffer.cs
+++ b/Framework/Core/Native_Hardware/LargeBuffer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.SPOT.Hardware
         {
             if(ev is GenericEvent)
             {
-                if(OnLargeBufferRequest != null)               
+                if(OnLargeBufferRequest != null)
                 {
                     ushort id = (ushort)((GenericEvent)ev).EventData;
                     


### PR DESCRIPTION
- Convert tabs to spaces in files with mixed tabs/spaces.
- Convert mixed line endings to Windows-style (\r\n).

This is not by any means comprehensive for the code base.  These are just the instances which were cheap to find and fix.