### PR TITLE
Fix PWM issues.

### DIFF
--- a/DeviceCode/include/PWM_decl.h
+++ b/DeviceCode/include/PWM_decl.h
@@ -21,6 +21,14 @@ enum PWM_CHANNEL
     PWM_CHANNEL_5    =  5,
     PWM_CHANNEL_6    =  6,
     PWM_CHANNEL_7    =  7,
+    PWM_CHANNEL_8    =  8,
+    PWM_CHANNEL_9    =  9,
+    PWM_CHANNEL_10   = 10,
+    PWM_CHANNEL_11   = 11,
+    PWM_CHANNEL_12   = 12,
+    PWM_CHANNEL_13   = 13,
+    PWM_CHANNEL_14   = 14,
+    PWM_CHANNEL_15   = 15,
 };
 
 enum PWM_SCALE_FACTOR

--- a/Framework/Core/Native_Hardware/Cpu.cs
+++ b/Framework/Core/Native_Hardware/Cpu.cs
@@ -60,7 +60,7 @@ namespace Microsoft.SPOT.Hardware
 
         public enum PWMChannel : int
         {
-            PWM_NONE = -1, 
+            PWM_NONE = -1,
             PWM_0    =  0,
             PWM_1    =  1,
             PWM_2    =  2,
@@ -69,6 +69,14 @@ namespace Microsoft.SPOT.Hardware
             PWM_5    =  5,
             PWM_6    =  6,
             PWM_7    =  7,
+            PWM_8    =  8,
+            PWM_9    =  9,
+            PWM_10   = 10,
+            PWM_11   = 11,
+            PWM_12   = 12,
+            PWM_13   = 13,
+            PWM_14   = 14,
+            PWM_15   = 15,
         }
 
         public enum AnalogChannel : int

--- a/Framework/Core/Native_Hardware/Native_PWM/PWM.cs
+++ b/Framework/Core/Native_Hardware/Native_PWM/PWM.cs
@@ -2,7 +2,6 @@ using System;
 using Microsoft.SPOT.Hardware;
 using System.Runtime.CompilerServices;
 
-
 namespace Microsoft.SPOT.Hardware
 {
     /// <summary>
@@ -43,6 +42,10 @@ namespace Microsoft.SPOT.Hardware
         /// Scale of the period/duration (mS, uS, nS)
         /// </summary>
         private ScaleFactor m_scale;
+        /// <summary>
+        /// Whether this object has been disposed.
+        /// </summary>
+        private bool m_disposed = false;
 
         //--//
 
@@ -129,7 +132,12 @@ namespace Microsoft.SPOT.Hardware
         /// </summary>
         public void Dispose()
         {
-            Dispose(true);
+            if (!m_disposed)
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+                m_disposed = true;
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
This addresses two issues from CodePlex:
- Extend the PWMChannel enum to 16 values by default.  These can still be overridden by board manufacturers.
- Fix PWM.Dispose to call the internal Dispose(bool) implementation exactly once.