### PR TITLE
Modify Exception.ToString() to use the (virtual) Message property

### DIFF
--- a/Framework/Subset_of_CorLib/System/Exception.cs
+++ b/Framework/Subset_of_CorLib/System/Exception.cs
@@ -58,7 +58,7 @@ namespace System
 
         public override String ToString()
         {
-            String message = _message;
+            String message = Message;
             String s = base.ToString();
 
             if (message != null && message.Length > 0)


### PR DESCRIPTION
Previously, if a class that inherited from Exception overrode the Message property, ToString would ignore the value of that overridden property when generating its result.

This change mirrors behavior in the desktop framework.