### PR TITLE
Fixed delays due to debug port buffer fills when no debugger present.

### DIFF
--- a/CLR/Diagnostics/Info.cpp
+++ b/CLR/Diagnostics/Info.cpp
@@ -208,7 +208,7 @@ void CLR_Debug::Emit( const char *text, int len )
             if(!CLR_EE_DBG_IS( Enabled ) || HalSystemConfig.DebugTextPort != HalSystemConfig.DebuggerPorts[ 0 ])
             {
 #if !defined(PLATFORM_WINDOWS) && !defined(PLATFORM_WINCE)
-                DebuggerPort_Write( HalSystemConfig.DebugTextPort, s_buffer, s_chars ); // skip null terminator
+                DebuggerPort_Write( HalSystemConfig.DebugTextPort, s_buffer, s_chars, 0 ); // skip null terminator and don't bother retrying
                 DebuggerPort_Flush( HalSystemConfig.DebugTextPort );                    // skip null terminator
 #endif
             }

--- a/DeviceCode/Initialization/tinyhal.cpp
+++ b/DeviceCode/Initialization/tinyhal.cpp
@@ -618,7 +618,7 @@ void debug_printf( const char* format, ... )
     DebuggerPort_Flush( HalSystemConfig.DebugTextPort );
 
     // write string
-    DebuggerPort_Write( HalSystemConfig.DebugTextPort, buffer, len );
+    DebuggerPort_Write( HalSystemConfig.DebugTextPort, buffer, len, 0 );
 
     // flush new characters
     DebuggerPort_Flush( HalSystemConfig.DebugTextPort );

--- a/DeviceCode/include/COM_decl.h
+++ b/DeviceCode/include/COM_decl.h
@@ -12,14 +12,14 @@ extern INT32 g_DebuggerPort_SslCtx_Handle;
 BOOL DebuggerPort_Initialize  ( COM_HANDLE ComPortNum );
 BOOL DebuggerPort_Uninitialize( COM_HANDLE ComPortNum );
 
-int  DebuggerPort_Write( COM_HANDLE ComPortNum, const char* Data, size_t size );
+// max retries is the number of retries if the first attempt fails, thus the maximum
+// total number of attempts is maxRretries + 1 since it always tries at least once.
+int  DebuggerPort_Write( COM_HANDLE ComPortNum, const char* Data, size_t size, int maxRetries = 99 );
 int  DebuggerPort_Read ( COM_HANDLE ComPortNum, char*       Data, size_t size );
 BOOL DebuggerPort_Flush( COM_HANDLE ComPortNum                                );
 BOOL DebuggerPort_IsSslSupported( COM_HANDLE ComPortNum );
 BOOL DebuggerPort_UpgradeToSsl( COM_HANDLE ComPortNum, UINT32 flags );
 BOOL DebuggerPort_IsUsingSsl( COM_HANDLE ComPortNum );
-
-
 
 struct IDebuggerPortSslConfig
 {
@@ -30,16 +30,9 @@ struct IDebuggerPortSslConfig
 
 extern IDebuggerPortSslConfig g_DebuggerPortSslConfig;
 
-//--//
-
 void CPU_ProtectCommunicationGPIOs( BOOL On );
 
-//--//
-
 void CPU_InitializeCommunication();
-
 void CPU_UninitializeCommunication();
-
-//--//
 
 #endif // _DRIVERS_COM_DIRECTOR_DECL_H_

--- a/DeviceCode/pal/COM/stubs/ComDirector_stubs.cpp
+++ b/DeviceCode/pal/COM/stubs/ComDirector_stubs.cpp
@@ -19,7 +19,7 @@ BOOL DebuggerPort_Uninitialize( COM_HANDLE ComPortNum )
 }
 
 
