### PR TITLE
Fix Single.ToString() for special values

### DIFF
--- a/Framework/Subset_of_CorLib/System/Single.cs
+++ b/Framework/Subset_of_CorLib/System/Single.cs
@@ -22,14 +22,34 @@ namespace System
 
         public override String ToString()
         {
-            return Number.Format(m_value, false, "G", NumberFormatInfo.CurrentInfo);
+            // Number.Format method is responsible for returning the correct string representation of the value; however, it does not work properly for special values.
+            // Fixing the issue in Number.Format requires a significant amount of modification in both native and managed code.
+            // In order to avoid that (at lease for now), we use the help of Double class to identify special values and use Number.Format for the others.
+            string str = ((Double)m_value).ToString();
+            switch (str)
+            {
+                case "Infinity":
+                case "-Infinity":
+                case "NaN":
+                    return str;
+                default:
+                    return Number.Format(m_value, false, "G", NumberFormatInfo.CurrentInfo);
+            }
         }
 
         public String ToString(String format)
         {
-            return Number.Format(m_value, false, format, NumberFormatInfo.CurrentInfo);
+            string str = ((Double)m_value).ToString();
+            switch (str)
+            {
+                case "Infinity":
+                case "-Infinity":
+                case "NaN":
+                    return str;
+                default:
+                    return Number.Format(m_value, false, format, NumberFormatInfo.CurrentInfo);
+            }
         }
-
     }
 }
 

--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/SystemTypeTests.cs
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/SystemTypeTests.cs
@@ -100,6 +100,14 @@ namespace Microsoft.SPOT.Platform.Tests
             tst = (-3210).ToString("g");
             bRet &= "-3210" == tst;
 
+            bRet &= "NaN" == ((float)0f / 0f).ToString();
+            bRet &= "Infinity" == ((float)1f / 0f).ToString();
+            bRet &= "-Infinity" == ((float)-1f / 0f).ToString();
+
+            bRet &= "NaN" == ((double)0f / 0f).ToString();
+            bRet &= "Infinity" == ((double)1f / 0f).ToString();
+            bRet &= "-Infinity" == ((double)-1f / 0f).ToString();
+
             if (bRet)
             {
                 return MFTestResults.Pass;


### PR DESCRIPTION
Fix ToString method for float type so that it returns correct strings for NaN, Infinity, and -Infinity values

Fixes #157 
