### PR TITLE
Fix DateTime.Ticks to match the behavior of .NET

### DIFF
--- a/Framework/Subset_of_CorLib/System/DateTime.cs
+++ b/Framework/Subset_of_CorLib/System/DateTime.cs
@@ -35,7 +35,17 @@ namespace System
      * This value type represents a date and time.  Every DateTime
      * object has a private field (Ticks) of type Int64 that stores the
      * date and time as the number of 100 nanosecond intervals since
-     * 12:00 AM January 1, year 1601 A.D. in the proleptic Gregorian Calendar.
+     * 12:00 AM January 1, year 1601 A.D. in the proleptic Gregorian Calendar. 
+     * See DeviceCode\PAL\time_decl.h for explanation of why we are taking
+     * year 1601 as origin for our HAL, PAL, and CLR.
+     *
+     * It should be considered that previously DateTime.Ticks used to represent
+     * the number 100 nanosecond intervals since 12:00 AM January 1, year 1601 A.D.
+     * causing a 504911232000000000 difference between ticks in .NET and .NET MF
+     * To fix this disparity, we modified the CLR portion of DateTime type without 
+     * changing the origin of the DateTime. In particular, TicksAtOrigin is subtracted
+     * from any ticks value provided by user code, and it is added back whenever the 
+     * ticks value is read.
      *
      * <p>For a description of various calendar issues, look at
      * <a href="http://serendipity.nofadz.com/hermetic/cal_stud.htm">
@@ -77,11 +87,6 @@ namespace System
         private const int DaysPer100Years = DaysPer4Years * 25 - 1;
         // Number of days in 400 years
         private const int DaysPer400Years = DaysPer100Years * 4 + 1;
-
-        // Number of days from 1/1/0001 to 12/31/1600
-        private const int DaysTo1601 = DaysPer400Years * 4;
-        // Number of days from 1/1/0001 to 12/30/1899
-        private const int DaysTo1899 = DaysPer400Years * 4 + DaysPer100Years * 3 - 367;
         // Number of days from 1/1/0001 to 12/31/9999
         private const int DaysTo10000 = DaysPer400Years * 25 - 366;
 
@@ -93,13 +98,18 @@ namespace System
         private const ulong TickMask = 0x7FFFFFFFFFFFFFFFL;
         private const ulong UTCMask = 0x8000000000000000L;
 
-        public static readonly DateTime MinValue = new DateTime(MinTicks);
-        public static readonly DateTime MaxValue = new DateTime(MaxTicks);
+        // Ticks at 12:00 AM January 1, year 1601 A.D.
+        private const long TicksAtOrigin = 504911232000000000;
+
+        public static readonly DateTime MinValue = new DateTime(MinTicks + TicksAtOrigin);
+        public static readonly DateTime MaxValue = new DateTime(MaxTicks + TicksAtOrigin);
 
         private ulong m_ticks;
 
         public DateTime(long ticks)
         {
+            ticks -= TicksAtOrigin;
+
             if (((ticks & (long)TickMask) < MinTicks) || ((ticks & (long)TickMask) > MaxTicks))
             {
                 throw new ArgumentOutOfRangeException("ticks", "Ticks must be between DateTime.MinValue.Ticks and DateTime.MaxValue.Ticks.");
@@ -136,12 +146,12 @@ namespace System
 
         public DateTime Add(TimeSpan val)
         {
-            return new DateTime((long)m_ticks + val.Ticks);
+            return new DateTime((long)m_ticks + val.Ticks + TicksAtOrigin);
         }
 
         private DateTime Add(double val, int scale)
         {
-            return new DateTime((long)((long)m_ticks + (long)(val * scale * TicksPerMillisecond + (val >= 0 ? 0.5 : -0.5))));
+            return new DateTime((long)((long)m_ticks + (long)(val * scale * TicksPerMillisecond + (val >= 0 ? 0.5 : -0.5))) + TicksAtOrigin);
         }
 
         public DateTime AddDays(double val)
@@ -171,7 +181,7 @@ namespace System
 
         public DateTime AddTicks(long val)
         {
-            return new DateTime((long)m_ticks + val);
+            return new DateTime((long)m_ticks + val + TicksAtOrigin);
         }
 
         public static int Compare(DateTime t1, DateTime t2)
@@ -233,11 +243,11 @@ namespace System
                 // Need to remove UTC mask before arithmetic operations. Then set it back.
                 if ((m_ticks & UTCMask) != 0)
                 {
-                    return new DateTime((long)(((m_ticks & TickMask) - (m_ticks & TickMask) % TicksPerDay) | UTCMask));
+                    return new DateTime((long)(((m_ticks & TickMask) - (m_ticks & TickMask) % TicksPerDay) | UTCMask) + TicksAtOrigin);
                 }
                 else
                 {
-                    return new DateTime((long)(m_ticks - m_ticks % TicksPerDay));
+                    return new DateTime((long)(m_ticks - m_ticks % TicksPerDay) + TicksAtOrigin);
                 }
             }
         }
