### PR TITLE
Fix an issue with StreamReader.Peek() that led to missing bytes

### DIFF
--- a/Framework/Core/System/IO/StreamReader.cs
+++ b/Framework/Core/System/IO/StreamReader.cs
@@ -93,7 +93,7 @@ namespace System.IO
             {
                 // Move any bytes read for this character to front of new buffer
                 int totRead;
-                for (totRead = 0; totRead < m_curBufLen - m_curBufPos - 1; ++totRead)
+                for (totRead = 0; totRead < m_curBufLen - m_curBufPos; ++totRead)
                 {
                     m_buffer[totRead] = m_buffer[m_curBufPos + totRead];
                 }


### PR DESCRIPTION
Previously, if the buffer needed to be refreshed from within Peek, the last byte in the buffer would be skipped.

Sample code to demonstrate this issue:
```cs
// Create a buffer (with more than 512 bytes)
byte[] buffer = new byte[600];
// Fill the buffer with data
for (int i = 0; i < buffer.Length; i++)
    buffer[i] = (byte)(1 + i % 10);
// Create a stream and stream reader
var stream = new MemoryStream(buffer);
var reader = new StreamReader(stream);
// Attempt to read back and verify the data
for (int i = 0; i < buffer.Length; i++)
{
    reader.Peek();
    // Verify that we have the correct byte
    if (reader.Read() != (1 + i % 10))
    {
        Debug.Print("Invalid character at position " + i);
    }
}
```

Without this fix, StreamReader skips a byte every 512 bytes (when Peek() is called). The above code will start reporting invalid characters at index 511.