### PR TITLE
Fix bug in STM32F4 ADC generating compiler warning

### DIFF
--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/STM32F4_AD_functions.cpp
@@ -111,7 +111,7 @@ INT32 AD_Read( ANALOG_CHANNEL channel )
     
             // disable internally reference
             if(chNum == 16 || chNum == 17) {
-                ADC->CCR &= ~(1 << ADC_CCR_TSVREFE); 
+                ADC->CCR &= ~ADC_CCR_TSVREFE; 
             }
     
             return ADCx->DR; // read result


### PR DESCRIPTION
- fixed bug where code was doing a shift of an already properly positioned bitmask leading to warning from compiler and incorrect code.