@@ -291,7 +301,7 @@ namespace System
 
         public static DateTime SpecifyKind(DateTime value, DateTimeKind kind)
         {
-            DateTime retVal = new DateTime((long)value.m_ticks);
+            DateTime retVal = new DateTime((long)value.m_ticks + TicksAtOrigin);
 
             if (kind == DateTimeKind.Utc)
             {
@@ -360,18 +370,11 @@ namespace System
             }
         }
 
-        /// Our origin is at 1601/01/01:00:00:00.000
-        /// While desktop CLR's origin is at 0001/01/01:00:00:00.000.
-        /// There are 504911232000000000 ticks between them which we are subtracting.
-        /// See DeviceCode\PAL\time_decl.h for explanation of why we are taking
-        /// year 1601 as origin for our HAL, PAL, and CLR.
-        // static Int64 ticksAtOrigin = 504911232000000000;
-        static Int64 ticksAtOrigin = 0;
         public long Ticks
         {
             get
             {
-                return (long)(m_ticks & TickMask) + ticksAtOrigin;
+                return (long)(m_ticks & TickMask) + TicksAtOrigin;
             }
         }
 
@@ -408,7 +411,7 @@ namespace System
 
         public DateTime Subtract(TimeSpan val)
         {
-            return new DateTime((long)(m_ticks - (ulong)val.m_ticks));
+            return new DateTime((long)(m_ticks - (ulong)val.m_ticks) + TicksAtOrigin);
         }
 
         [MethodImplAttribute(MethodImplOptions.InternalCall)]
@@ -429,12 +432,12 @@ namespace System
 
         public static DateTime operator +(DateTime d, TimeSpan t)
         {
-            return new DateTime((long)(d.m_ticks + (ulong)t.m_ticks));
+            return new DateTime((long)(d.m_ticks + (ulong)t.m_ticks) + TicksAtOrigin);
         }
 
         public static DateTime operator -(DateTime d, TimeSpan t)
         {
-            return new DateTime((long)(d.m_ticks - (ulong)t.m_ticks));
+            return new DateTime((long)(d.m_ticks - (ulong)t.m_ticks) + TicksAtOrigin);
         }
 
         public static TimeSpan operator -(DateTime d1, DateTime d2)

