### PR TITLE
Eliminate or suppress warnings for build_sdk (VS14)

### DIFF
--- a/CLR/Libraries/SPOT_Touch/spot_touch_native_Microsoft_SPOT_Touch_Ink.cpp
+++ b/CLR/Libraries/SPOT_Touch/spot_touch_native_Microsoft_SPOT_Touch_Ink.cpp
@@ -32,7 +32,7 @@ HRESULT Library_spot_touch_native_Microsoft_SPOT_Touch_Ink::SetInkRegion___STATI
     inkRegionInfo.Y2 = pArgs[ 4 ].NumericByRef().s4;    
     inkRegionInfo.BorderWidth = pArgs[ 5 ].NumericByRef().s4;
 
-    GFX_Pen pen = {pArgs[ 6 ].NumericByRef().s4, pArgs[ 7 ].NumericByRef().s4};
+    GFX_Pen pen = {pArgs[ 6 ].NumericByRef().u4, pArgs[ 7 ].NumericByRef().s4};
     inkRegionInfo.Pen = pen;
 
     m_InkPinnedBitmap = pArgs[ 8 ].Dereference();

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/bio/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/crypto/bio/dotNetMF.proj
@@ -24,7 +24,9 @@
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <PropertyGroup>
     <!-- warning C4065: switch statement contains 'default' but no 'case' labels -->
-    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4065</ExtraFlags>
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">$(ExtraFlags) /wd4065</ExtraFlags>
+    <!-- warning C4267: '=': conversion from 'size_t' to 'type', possible loss of data -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">$(ExtraFlags) /wd4267</ExtraFlags>
   </PropertyGroup>
   <!--
   <ItemGroup>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/ssl/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/ssl/dotNetMF.proj
@@ -24,7 +24,9 @@
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
   <PropertyGroup>
     <!-- warning C4390: ';' : empty controlled statement found; is this the intent? -->
-    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">/wd4390</ExtraFlags>
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">$(ExtraFlags) /wd4390</ExtraFlags>
+    <!-- warning C4838: conversion from 'type1' to 'type2' requires a narrowing conversion -->
+    <ExtraFlags Condition="'$(PLATFORM_FAMILY)'=='x86'">$(ExtraFlags) /wd4838</ExtraFlags>
   </PropertyGroup>
   <!--
   <ItemGroup>

--- a/Solutions/Windows2/TinyCLR/Serial.cpp
+++ b/Solutions/Windows2/TinyCLR/Serial.cpp
@@ -19,24 +19,26 @@ struct EmuSerialPortEvent
     PFNUsartEvent UsartErrorEventCallback;
 };
 
+const UINT32 INVALID_PORT_INDEX = (UINT32)-1;
+
 static struct EmuSerialPortEvent s_EmuUsartState[16] =
 {
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
-    { -1, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
+    { INVALID_PORT_INDEX, NULL, NULL, NULL, NULL },
 };
 
 static bool s_HandlerInitialized = false;


### PR DESCRIPTION
Fix for #128 - suppressed VS14 compiler warnings in OpenSSL, fixed in NETMF code.