-int DebuggerPort_Write( COM_HANDLE ComPortNum, const char* Data, size_t size )
+int DebuggerPort_Write( COM_HANDLE ComPortNum, const char* Data, size_t size, int maxRetries )
 {
     NATIVE_PROFILE_PAL_COM();
     return 0;

--- a/DeviceCode/pal/COM/usb/usb.cpp
+++ b/DeviceCode/pal/COM/usb/usb.cpp
@@ -24,7 +24,7 @@ void USB_debug_printf( const char*format, ... )
     DebuggerPort_Flush( USART_DEFAULT_PORT );
 
     // write string
-    DebuggerPort_Write( USART_DEFAULT_PORT, buffer, len );
+    DebuggerPort_Write( USART_DEFAULT_PORT, buffer, len, 0 );
 
     // flush new characters
     DebuggerPort_Flush( USART_DEFAULT_PORT );

--- a/DeviceCode/pal/tinycrt/tinycrt.cpp
+++ b/DeviceCode/pal/tinycrt/tinycrt.cpp
@@ -120,7 +120,7 @@ int hal_vfprintf( COM_HANDLE stream, const char* format, va_list arg )
     case USART_TRANSPORT:
     case USB_TRANSPORT:
     case SOCKET_TRANSPORT:
-        DebuggerPort_Write( stream, buffer, chars ); // skip null terminator
+        DebuggerPort_Write( stream, buffer, chars, 0 ); // skip null terminator
         break;
 
 #if !defined(BUILD_RTM)

--- a/Solutions/MCBSTM32F400/ManagedCode/Hardware/CPU.cs
+++ b/Solutions/MCBSTM32F400/ManagedCode/Hardware/CPU.cs
@@ -11,25 +11,25 @@ namespace Microsoft.SPOT.Hardware.MCBSTM32F400
     /* Specifies valid hardware I/O pins. */
     public static class Pins
     {
-		public const Cpu.Pin GPIO_A8      = (Cpu.Pin) 8;   // GPIO Port A Pin 8
-		public const Cpu.Pin GPIO_B14     = (Cpu.Pin) 30;  // GPIO Port B Pin 14
-		public const Cpu.Pin GPIO_B15     = (Cpu.Pin) 31;  // GPIO Port B Pin 15
-		public const Cpu.Pin GPIO_D3      = (Cpu.Pin) 51;  // GPIO Port D Pin 3
-		public const Cpu.Pin GPIO_F6      = (Cpu.Pin) 86;  // GPIO Port F Pin 6
-		public const Cpu.Pin GPIO_F7      = (Cpu.Pin) 87;  // GPIO Port F Pin 7
-		public const Cpu.Pin GPIO_F8      = (Cpu.Pin) 88;  // GPIO Port F Pin 8
-		public const Cpu.Pin GPIO_F10     = (Cpu.Pin) 90;  // GPIO Port F Pin 10
-		public const Cpu.Pin GPIO_G6_LED  = (Cpu.Pin) 102; // GPIO Port G Pin 6
-		public const Cpu.Pin GPIO_G7_LED  = (Cpu.Pin) 103; // GPIO Port G Pin 7
-		public const Cpu.Pin GPIO_G8_LED  = (Cpu.Pin) 104; // GPIO Port G Pin 8
-		public const Cpu.Pin GPIO_H2_LED  = (Cpu.Pin) 114; // GPIO Port H Pin 2
-		public const Cpu.Pin GPIO_H3_LED  = (Cpu.Pin) 115; // GPIO Port H Pin 3
-		public const Cpu.Pin GPIO_H6_LED  = (Cpu.Pin) 118; // GPIO Port H Pin 6
-		public const Cpu.Pin GPIO_H7_LED  = (Cpu.Pin) 119; // GPIO Port H Pin 7
-		public const Cpu.Pin GPIO_H15     = (Cpu.Pin) 127; // GPIO Port H Pin 15
-		public const Cpu.Pin GPIO_I1      = (Cpu.Pin) 129; // GPIO Port I Pin 1
-		public const Cpu.Pin GPIO_I8      = (Cpu.Pin) 136; // GPIO Port I Pin 8
-		public const Cpu.Pin GPIO_I10_LED = (Cpu.Pin) 138; // GPIO Port I Pin 10
+        public const Cpu.Pin GPIO_A8      = (Cpu.Pin) 8;   // GPIO Port A Pin 8
+        public const Cpu.Pin GPIO_B14     = (Cpu.Pin) 30;  // GPIO Port B Pin 14
+        public const Cpu.Pin GPIO_B15     = (Cpu.Pin) 31;  // GPIO Port B Pin 15
+        public const Cpu.Pin GPIO_D3      = (Cpu.Pin) 51;  // GPIO Port D Pin 3
+        public const Cpu.Pin GPIO_F6      = (Cpu.Pin) 86;  // GPIO Port F Pin 6
+        public const Cpu.Pin GPIO_F7      = (Cpu.Pin) 87;  // GPIO Port F Pin 7
+        public const Cpu.Pin GPIO_F8      = (Cpu.Pin) 88;  // GPIO Port F Pin 8
+        public const Cpu.Pin GPIO_F10     = (Cpu.Pin) 90;  // GPIO Port F Pin 10
+        public const Cpu.Pin GPIO_G6_LED  = (Cpu.Pin) 102; // GPIO Port G Pin 6
+        public const Cpu.Pin GPIO_G7_LED  = (Cpu.Pin) 103; // GPIO Port G Pin 7
+        public const Cpu.Pin GPIO_G8_LED  = (Cpu.Pin) 104; // GPIO Port G Pin 8
+        public const Cpu.Pin GPIO_H2_LED  = (Cpu.Pin) 114; // GPIO Port H Pin 2
+        public const Cpu.Pin GPIO_H3_LED  = (Cpu.Pin) 115; // GPIO Port H Pin 3
+        public const Cpu.Pin GPIO_H6_LED  = (Cpu.Pin) 118; // GPIO Port H Pin 6
+        public const Cpu.Pin GPIO_H7_LED  = (Cpu.Pin) 119; // GPIO Port H Pin 7
+        public const Cpu.Pin GPIO_H15     = (Cpu.Pin) 127; // GPIO Port H Pin 15
+        public const Cpu.Pin GPIO_I1      = (Cpu.Pin) 129; // GPIO Port I Pin 1
+        public const Cpu.Pin GPIO_I8      = (Cpu.Pin) 136; // GPIO Port I Pin 8
+        public const Cpu.Pin GPIO_I10_LED = (Cpu.Pin) 138; // GPIO Port I Pin 10
         
         public const Cpu.Pin GPIO_NONE = Cpu.Pin.GPIO_NONE;
     }
@@ -40,10 +40,10 @@ namespace Microsoft.SPOT.Hardware.MCBSTM32F400
         public const string COM1 = "COM1";
     }
     
