### PR TITLE
Fix array range exception during WriteConfig

### DIFF
--- a/Framework/Tools/MFDeploy/Library/MFConfigHelper.cs
+++ b/Framework/Tools/MFDeploy/Library/MFConfigHelper.cs
@@ -875,7 +875,7 @@ namespace Microsoft.NetMicroFramework.Tools.MFDeployTool.Engine
                     newLastIndex++;        // Force a 4 byte boundary
                 }
 
-                byte[] temp = new byte[m_lastCfgIndex >= m_all_cfg_data.Length ? m_lastCfgIndex + data.Length : m_all_cfg_data.Length];
+                byte[] temp = new byte[m_lastCfgIndex + data.Length >= m_all_cfg_data.Length ? m_lastCfgIndex + data.Length : m_all_cfg_data.Length];
 
                 Array.Copy(m_all_cfg_data, 0, temp,              0, m_all_cfg_data.Length);
                 Array.Copy(          data, 0, temp, m_lastCfgIndex,           data.Length);


### PR DESCRIPTION
In WriteConfig at line 878 in MFConfigHelper.cs, a temp buffer is allocated to include the current config plus the addition.  When the length of the current config plus the new data is larger than the current size of the m_cfg_all_data array, the temp array should be enlarged to accomodate the new data. In the existing code, the allocation uses m_lastCfgIndex instead of _lastCfgIndex+data.Length and so under-allocates space when m_lastCfgIndex+data.Length would exceed the current size of m_all_cfg_data.Length. This fix corrects the under-allocation and resulting exception on line 881.