### PR TITLE
Fix build break

### DIFF
--- a/DeviceCode/Targets/OS/CMSIS_RTOS/DeviceCode/lwip_1_4_1_os/arch/cc.h
+++ b/DeviceCode/Targets/OS/CMSIS_RTOS/DeviceCode/lwip_1_4_1_os/arch/cc.h
@@ -70,13 +70,13 @@ typedef intptr_t    mem_ptr_t;
 #define PACK_STRUCT_END
 
 /* Plaform specific diagnostic output */
-extern void hal_printf(const char *format, ...);
+extern void debug_printf(const char *format, ...);
 
 #define LWIP_PLATFORM_DIAG(x) do {debug_printf x;} while(0)
 
 #ifndef LWIP_NOASSERT
 #define LWIP_PLATFORM_ASSERT(x) \
-  do {hal_printf("LWIP Assertion \"%s\" failed at line %d in %s\n", \
+  do {debug_printf("LWIP Assertion \"%s\" failed at line %d in %s\n", \
              x, __LINE__, __FILE__); } while(0)
 #else
 #define LWIP_PLATFORM_ASSERT(x)


### PR DESCRIPTION
Fixes #227 

restored LWIP cc.h to use debug_printf as that is already set to extern "C" linkage. Changing hal_printf and everything that uses it to ensure it is always extern "C" as well was more work than seems worth it in this case.