### PR TITLE
STM32F4DISCOVERY: TinyBooter uses ITM0

### DIFF
--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Init/IO_Init.cpp
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Init/IO_Init.cpp
@@ -14,6 +14,11 @@
 #include <tinyhal.h>
 #include "..\..\..\..\DeviceCode\Targets\Native\STM32F4\DeviceCode\stm32f4xx.h"
 
+// Define the generic port table, only one generic extensionn port type supported
+// and that is the ITM hardware trace port on Channel 0.
+extern GenericPortTableEntry const Itm0GenericPort;
+extern GenericPortTableEntry const* const g_GenericPorts[TOTAL_GENERIC_PORTS] = { &Itm0GenericPort };
+
 extern void STM32F4_GPIO_Pin_Config( GPIO_PIN pin, UINT32 mode, GPIO_RESISTOR resistor, UINT32 alternate );    // Workaround, since CPU_GPIO_DisablePin() does not correctly initialize pin speeds
 
 void __section("SectionForBootstrapOperations") BootstrapCode_GPIO()

--- a/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
@@ -31,6 +31,10 @@
         <Compile Include="$(SRC_DIR)\TinyBooterEntry.cpp" />
     </ItemGroup>
     <ItemGroup>
+        <DriverLibs Include="CortexMx_ItmPort.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Cores\arm\Processors\CortexMx\ItmPort\dotNetMF.proj" />
+    </ItemGroup>
+    <ItemGroup>
         <PlatformIndependentLibs Include="TinybooterLib.$(LIB_EXT)" />
         <RequiredProjects Include="$(SPOCLIENT)\Application\TinyBooter\TinyBooterLib.proj" />
     </ItemGroup>
@@ -87,8 +91,8 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Drivers\Stubs\Processor\stubs_SPI\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="STM32F4_USART.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_USART\dotNetMF.proj" />
+        <DriverLibs Include="cpu_usart_stubs.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Drivers\Stubs\processor\stubs_USART\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="STM32F4_USB.$(LIB_EXT)" />
@@ -131,8 +135,8 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\PAL\COM\I2C\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="usart_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\PAL\COM\USART\dotNetMF.proj" />
+        <DriverLibs Include="usart_pal_stubs.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\PAL\COM\USART\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="usb_pal.$(LIB_EXT)" />

--- a/Solutions/STM32F4DISCOVERY/TinyCLR/TinyCLR.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyCLR/TinyCLR.proj
@@ -66,6 +66,10 @@
     <Import Condition="'$(WINDOWS_DEVICES_FEATUREPROJ)'==''" Project="$(SPOCLIENT)\Framework\Features\Windows_Devices.featureproj" />
     <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Interop.Settings" />
     <ItemGroup>
+        <DriverLibs Include="CortexMx_ItmPort.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Cores\arm\Processors\CortexMx\ItmPort\dotNetMF.proj" />
+    </ItemGroup>
+    <ItemGroup>
         <DriverLibs Include="LargeBuffer_hal_stubs.$(LIB_EXT)" />
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\drivers\LargeBuffer\stubs\dotnetmf.proj" />
     </ItemGroup>

--- a/Solutions/STM32F4DISCOVERY/platform_selector.h
+++ b/Solutions/STM32F4DISCOVERY/platform_selector.h
@@ -80,13 +80,16 @@
 
 #define INSTRUMENTATION_H_GPIO_PIN      GPIO_PIN_NONE
 
-#define TOTAL_USART_PORT                7 // ITM0 + 6 physical UARTS
+#define TOTAL_USART_PORT                6 // 6 physical UARTS
 
 #define USART_DEFAULT_PORT              COM1
 #define USART_DEFAULT_BAUDRATE          115200
 
+#define TOTAL_GENERIC_PORTS             1 // 1 generic port extensions (ITM channel 0 )
+#define ITM_GENERIC_PORTNUM             0 // ITM0 is index 0 in generic port interface table
+
 #define DEBUG_TEXT_PORT                 ITM0
-#define STDIO                           USB1
+#define STDIO                           ITM0
 #define DEBUGGER_PORT                   USB1
 #define MESSAGING_PORT                  USB1
 


### PR DESCRIPTION
This is implementation of ITM virtual port fix #223 for the STM32F4DISCOVERY solution. TinyBooter diagnostic output (STDIO) is set to ITM0, USART driver and PAL replaced with stubs (now both GCC and MDK binaries fit into 32 KB).