### PR TITLE
Fix NullReferenceException in String.Concat(params object[] args)

### DIFF
--- a/Framework/Subset_of_CorLib/System/String.cs
+++ b/Framework/Subset_of_CorLib/System/String.cs
@@ -228,12 +228,10 @@ namespace System
 
             int length = args.Length;
             String[] sArgs = new String[length];
-            int totalLength = 0;
 
             for (int i = 0; i < length; i++)
             {
                 sArgs[i] = ((args[i] == null) ? (String.Empty) : (args[i].ToString()));
-                totalLength += sArgs[i].Length;
             }
 
             return String.Concat(sArgs);

--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/SystemStringTests.cs
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/SystemStringTests.cs
@@ -436,6 +436,35 @@ namespace Microsoft.SPOT.Platform.Tests
             testResult &= (str1.Length == 9);
             return (testResult ? MFTestResults.Pass : MFTestResults.Fail);
         }
-    
+        
+        [TestMethod]
+        public MFTestResults Concat_Test1()
+        {
+            /// <summary>
+            /// 1. Tests the string concat of several object where one of the arguments returns a null value for ToString()
+            /// </summary>
+            ///
+            
+            try
+            {
+                string str = "a" + 1 + "b" + new ToStringReturnsNull();
+                return (str == "a1b" ? MFTestResults.Pass : MFTestResults.Fail);
+            }
+            catch
+            {
+                return MFTestResults.Fail;
+            }
+        }
+    }
+
+    /// <summary>
+    /// A class whose ToString method return null
+    /// </summary>
+    public class ToStringReturnsNull
+    {
+        public override string ToString()
+        {
+            return null;
+        }
     }
 }


### PR DESCRIPTION
fixes #145 