### PR TITLE
Add support for Windows.Devices.Adc

### DIFF
--- a/Framework/Core/Windows/Devices/Adc/AdcChannel.cs
+++ b/Framework/Core/Windows/Devices/Adc/AdcChannel.cs
@@ -1,0 +1,80 @@
+using System;
+using Windows.Devices.Adc.Provider;
+
+namespace Windows.Devices.Adc
+{
+    public sealed class AdcChannel : IDisposable
+    {
+        private readonly int m_channelNumber;
+        private AdcController m_controller;
+        private IAdcControllerProvider m_provider;
+        private bool m_disposed = false;
+
+        internal AdcChannel(AdcController controller, IAdcControllerProvider provider, int channelNumber)
+        {
+            m_controller = controller;
+            m_provider = provider;
+            m_channelNumber = channelNumber;
+
+            m_provider.AcquireChannel(channelNumber);
+        }
+
+        ~AdcChannel()
+        {
+            Dispose(false);
+        }
+
+        public AdcController Controller
+        {
+            get
+            {
+                if (m_disposed)
+                {
+                    throw new ObjectDisposedException();
+                }
+
+                return m_controller;
+            }
+        }
+
+        int ReadValue()
+        {
+            if (m_disposed)
+            {
+                throw new ObjectDisposedException();
+            }
+
+            return m_provider.ReadValue(m_channelNumber);
+        }
+
+        double ReadRatio()
+        {
+            if (m_disposed)
+            {
+                throw new ObjectDisposedException();
+            }
+
+            return ((double)m_provider.ReadValue(m_channelNumber)) / m_provider.MaxValue;
+        }
+
+        public void Dispose()
+        {
+            if (!m_disposed)
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+                m_disposed = true;
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                m_provider.ReleaseChannel(m_channelNumber);
+                m_controller = null;
+                m_provider = null;
+            }
+        }
+    }
+}

--- a/Framework/Core/Windows/Devices/Adc/AdcChannel.cs
+++ b/Framework/Core/Windows/Devices/Adc/AdcChannel.cs
@@ -37,7 +37,7 @@ namespace Windows.Devices.Adc
             }
         }
 
-        int ReadValue()
+        public int ReadValue()
         {
             if (m_disposed)
             {
@@ -47,7 +47,7 @@ namespace Windows.Devices.Adc
             return m_provider.ReadValue(m_channelNumber);
         }
 
-        double ReadRatio()
+        public double ReadRatio()
         {
             if (m_disposed)
             {

--- a/Framework/Core/Windows/Devices/Adc/AdcController.cs
+++ b/Framework/Core/Windows/Devices/Adc/AdcController.cs
@@ -1,0 +1,110 @@
+using System;
+using Windows.Devices.Adc.Provider;
+
+namespace Windows.Devices.Adc
+{
+    public sealed class AdcController
+    {
+        private IAdcControllerProvider m_provider;
+
+        internal AdcController(IAdcControllerProvider provider)
+        {
+            m_provider = provider;
+        }
+
+        public int ChannelCount
+        {
+            get
+            {
+                return m_provider.ChannelCount;
+            }
+        }
+
+        public int ResolutionInBits
+        {
+            get
+            {
+                return m_provider.ResolutionInBits;
+            }
+        }
+
+        public int MinValue
+        {
+            get
+            {
+                return m_provider.MinValue;
+            }
+        }
+
+        public int MaxValue
+        {
+            get
+            {
+                return m_provider.MaxValue;
+            }
+        }
+
+        public AdcChannelMode ChannelMode
+        {
+            get
+            {
+                return (AdcChannelMode)m_provider.ChannelMode;
+            }
+
+            set
+            {
+                switch (value)
+                {
+                case AdcChannelMode.Differential:
+                case AdcChannelMode.SingleEnded:
+                    break;
+
+                default:
+                    throw new ArgumentException();
+                }
+
+                m_provider.ChannelMode = (ProviderAdcChannelMode)value;
+            }
+        }
+
+        public static AdcController[] GetControllers(IAdcProvider provider)
+        {
+            // FUTURE: This should return "Task<IVectorView<AdcController>>"
+
+            var providers = provider.GetControllers();
+            var controllers = new AdcController[providers.Length];
+
+            for (int i = 0; i < providers.Length; ++i)
+            {
+                controllers[i] = new AdcController(providers[i]);
+            }
+
+            return controllers;
+        }
+
+        public bool IsChannelModeSupported(AdcChannelMode channelMode)
+        {
+            switch (channelMode)
+            {
+            case AdcChannelMode.Differential:
+            case AdcChannelMode.SingleEnded:
+                break;
+
+            default:
+                throw new ArgumentException();
+            }
+
+            return m_provider.IsChannelModeSupported((ProviderAdcChannelMode)channelMode);
+        }
+
+        public AdcChannel OpenChannel(int channelNumber)
+        {
+            if ((channelNumber < 0) || (channelNumber >= m_provider.ChannelCount))
+            {
+                throw new ArgumentOutOfRangeException();
+            }
+
+            return new AdcChannel(this, m_provider, channelNumber);
+        }
+    }
+}

--- a/Framework/Core/Windows/Devices/Adc/AdcEnums.cs
+++ b/Framework/Core/Windows/Devices/Adc/AdcEnums.cs
@@ -1,0 +1,17 @@
+namespace Windows.Devices.Adc
+{
+    public enum AdcChannelMode
+    {
+        SingleEnded = 0,
+        Differential,
+    }
+}
+
+namespace Windows.Devices.Adc.Provider
+{
+    public enum ProviderAdcChannelMode
+    {
+        SingleEnded = 0,
+        Differential,
+    }
+}

--- a/Framework/Core/Windows/Devices/Adc/AdcProvider.cs
+++ b/Framework/Core/Windows/Devices/Adc/AdcProvider.cs
@@ -1,0 +1,43 @@
+using System;
+
+namespace Windows.Devices.Adc.Provider
+{
+    public interface IAdcControllerProvider
+    {
+        int ChannelCount
+        {
+            get;
+        }
+
+        int ResolutionInBits
+        {
+            get;
+        }
+
+        int MinValue
+        {
+            get;
+        }
+
+        int MaxValue
+        {
+            get;
+        }
+
+        ProviderAdcChannelMode ChannelMode
+        {
+            get;
+            set;
+        }
+
+        bool IsChannelModeSupported(ProviderAdcChannelMode channelMode);
+        void AcquireChannel(int channel);
+        void ReleaseChannel(int channel);
+        int ReadValue(int channelNumber);
+    }
+
+    public interface IAdcProvider
+    {
+        IAdcControllerProvider[] GetControllers();
+    }
+}

--- a/Framework/Core/Windows/Devices/Devices.csproj
+++ b/Framework/Core/Windows/Devices/Devices.csproj
@@ -24,6 +24,10 @@
     </MMP_STUB_Load>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Adc\AdcChannel.cs" />
+    <Compile Include="Adc\AdcController.cs" />
+    <Compile Include="Adc\AdcEnums.cs" />
+    <Compile Include="Adc\AdcProvider.cs" />
     <Compile Include="Enumeration\DeviceInformation.cs" />
     <Compile Include="Gpio\GpioController.cs" />
     <Compile Include="Gpio\GpioEnums.cs" />


### PR DESCRIPTION
This feature is currently lacking a reference implementation, but adds support for the UWP ability to hook ADC Providers into the richer API.  Reference implementations for IAdcControllerProvider will be provided at a later date. Tracked by issue #163.