--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/SystemDateTimeTests.cs
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/SystemDateTimeTests.cs
@@ -11,6 +11,10 @@ namespace Microsoft.SPOT.Platform.Tests
 {
     public class SystemDateTimeTests : IMFTestInterface
     {
+        // Ticks at 12:00 AM January 1, year 1601 A.D.
+        private const long TicksAtOrigin = 504911232000000000;
+        private const long MaxTicks = 946708127990000000;
+
         [SetUp]
         public InitializeResult Initialize()
         {
@@ -115,7 +119,7 @@ namespace Microsoft.SPOT.Platform.Tests
                 Log.Comment("Creating Minimum DateTime and verifying");
                 DateTime minDT1 = DateTime.MinValue;
                 DateTime minDT2 = new DateTime();
-                DateTime minDT3 = new DateTime(0);
+                DateTime minDT3 = new DateTime(TicksAtOrigin);
                 DateTime minDT4 = new DateTime(1601, 1, 1, 0, 0, 0, 0);
 
                 if ((DateTime.Compare(minDT1, minDT2) != 0) ||
@@ -131,10 +135,10 @@ namespace Microsoft.SPOT.Platform.Tests
                 }
 
                 Log.Comment("Creating Maximum DateTime and verifying");
-                DateTime maxDateTime = new DateTime(441796895990000000);
+                DateTime maxDateTime = new DateTime(MaxTicks);
                 if (!DateTime.MaxValue.Equals(maxDateTime))
                 {
-                    Log.Comment("Expected Ticks '441796895990000000' but got '" + DateTime.MaxValue.Ticks + "'");
+                    Log.Comment("Expected Ticks '946708127990000000' but got '" + DateTime.MaxValue.Ticks + "'");
                     testResult = MFTestResults.Fail;
                 }
             }
@@ -1316,7 +1320,7 @@ namespace Microsoft.SPOT.Platform.Tests
                 for (int i = 0; i < dtArr.Length; i++)
                 {
                     DateTime dt1 = dtArr[i];
-                    DateTime dt2 = new DateTime(random.Next(1000) + 1);
+                    DateTime dt2 = new DateTime(random.Next(1000) + 1 + TicksAtOrigin);
                     TimeSpan ts = dt1 - dt2;
                     if (ts.Ticks != (dt1.Ticks - dt2.Ticks))
                     {
@@ -1562,9 +1566,9 @@ namespace Microsoft.SPOT.Platform.Tests
             {
                 Log.Comment("Getting the Min. DateTime and Verifying");
                 DateTime field = DateTime.MinValue;
-                if (field.Ticks != 0)
+                if (field.Ticks != TicksAtOrigin)
                 {
-                    Log.Comment("Failure : expected DateTime.MinValue = '0' but got '" + field.Ticks + "'");
+                    Log.Comment("Failure : expected DateTime.MinValue = '504911232000000000' but got '" + field.Ticks + "'");
                     testResult = MFTestResults.Fail;
                 }
             }
@@ -1590,9 +1594,9 @@ namespace Microsoft.SPOT.Platform.Tests
                 Log.Comment("Getting the Max. DateTime and Verifying");
                 DateTime field = DateTime.MaxValue;
                 Log.Comment(field.Ticks.ToString());
-                if (field.Ticks != 441796895990000000)
+                if (field.Ticks != MaxTicks)
                 {
-                    Log.Comment("Failure : expected DateTime.MinValue = '441796895990000000'" +
+                    Log.Comment("Failure : expected DateTime.MaxValue = '946708127990000000'" +
                         " but got '" + field.Ticks + "'");
                     testResult = MFTestResults.Fail;
                 }
@@ -1940,12 +1944,15 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults testResult = MFTestResults.Pass;
             try
             {
+                // This is an arbitrary ticks value which corresponds to a point of time in year 2015
+                long testTicks = 635688622030533832;
+                
                 Log.Comment("Creating a DateTime, getting the Ticks and Verifying");
-                DateTime testDateTime = new System.DateTime(0);
+                DateTime testDateTime = new System.DateTime(testTicks);
                 long _ticks = testDateTime.Ticks;
-                if (_ticks != 0)
+                if (_ticks != testTicks)
                 {
-                    Log.Comment("Failure : Expected ticks '0' but got '" + _ticks + "'");
+                    Log.Comment("Failure : Expected ticks '635688622030533832' but got '" + _ticks + "'");
                     testResult = MFTestResults.Fail;
                 }
             }


### PR DESCRIPTION
This pull request fixes #138 

Basically, the interface of DateTime type is modified so that Ticks correspond as the number of 100-nanosecond intervals that have elapsed since 12:00:00 midnight, January 1, 0001 instead of 12:00 AM January 1, year 1601 A.D.
This is done without modifying the native portion of DateTime to minimize the required changes.
