### PR TITLE
User button can enter bootloader during startup (STM32F4DISCOVERY)

### DIFF
--- a/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
@@ -115,8 +115,8 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\PAL\BlockStorage\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Buttons_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\PAL\Buttons\dotNetMF.proj" />
+        <DriverLibs Include="Buttons_pal_stubs.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\PAL\Buttons\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="COM_pal.$(LIB_EXT)" />

--- a/Solutions/STM32F4DISCOVERY/platform_selector.h
+++ b/Solutions/STM32F4DISCOVERY/platform_selector.h
@@ -118,19 +118,16 @@
 #define STM32F4_UART_CTS_PINS {(BYTE)GPIO_PIN_NONE, 51, 59} // GPIO_PIN_NONE, D3, D11
 #define STM32F4_UART_RTS_PINS {(BYTE)GPIO_PIN_NONE, 52, 60} // GPIO_PIN_NONE, D4, D12
 
-#define DRIVER_PAL_BUTTON_MAPPING         \
-        { 0, BUTTON_NONE }, /* Up */      \
-        { 0, BUTTON_NONE }, /* Down */    \
-        { 0, BUTTON_NONE }, /* Left */    \
-        { 0, BUTTON_NONE }, /* Right */   \
-        { 0, BUTTON_NONE }, /* Enter */   \
-        { PORT_PIN(GPIO_PORTA, 0), BUTTON_B5 }, // User
-
 // User LEDs
 #define LED3 PORT_PIN(GPIO_PORTD, 13) // PD.13 (orange)
 #define LED4 PORT_PIN(GPIO_PORTD, 12) // PD.12 (green)
 #define LED5 PORT_PIN(GPIO_PORTD, 14) // PD.14 (red)
 #define LED6 PORT_PIN(GPIO_PORTD, 15) // PD.15 (blue)
+
+// TinyBooter entry using GPIO
+#define TINYBOOTER_ENTRY_GPIO_PIN       PORT_PIN(GPIO_PORTA, 0) // 'User' button
+#define TINYBOOTER_ENTRY_GPIO_STATE     TRUE                    // Active high
+#define TINYBOOTER_ENTRY_GPIO_RESISTOR  RESISTOR_DISABLED       // No internal resistor, there is external pull-down (R39)
 
 //
 // constants


### PR DESCRIPTION
As discussed in #174. Pressing the User button (or pulling PA.0 to logic high) during startup enters the bootloader.

Implemented using `CPU_GPIO_GetPinState()`, Buttons driver replaced with stub. There are a few #define-s in `platform_selector.h` for easier configuration, i.e. for the Discovery
```
// TinyBooter entry using GPIO
#define TINYBOOTER_ENTRY_GPIO_PIN       PORT_PIN(GPIO_PORTA, 0) // 'User' button
#define TINYBOOTER_ENTRY_GPIO_STATE     TRUE                    // Active high
#define TINYBOOTER_ENTRY_GPIO_RESISTOR  RESISTOR_DISABLED       // No internal resistor, there is external pull-down (R39)
```
To disable the functionality, undefine (comment-out) TINYBOOTER_ENTRY_GPIO_PIN.