### PR TITLE
Fixed the build break for MCBStm32F400, the LR_dat assigned size is n…

### DIFF
--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/M29W640FB_BlConfig.cpp
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/M29W640FB_BlConfig.cpp
@@ -50,12 +50,12 @@ const BlockRange g_M29W640FB_BlockRange1[] =
 const BlockRange g_M29W640FB_BlockRange2[] =
 {
     // ER_DAT
-    { BlockRange::BLOCKTYPE_CODE,   0,  1 },    // 2x64KB = 128KB
+    { BlockRange::BLOCKTYPE_CODE,   0,  2 },    // 2x64KB = 128KB
 #ifdef DEBUG
     // In debug builds with TRACE pins enabled, only 1MB is available
-    { BlockRange::BLOCKTYPE_DEPLOYMENT,   2,  15 },   // 15x64KB = 896KB
+    { BlockRange::BLOCKTYPE_DEPLOYMENT,   3,  15 },   // 15x64KB = 896KB
 #else
-    { BlockRange::BLOCKTYPE_DEPLOYMENT,   2,  126 },  // 126x64KB = 8000KB
+    { BlockRange::BLOCKTYPE_DEPLOYMENT,   3,  126 },  // 126x64KB = 8000KB
 #endif
 };
 

--- a/Solutions/MCBSTM32F400/TinyCLR/scatterfile_tinyclr_mdk.xml
+++ b/Solutions/MCBSTM32F400/TinyCLR/scatterfile_tinyclr_mdk.xml
@@ -50,7 +50,7 @@
 
     <!-- DAT region goes into external NOR Flash -->
     <Set Name="Data_BaseAddress"        Value="%Config_BaseAddress% + %Config_Size%"/>
-    <Set Name="Data_Size"               Value="0x00020000"/><!-- 128KB -->
+    <Set Name="Data_Size"               Value="0x00030000"/><!-- 128KB -->
     <!-- Deployment fills the rest of external NOR flash... -->
 
     <!-- Internal FLASH -->


### PR DESCRIPTION
Fixed the build break for MCBStm32F400, the LR_dat assigned size is not large enough. Just adding one more block to the DAT region.