-	/* Specifies valid baud rates for hardware serial ports */
+    /* Specifies valid baud rates for hardware serial ports */
     public static class BaudRates
     {
-		public const BaudRate Baud9600   = BaudRate.Baudrate9600;   // Baudrate 9600
+        public const BaudRate Baud9600   = BaudRate.Baudrate9600;   // Baudrate 9600
         public const BaudRate Baud19200  = BaudRate.Baudrate19200;  // Baudrate 19200
         public const BaudRate Baud38400  = BaudRate.Baudrate38400;  // Baudrate 38400
         public const BaudRate Baud57600  = BaudRate.Baudrate57600;  // Baudrate 57600
@@ -51,15 +51,15 @@ namespace Microsoft.SPOT.Hardware.MCBSTM32F400
         public const BaudRate Baud230400 = BaudRate.Baudrate230400; // Baudrate 230400
     }
 
-	/* Specifies resistor modes for GPIO ports */
+    /* Specifies resistor modes for GPIO ports */
     public static class ResistorModes
     {
         public const Port.ResistorMode PullUp   = Port.ResistorMode.PullUp;   // Internal Resistor Pull-Up
-		public const Port.ResistorMode PullDown = Port.ResistorMode.PullDown; // Internal Resistor Pull-Down
+        public const Port.ResistorMode PullDown = Port.ResistorMode.PullDown; // Internal Resistor Pull-Down
         public const Port.ResistorMode Disabled = Port.ResistorMode.Disabled; // Internal Resistor Disabled
-		
+        
     }
-	 /* Specifies interrupt modes for GPIO ports */
+     /* Specifies interrupt modes for GPIO ports */
     public static class InterruptModes
     {
         public const Port.InterruptMode InterruptEdgeLow       = Port.InterruptMode.InterruptEdgeLow ;
@@ -69,8 +69,8 @@ namespace Microsoft.SPOT.Hardware.MCBSTM32F400
         public const Port.InterruptMode InterruptEdgeLevelLow  = Port.InterruptMode.InterruptEdgeLevelLow;
         public const Port.InterruptMode InterruptNone          = Port.InterruptMode.InterruptNone;
     }
-	
-	/* Specified valid SPI ports */
+    
+    /* Specified valid SPI ports */
     public static class SPI_Devices
     {
         public const Microsoft.SPOT.Hardware.SPI.SPI_module SPI3 = Microsoft.SPOT.Hardware.SPI.SPI_module.SPI3; // SPI Module SPI3

--- a/Solutions/Windows2/TinyCLR/Com.cpp
+++ b/Solutions/Windows2/TinyCLR/Com.cpp
@@ -19,7 +19,7 @@ BOOL DebuggerPort_Uninitialize( COM_HANDLE ComPortNum )
     return EmulatorNative::GetIComDriver()->Uninitialize( ComPortNum );
 }
 
-int DebuggerPort_Write( COM_HANDLE ComPortNum, const char* Data, size_t size )
+int DebuggerPort_Write( COM_HANDLE ComPortNum, const char* Data, size_t size, int maxRetries )
 {        
     return EmulatorNative::GetIComDriver()->Write( ComPortNum, (IntPtr)(char*)Data, (unsigned int)size );
 }

--- a/Solutions/Windows2/TinyCLR/Various.cpp
+++ b/Solutions/Windows2/TinyCLR/Various.cpp
@@ -506,7 +506,7 @@ int hal_vfprintf( COM_HANDLE stream, const char* format, va_list arg )
     case USART_TRANSPORT:
     case USB_TRANSPORT:
     case SOCKET_TRANSPORT:
-        DebuggerPort_Write( stream, buffer, chars ); // skip null terminator
+        DebuggerPort_Write( stream, buffer, chars, 0 ); // skip null terminator
         break;
 
     case LCD_TRANSPORT:


### PR DESCRIPTION
Fix #188 
- added new parameter to DebugPort_Write for max retries with default value of 99 to match previous code behavior unless explicitly set to something else.
- modified all debug prints string functions and calls to DebugPort_Write() to use a retriy count of 0 so that if the first attempt to send the string fails due to buffer full, it just returns and moves on with life.
- fixed tabs in MCPSTM32F400 Hardware managed code CPU class (as that was used for testing this)
