### PR TITLE
Fix UTF8Encoding.UTF8.GetBytes

### DIFF
--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/Utf8EncodingTests.cs
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/Utf8EncodingTests.cs
@@ -76,5 +76,24 @@ namespace Microsoft.SPOT.Platform.Tests
 
             return result ? MFTestResults.Pass : MFTestResults.Fail;
         }
+
+        [TestMethod]
+        public MFTestResults Utf8EncodingTests_Test3()
+        {
+            // This tests involves a string with a special character
+
+            bool result = true;
+
+            string str = "AB\u010DAB";
+
+            byte[] data = new byte[4];
+            int count = UTF8Encoding.UTF8.GetBytes(str, 1, 3, data, 0);
+
+            result &= count == 4;
+
+            result &= (new string(UTF8Encoding.UTF8.GetChars(data)) == "B\u010DA");
+
+            return result ? MFTestResults.Pass : MFTestResults.Fail;
+        }
     }
 }


### PR DESCRIPTION
This overload of the GetBytes method had some fundamental issues. Specifically, it assumed that every character maps to one byte which is not correct for UTF8. This change fix the problem by involving UnicodeHelper.