### PR TITLE
Support to build VS integration directly in VS2015

### DIFF
--- a/Framework/CorDebug/VsPackage.cs
+++ b/Framework/CorDebug/VsPackage.cs
@@ -63,7 +63,6 @@ namespace Microsoft.SPOT.Debugger
                           , TemplateIDsVsTemplate=VsPackage.VbTemplateIds
                           )
     ]
-    [ProvideExpressLoadKey( "4.3.0.0", "Microsoft .NET Micro Framework SDK", "Microsoft Corporation", VsWinExpressId=1001 )]
     [ProvideObject( typeof( PropertyPageComObject ) )]
     [ProvideObject( typeof( CorDebug ) )]
     [ProvideDebugEngine]

--- a/Framework/CorDebug/vs12/cordebugvs12.csproj
+++ b/Framework/CorDebug/vs12/cordebugvs12.csproj
@@ -181,6 +181,12 @@
     <ProjectReference Include="..\..\Debugger\Debugger.csproj">
       <Project>{d9dca6fb-680f-4355-abef-128db02721e6}</Project>
       <Name>Debugger</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Debugger\WinUsb\WinUsb.csproj">
+      <Project>{daeb83a4-5868-4725-a15d-85f75db87eac}</Project>
+      <Name>WinUsb</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>

--- a/Framework/CorDebug/vs12/source.extension.vsixmanifest
+++ b/Framework/CorDebug/vs12/source.extension.vsixmanifest
@@ -13,7 +13,6 @@
     </Metadata>
     <Installation InstalledByMsi="false">
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[12.0,13.0)" />
-        <InstallationTarget Version="[12.0,13.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />

--- a/Framework/CorDebug/vs14/cordebugvs14.csproj
+++ b/Framework/CorDebug/vs14/cordebugvs14.csproj
@@ -188,6 +188,12 @@
     <ProjectReference Include="..\..\Debugger\Debugger.csproj">
       <Project>{d9dca6fb-680f-4355-abef-128db02721e6}</Project>
       <Name>Debugger</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="..\..\Debugger\WinUsb\WinUsb.csproj">
+      <Project>{daeb83a4-5868-4725-a15d-85f75db87eac}</Project>
+      <Name>WinUsb</Name>
+      <Private>False</Private>
     </ProjectReference>
   </ItemGroup>
   <PropertyGroup>

--- a/Framework/CorDebug/vs14/cordebugvs14.sln
+++ b/Framework/CorDebug/vs14/cordebugvs14.sln
@@ -1,21 +1,37 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.22823.1
+VisualStudioVersion = 14.0.23107.0
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cordebugvs14", "cordebugvs14.csproj", "{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExeTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\CSharp\ExeTemplate\ExeTemplateProject.csproj", "{08FF08A7-6883-4875-BBC5-5F9405D59B4D}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\CSharp\LibTemplate\LibTemplateProject.csproj", "{0F0DFBB2-249D-4769-BF7D-29885153CF87}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\CSharp\WinTemplate\WinTemplateProject.csproj", "{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetmfVS14", "NetmfVS14.csproj", "{F15F8516-14E8-4CE2-8810-59CB869E1C38}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "cordebugvs14", "cordebugvs14.csproj", "{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Debugger", "..\..\Debugger\Debugger.csproj", "{D9DCA6FB-680F-4355-ABEF-128DB02721E6}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinUsb", "..\..\Debugger\WinUsb\WinUsb.csproj", "{DAEB83A4-5868-4725-A15D-85F75DB87EAC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClassTemplateProject", "..\..\..\Product\AllSDK\ItemTemplates\CSharp\Class\ClassTemplateProject.csproj", "{32FD8868-BC4E-4810-B811-66CF6B38FA02}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExeTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\CSharp\ExeTemplate\ExeTemplateProject.csproj", "{08FF08A7-6883-4875-BBC5-5F9405D59B4D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WinTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\CSharp\WinTemplate\WinTemplateProject.csproj", "{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LibTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\CSharp\LibTemplate\LibTemplateProject.csproj", "{0F0DFBB2-249D-4769-BF7D-29885153CF87}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CSharp Templates", "CSharp Templates", "{77AA22F3-7971-4C7D-B741-BE7D58CA5B0B}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "VB Templates", "VB Templates", "{B38D2886-E83D-416F-BA54-03AA6378E508}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBClassTemplateProject", "..\..\..\Product\AllSDK\ItemTemplates\VisualBasic\Class\VBClassTemplateProject.csproj", "{64BB93E1-F7F1-425E-89BF-1BDECEF523AC}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBExeTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\VB\ExeTemplate\VBExeTemplateProject.csproj", "{898B220F-11FF-400D-B40C-588CF06DF856}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBLibTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\VB\LibTemplate\VBLibTemplateProject.csproj", "{BC660833-4208-4D3E-B744-4AD17D502F8E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "VBWinTemplateProject", "..\..\..\Product\AllSDK\ProjectTemplates\VB\WinTemplate\VBWinTemplateProject.csproj", "{517662A3-1886-4811-818E-AB0333447656}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AssemblyInfoTemplateProject", "..\..\..\Product\AllSDK\ItemTemplates\CSharp\AssemblyInfo\AssemblyInfoTemplateProject.csproj", "{422D820B-8B80-4FF1-9828-3AB113C2ABC0}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,36 +39,71 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Debug|Any CPU.ActiveCfg = Release|Any CPU
-		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Debug|Any CPU.Build.0 = Release|Any CPU
-		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Release|Any CPU.Build.0 = Release|Any CPU
-		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Release|Any CPU.Build.0 = Release|Any CPU
 		{F15F8516-14E8-4CE2-8810-59CB869E1C38}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F15F8516-14E8-4CE2-8810-59CB869E1C38}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F15F8516-14E8-4CE2-8810-59CB869E1C38}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F15F8516-14E8-4CE2-8810-59CB869E1C38}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4C10D84-59C4-48EE-A62B-9DA56A2E9681}.Release|Any CPU.Build.0 = Release|Any CPU
 		{D9DCA6FB-680F-4355-ABEF-128DB02721E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D9DCA6FB-680F-4355-ABEF-128DB02721E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D9DCA6FB-680F-4355-ABEF-128DB02721E6}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{D9DCA6FB-680F-4355-ABEF-128DB02721E6}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{D9DCA6FB-680F-4355-ABEF-128DB02721E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D9DCA6FB-680F-4355-ABEF-128DB02721E6}.Release|Any CPU.Build.0 = Release|Any CPU
 		{DAEB83A4-5868-4725-A15D-85F75DB87EAC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DAEB83A4-5868-4725-A15D-85F75DB87EAC}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DAEB83A4-5868-4725-A15D-85F75DB87EAC}.Release|Any CPU.ActiveCfg = Debug|Any CPU
-		{DAEB83A4-5868-4725-A15D-85F75DB87EAC}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{DAEB83A4-5868-4725-A15D-85F75DB87EAC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DAEB83A4-5868-4725-A15D-85F75DB87EAC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{32FD8868-BC4E-4810-B811-66CF6B38FA02}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{32FD8868-BC4E-4810-B811-66CF6B38FA02}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{32FD8868-BC4E-4810-B811-66CF6B38FA02}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{32FD8868-BC4E-4810-B811-66CF6B38FA02}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08FF08A7-6883-4875-BBC5-5F9405D59B4D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0F0DFBB2-249D-4769-BF7D-29885153CF87}.Release|Any CPU.Build.0 = Release|Any CPU
+		{64BB93E1-F7F1-425E-89BF-1BDECEF523AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{64BB93E1-F7F1-425E-89BF-1BDECEF523AC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{64BB93E1-F7F1-425E-89BF-1BDECEF523AC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{64BB93E1-F7F1-425E-89BF-1BDECEF523AC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{898B220F-11FF-400D-B40C-588CF06DF856}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{898B220F-11FF-400D-B40C-588CF06DF856}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{898B220F-11FF-400D-B40C-588CF06DF856}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{898B220F-11FF-400D-B40C-588CF06DF856}.Release|Any CPU.Build.0 = Release|Any CPU
+		{BC660833-4208-4D3E-B744-4AD17D502F8E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{BC660833-4208-4D3E-B744-4AD17D502F8E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{BC660833-4208-4D3E-B744-4AD17D502F8E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{BC660833-4208-4D3E-B744-4AD17D502F8E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{517662A3-1886-4811-818E-AB0333447656}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{517662A3-1886-4811-818E-AB0333447656}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{517662A3-1886-4811-818E-AB0333447656}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{517662A3-1886-4811-818E-AB0333447656}.Release|Any CPU.Build.0 = Release|Any CPU
+		{422D820B-8B80-4FF1-9828-3AB113C2ABC0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{422D820B-8B80-4FF1-9828-3AB113C2ABC0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{422D820B-8B80-4FF1-9828-3AB113C2ABC0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{422D820B-8B80-4FF1-9828-3AB113C2ABC0}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{32FD8868-BC4E-4810-B811-66CF6B38FA02} = {77AA22F3-7971-4C7D-B741-BE7D58CA5B0B}
+		{08FF08A7-6883-4875-BBC5-5F9405D59B4D} = {77AA22F3-7971-4C7D-B741-BE7D58CA5B0B}
+		{D300D44B-0B0F-450F-B4A1-D4DCE9590F88} = {77AA22F3-7971-4C7D-B741-BE7D58CA5B0B}
+		{0F0DFBB2-249D-4769-BF7D-29885153CF87} = {77AA22F3-7971-4C7D-B741-BE7D58CA5B0B}
+		{64BB93E1-F7F1-425E-89BF-1BDECEF523AC} = {B38D2886-E83D-416F-BA54-03AA6378E508}
+		{898B220F-11FF-400D-B40C-588CF06DF856} = {B38D2886-E83D-416F-BA54-03AA6378E508}
+		{BC660833-4208-4D3E-B744-4AD17D502F8E} = {B38D2886-E83D-416F-BA54-03AA6378E508}
+		{517662A3-1886-4811-818E-AB0333447656} = {B38D2886-E83D-416F-BA54-03AA6378E508}
+		{422D820B-8B80-4FF1-9828-3AB113C2ABC0} = {77AA22F3-7971-4C7D-B741-BE7D58CA5B0B}
 	EndGlobalSection
 EndGlobal

--- a/Framework/CorDebug/vs14/source.extension.vsixmanifest
+++ b/Framework/CorDebug/vs14/source.extension.vsixmanifest
@@ -3,7 +3,7 @@
     <Metadata>
         <Identity Id="Microsoft.NETMF.CoreDebug.vs14" Version="4.4.0.0" Language="en-US" Publisher="Microsoft" />
         <DisplayName>.NET Micro Framework project system</DisplayName>
-        <Description xml:space="preserve">Visual Studio Next(VS14 CTP) Project System for the .NET Micro Framework</Description>
+        <Description xml:space="preserve">Visual Studio 2015 Project System for the .NET Micro Framework</Description>
         <MoreInfo>http://www.netmf.com</MoreInfo>
         <License>License.rtf</License>
         <GettingStartedGuide>http://www.netmf.com</GettingStartedGuide>
@@ -13,7 +13,6 @@
     </Metadata>
     <Installation InstalledByMsi="false">
         <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="[14.0,15.0)" />
-        <InstallationTarget Version="[12.0,13.0)" Id="Microsoft.VisualStudio.VSWinDesktopExpress" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -21,7 +20,7 @@
     </Dependencies>
     <Assets>
         <Asset Type="Microsoft.VisualStudio.ProjectTemplate" Path="ProjectTemplates" />
-        <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="ItemTemplates" />        
+        <Asset Type="Microsoft.VisualStudio.ItemTemplate" Path="ItemTemplates" />
         <Asset Type="Microsoft.VisualStudio.VsPackage" Path="Microsoft.SPOT.Debugger.CorDebug.14.pkgdef" />
     </Assets>
 </PackageManifest>

--- a/Framework/Debugger/Debugger.csproj
+++ b/Framework/Debugger/Debugger.csproj
@@ -24,6 +24,7 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <RunCodeAnalysis>false</RunCodeAnalysis>
@@ -32,6 +33,18 @@
 -->
     <CodeAnalysisRuleSet>Debugger.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisIgnoreGeneratedCode>false</CodeAnalysisIgnoreGeneratedCode>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>,1591,1668,1762</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisIgnoreGeneratedCode>false</CodeAnalysisIgnoreGeneratedCode>
+    <CodeAnalysisRuleSet>Debugger.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AbortHandler.cs" />
@@ -103,11 +116,11 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="Microsoft.SPOT.Tasks">
       <HintPath>$(BUILD_TREE_SERVER)\DLL\Microsoft.SPOT.Tasks.dll</HintPath>
-      <Private>true</Private>
+      <Private>false</Private>
     </Reference>
     <Reference Include="WinUsbInvoke">
       <HintPath>$(BUILD_TREE_SERVER)\DLL\WinUsbInvoke.dll</HintPath>
-      <Private>true</Private>
+      <Private>false</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Framework/Debugger/WinUsb/WinUsb.csproj
+++ b/Framework/Debugger/WinUsb/WinUsb.csproj
@@ -1,26 +1,38 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="12.0">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-    <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyName>WinUsbInvoke</AssemblyName>
+    <OutputType>Library</OutputType>
+    <RootNamespace>WinUsb</RootNamespace>
+    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+    <ProjectGuid>{DAEB83A4-5868-4725-A15D-85F75DB87EAC}</ProjectGuid>
+    <ComponentGuid>{aa03c31f-e697-4668-9206-3b2cc39e8a44}</ComponentGuid>
+    <DirectoryRef>ToolsDir</DirectoryRef>
+    <AssemblyType>Library</AssemblyType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
     <SccProjectName>SAK</SccProjectName>
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <OutDir>$(BUILD_TREE_SERVER)\DLL\</OutDir>
   </PropertyGroup>
-  <PropertyGroup>
-    <ProductVersion>9.0.21022</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{DAEB83A4-5868-4725-A15D-85F75DB87EAC}</ProjectGuid>
-    <ProjectTypeGuids>{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <ComponentGuid>{aa03c31f-e697-4668-9206-3b2cc39e8a44}</ComponentGuid>
-    <DirectoryRef>ToolsDir</DirectoryRef>
-    <OutputType>Library</OutputType>
-    <AssemblyType>Library</AssemblyType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>WinUsb</RootNamespace>
-    <AssemblyName>WinUsbInvoke</AssemblyName>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugSymbols>true</DebugSymbols>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>,1668,1762</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Framework/Tools/BuildTasks.sln
+++ b/Framework/Tools/BuildTasks.sln
@@ -1,0 +1,46 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.22823.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildSignerSpotBuild", "BuildTasksInternal\BuildSigner\BuildSignerSpotBuild.csproj", "{1A12104F-10D3-4746-8798-6D0DCDC5F58C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InternalBuildTasks", "BuildTasksInternal\InternalBuildTasks.csproj", "{04903C08-F89B-4CF0-A25F-E3D541542146}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BuildTasks", "BuildTasks\BuildTasks.csproj", "{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WixLibSpotBuild", "WiXLib\WixLibSpotBuild.csproj", "{4F18A5F1-08F2-4E7A-8F8C-7BAB5BFED12F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NativeBuildTasks", "BuildTasksNativeBuild\NativeBuildTasks.csproj", "{7B8DD39E-B0AA-47FC-B30B-B777CF840695}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1A12104F-10D3-4746-8798-6D0DCDC5F58C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A12104F-10D3-4746-8798-6D0DCDC5F58C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A12104F-10D3-4746-8798-6D0DCDC5F58C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A12104F-10D3-4746-8798-6D0DCDC5F58C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{04903C08-F89B-4CF0-A25F-E3D541542146}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{04903C08-F89B-4CF0-A25F-E3D541542146}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{04903C08-F89B-4CF0-A25F-E3D541542146}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{04903C08-F89B-4CF0-A25F-E3D541542146}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F18A5F1-08F2-4E7A-8F8C-7BAB5BFED12F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F18A5F1-08F2-4E7A-8F8C-7BAB5BFED12F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F18A5F1-08F2-4E7A-8F8C-7BAB5BFED12F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F18A5F1-08F2-4E7A-8F8C-7BAB5BFED12F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B8DD39E-B0AA-47FC-B30B-B777CF840695}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B8DD39E-B0AA-47FC-B30B-B777CF840695}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B8DD39E-B0AA-47FC-B30B-B777CF840695}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B8DD39E-B0AA-47FC-B30B-B777CF840695}.Release|Any CPU.Build.0 = Debug|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Framework/Tools/BuildTasks/BuildTasks.csproj
+++ b/Framework/Tools/BuildTasks/BuildTasks.csproj
@@ -1,87 +1,104 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-    <PropertyGroup>
-        <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-        <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
-        <SccProjectName>SAK</SccProjectName>
-        <SccLocalPath>SAK</SccLocalPath>
-        <SccAuxPath>SAK</SccAuxPath>
-        <SccProvider>SAK</SccProvider>
-    </PropertyGroup>
-    <PropertyGroup>
-        <AssemblyName>Microsoft.SPOT.Tasks</AssemblyName>
-        <OutputType>Library</OutputType>
-        <RootNamespace>Microsoft.SPOT.Tasks</RootNamespace>
-        <ProjectTypeGuids>{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <ProjectGuid>{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}</ProjectGuid>
-    </PropertyGroup>
-    <PropertyGroup>
-        <ComponentGuid>{3f32ca8e-2457-4a72-b076-63ce714022ee}</ComponentGuid>
-        <DirectoryRef>ToolsDir</DirectoryRef>
-    </PropertyGroup>
-    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-        <!--    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet> -->
-    </PropertyGroup>
-    <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
-    <ItemGroup>
-        <Compile Include="BuildTaskResources.Designer.cs">
-            <AutoGen>True</AutoGen>
-            <DesignTime>True</DesignTime>
-            <DependentUpon>BuildTaskResources.resx</DependentUpon>
-        </Compile>
-        <Compile Include="CreateInteropFeatureProj.cs" />
-        <Compile Include="GenerateAssemblyInfoFile.cs" />
-        <Compile Include="GenerateReleaseInfo.cs" />
-        <Compile Include="GenerateResource.cs" />
-        <Compile Include="GetDeviceFrameworkPath.cs" />
-        <Compile Include="MetaDataProcessor.cs" />
-        <Compile Include="RegisterEmulator.cs" />
-        <Compile Include="ResolveRuntimeDependencies.cs" />
-        <Compile Include="ScatterFile.cs" />
-        <Compile Include="ProcessScatterFile.cs" />
-        <Compile Include="RVDSLinkerScript.cs" />
-        <Compile Include="GCCLinkerScript.cs" />
-        <Compile Include="CreateLibManifest.cs" />
-        <Compile Include="SetEnvironmentVariable.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="Microsoft.Build" />
-        <Reference Include="Microsoft.Build.Engine" />
-        <Reference Include="Microsoft.Build.Framework" />
-        <Reference Include="Microsoft.Build.Tasks.v4.0" />
-        <Reference Include="Microsoft.Build.Utilities.v4.0" />
-        <Reference Include="System" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Drawing" />
-        <Reference Include="System.Windows.Forms" />
-    </ItemGroup>
-    <ItemGroup>
-        <AppDesigner Include="Properties\" />
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="Microsoft.SPOT.Tasks.Internal">
-            <HintPath Condition="!EXISTS('$(BUILD_TREE_SERVER)\DLL\Microsoft.SPOT.Tasks.Internal.dll')">$(SPOCLIENT)\tools\build\Microsoft.SPOT.Tasks.Internal.dll</HintPath>
-            <HintPath Condition=" EXISTS('$(BUILD_TREE_SERVER)\DLL\Microsoft.SPOT.Tasks.Internal.dll')">$(BUILD_TREE_SERVER)\DLL\Microsoft.SPOT.Tasks.Internal.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Include="BuildTaskResources.resx">
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>BuildTaskResources.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="CsAssemblyInfoTemplate.txt" />
-    </ItemGroup>
-    <ItemGroup>
-        <None Include="VisualBasicAssemblyInfoTemplate.txt" />
-    </ItemGroup>
-    <ItemGroup>
-        <Content Include="ResourceAssemblyInfoTemplate.txt" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyName>Microsoft.SPOT.Tasks</AssemblyName>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.SPOT.Tasks</RootNamespace>
+    <ProjectTypeGuids>{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{9B3D156D-B9D2-4F9C-BFDF-91FC42EE1280}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ComponentGuid>{3f32ca8e-2457-4a72-b076-63ce714022ee}</ComponentGuid>
+    <DirectoryRef>ToolsDir</DirectoryRef>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>TRACE;DEBUG;,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
+  <ItemGroup>
+    <Compile Include="BuildTaskResources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>BuildTaskResources.resx</DependentUpon>
+    </Compile>
+    <Compile Include="CreateInteropFeatureProj.cs" />
+    <Compile Include="GenerateAssemblyInfoFile.cs" />
+    <Compile Include="GenerateReleaseInfo.cs" />
+    <Compile Include="GenerateResource.cs" />
+    <Compile Include="GetDeviceFrameworkPath.cs" />
+    <Compile Include="MetaDataProcessor.cs" />
+    <Compile Include="RegisterEmulator.cs" />
+    <Compile Include="ResolveRuntimeDependencies.cs" />
+    <Compile Include="ScatterFile.cs" />
+    <Compile Include="ProcessScatterFile.cs" />
+    <Compile Include="RVDSLinkerScript.cs" />
+    <Compile Include="GCCLinkerScript.cs" />
+    <Compile Include="CreateLibManifest.cs" />
+    <Compile Include="SetEnvironmentVariable.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+  </ItemGroup>
+  <ItemGroup>
+    <AppDesigner Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="BuildTaskResources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>BuildTaskResources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="CsAssemblyInfoTemplate.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="VisualBasicAssemblyInfoTemplate.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="ResourceAssemblyInfoTemplate.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\BuildTasksInternal\InternalBuildTasks.csproj">
+      <Project>{04903c08-f89b-4cf0-a25f-e3d541542146}</Project>
+      <Name>InternalBuildTasks</Name>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/Framework/Tools/BuildTasksInternal/BuildSigner/BuildSignerSpotBuild.csproj
+++ b/Framework/Tools/BuildTasksInternal/BuildSigner/BuildSignerSpotBuild.csproj
@@ -1,4 +1,6 @@
-﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
@@ -7,6 +9,26 @@
     <RootNamespace>Microsoft.SPOT.AutomatedBuild.BuildSigner</RootNamespace>
     <AssemblyName>Microsoft.SPOT.AutomatedBuild.BuildSigner</AssemblyName>
     <ProjectTypeGuids>{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>TRACE;DEBUG;,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>false</Optimize>
   </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
   <ItemGroup>

--- a/Framework/Tools/BuildTasksInternal/InternalBuildTasks.csproj
+++ b/Framework/Tools/BuildTasksInternal/InternalBuildTasks.csproj
@@ -1,99 +1,131 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-    <PropertyGroup>
-        <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
-        <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
-        <SccProjectName>SAK</SccProjectName>
-        <SccLocalPath>SAK</SccLocalPath>
-        <SccAuxPath>SAK</SccAuxPath>
-        <SccProvider>SAK</SccProvider>
-    </PropertyGroup>
-    <PropertyGroup>
-        <AssemblyName>Microsoft.SPOT.Tasks.Internal</AssemblyName>
-        <OutputType>Library</OutputType>
-        <RootNamespace>Microsoft.SPOT.Tasks.Internal</RootNamespace>
-        <ProjectTypeGuids>{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-        <ProjectGuid>{04903C08-F89B-4CF0-A25F-E3D541542146}</ProjectGuid>
-        <ProductVersion>9.0.21022</ProductVersion>
-        <SchemaVersion>2.0</SchemaVersion>
-    </PropertyGroup>
-    <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
-    <ItemGroup>
-        <Compile Include="BuildTaskUtility.cs" />
-        <Compile Include="CreateZip.cs" />
-        <Compile Include="CharacterReplace.cs" />
-        <Compile Include="CompressSample.cs" />
-        <Compile Include="CreateAssemblyFragment.cs" />
-        <Compile Include="CreateSymbolRequest.cs" />
-        <Compile Include="DirectorySearch.cs" />
-        <Compile Include="FindWixObjects.cs" />
-        <Compile Include="GenerateCLRDefines.cs" />
-        <Compile Include="GenerateFrameworkList.cs" />
-        <Compile Include="GenerateVSTemplate.cs" />
-        <Compile Include="GetGuid.cs" />
-        <Compile Include="GetOrSetXmlAttribute.cs" />
-        <Compile Include="GetProjectFiles.cs" />
-        <Compile Include="ProjectEx.cs" />
-        <Compile Include="RegexReplace.cs" />
-        <Compile Include="ResourceConverter.cs" />
-        <Compile Include="SignMSI.cs" />
-        <Compile Include="SignMSIAssemblies.cs" />
-        <Compile Include="Solution.cs" />
-        <Compile Include="SubmitSymbols.cs" />
-        <Compile Include="TargetLock.cs" />
-        <Compile Include="BBCover.cs" />
-        <Compile Include="CommandRunner.cs" />
-        <Compile Include="CreatePseudoInstallScript.cs" />
-        <Compile Include="BuildTaskResource.Designer.cs">
-            <AutoGen>True</AutoGen>
-            <DesignTime>True</DesignTime>
-            <DependentUpon>BuildTaskResource.resx</DependentUpon>
-        </Compile>
-        <Compile Include="TransmorgificationUtilities.cs" />
-        <Compile Include="TransmorgifyProject.cs" />
-        <Compile Include="TransmorgifyTemplateFiles.cs" />
-    </ItemGroup>
-    <ItemGroup>
-        <EmbeddedResource Include="BuildTaskResource.resx">
-            <SubType>Designer</SubType>
-            <Generator>ResXFileCodeGenerator</Generator>
-            <LastGenOutput>BuildTaskResource.Designer.cs</LastGenOutput>
-        </EmbeddedResource>
-    </ItemGroup>
-    <ItemGroup>
-        <Reference Include="Microsoft.Build" />
-        <Reference Include="Microsoft.Build.Engine" />
-        <Reference Include="Microsoft.Build.Framework" />
-        <Reference Include="Microsoft.Build.Tasks.v4.0" />
-        <Reference Include="Microsoft.Build.Utilities.v4.0" />
-        <Reference Include="System" />
-        <Reference Include="System.Core" />
-        <Reference Include="System.Data" />
-        <Reference Include="System.Windows.Forms" />
-        <Reference Include="System.Xml" />
-        <Reference Include="System.Drawing" />
-        <Reference Include="wix">
-            <Name>wix</Name>
-            <HintPath>$(SPOROOT)\tools\x86\WiX\tools_3_5_1315_0\wix.dll</HintPath>
-            <Private>True</Private>
-        </Reference>
-        <Reference Include="Microsoft.SPOT.WiX">
-            <HintPath>$(BUILD_TREE_DLL)\Microsoft.SPOT.WiX.dll</HintPath>
-        </Reference>
-        <Reference Include="Microsoft.SPOT.AutomatedBuild.BuildSigner">
-            <HintPath>$(BUILD_TREE_DLL)\Microsoft.SPOT.AutomatedBuild.BuildSigner.dll</HintPath>
-        </Reference>
-    </ItemGroup>
-    <ItemGroup>
-        <AppDesigner Include="Properties\" />
-    </ItemGroup>
-    <ItemGroup>
-        <Content Include="depot2sdk.csproj.xslt" />
-        <Content Include="depot2sdk.vbproj.xslt" />
-        <Content Include="SolutionTemplate.txt" />
-    </ItemGroup>
-    <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
+    <SccProjectName>SAK</SccProjectName>
+    <SccLocalPath>SAK</SccLocalPath>
+    <SccAuxPath>SAK</SccAuxPath>
+    <SccProvider>SAK</SccProvider>
+  </PropertyGroup>
+  <PropertyGroup>
+    <AssemblyName>Microsoft.SPOT.Tasks.Internal</AssemblyName>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Microsoft.SPOT.Tasks.Internal</RootNamespace>
+    <ProjectTypeGuids>{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{04903C08-F89B-4CF0-A25F-E3D541542146}</ProjectGuid>
+    <ProductVersion>9.0.21022</ProductVersion>
+    <SchemaVersion>2.0</SchemaVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>TRACE;DEBUG;,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
+  <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
+  <ItemGroup>
+    <Compile Include="BuildTaskUtility.cs" />
+    <Compile Include="CreateZip.cs" />
+    <Compile Include="CharacterReplace.cs" />
+    <Compile Include="CompressSample.cs" />
+    <Compile Include="CreateAssemblyFragment.cs" />
+    <Compile Include="CreateSymbolRequest.cs" />
+    <Compile Include="DirectorySearch.cs" />
+    <Compile Include="FindWixObjects.cs" />
+    <Compile Include="GenerateCLRDefines.cs" />
+    <Compile Include="GenerateFrameworkList.cs" />
+    <Compile Include="GenerateVSTemplate.cs" />
+    <Compile Include="GetGuid.cs" />
+    <Compile Include="GetOrSetXmlAttribute.cs" />
+    <Compile Include="GetProjectFiles.cs" />
+    <Compile Include="ProjectEx.cs" />
+    <Compile Include="RegexReplace.cs" />
+    <Compile Include="ResourceConverter.cs" />
+    <Compile Include="SignMSI.cs" />
+    <Compile Include="SignMSIAssemblies.cs" />
+    <Compile Include="Solution.cs" />
+    <Compile Include="SubmitSymbols.cs" />
+    <Compile Include="TargetLock.cs" />
+    <Compile Include="BBCover.cs" />
+    <Compile Include="CommandRunner.cs" />
+    <Compile Include="CreatePseudoInstallScript.cs" />
+    <Compile Include="BuildTaskResource.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DesignTime>True</DesignTime>
+      <DependentUpon>BuildTaskResource.resx</DependentUpon>
+    </Compile>
+    <Compile Include="TransmorgificationUtilities.cs" />
+    <Compile Include="TransmorgifyProject.cs" />
+    <Compile Include="TransmorgifyTemplateFiles.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="BuildTaskResource.resx">
+      <SubType>Designer</SubType>
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>BuildTaskResource.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.Build" />
+    <Reference Include="Microsoft.Build.Engine" />
+    <Reference Include="Microsoft.Build.Framework" />
+    <Reference Include="Microsoft.Build.Tasks.v4.0" />
+    <Reference Include="Microsoft.Build.Utilities.v4.0" />
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="wix">
+      <Name>wix</Name>
+      <HintPath>$(SPOROOT)\tools\x86\WiX\tools_3_5_1315_0\wix.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.SPOT.WiX">
+      <HintPath>$(BUILD_TREE_DLL)\Microsoft.SPOT.WiX.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.SPOT.AutomatedBuild.BuildSigner">
+      <HintPath>$(BUILD_TREE_DLL)\Microsoft.SPOT.AutomatedBuild.BuildSigner.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <AppDesigner Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="depot2sdk.csproj.xslt" />
+    <Content Include="depot2sdk.vbproj.xslt" />
+    <Content Include="SolutionTemplate.txt" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\WiXLib\WixLibSpotBuild.csproj">
+      <Project>{4f18a5f1-08f2-4e7a-8f8c-7bab5bfed12f}</Project>
+      <Name>WixLibSpotBuild</Name>
+      <Private>False</Private>
+    </ProjectReference>
+    <ProjectReference Include="BuildSigner\BuildSignerSpotBuild.csproj">
+      <Project>{1a12104f-10d3-4746-8798-6d0dcdc5f58c}</Project>
+      <Name>BuildSignerSpotBuild</Name>
+      <Private>False</Private>
+    </ProjectReference>
+  </ItemGroup>
 </Project>

--- a/Framework/Tools/WiXLib/WixLibSpotBuild.csproj
+++ b/Framework/Tools/WiXLib/WixLibSpotBuild.csproj
@@ -1,5 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
-
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.WiX</AssemblyName>
     <OutputType>Library</OutputType>
@@ -7,11 +8,29 @@
     <ProjectTypeGuids>{FAE04EC0-301F-11d3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <ProductVersion>9.0.21022</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{4f18a5f1-08f2-4e7a-8f8c-7bab5bfed12f}</ProjectGuid>
+    <ProjectGuid>{4F18A5F1-08F2-4E7A-8F8C-7BAB5BFED12F}</ProjectGuid>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>pdbonly</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>true</Optimize>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+    <DebugSymbols>true</DebugSymbols>
+    <DefineConstants>TRACE;DEBUG;,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1668,1762</NoWarn>
+    <DebugType>full</DebugType>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <Optimize>false</Optimize>
+  </PropertyGroup>
   <Import Project="$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Host.Targets" />
-
   <ItemGroup>
     <Compile Include="Component.cs" />
     <Compile Include="DirectoryRef.cs" />
@@ -20,7 +39,6 @@
     <Compile Include="Shortcut.cs" />
     <Compile Include="WiXElement.cs" />
   </ItemGroup>
-  
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />

--- a/Framework/Tools/buildTasks.dirproj
+++ b/Framework/Tools/buildTasks.dirproj
@@ -4,11 +4,9 @@
     <TinyCLR_Platform>Server</TinyCLR_Platform>
   </PropertyGroup>
 
-  <ItemGroup Condition="EXISTS('$(SPOCLIENT)\Framework\Tools\BuildTasksInternal\InternalBuildTasks.csproj')">
+  <ItemGroup>
     <Project Include="WiXLib\WixLibSpotBuild.csproj"/>
     <Project Include="BuildTasksInternal\BuildSigner\BuildSignerSpotBuild.csproj"/>
-  </ItemGroup>
-  <ItemGroup>
     <Project Include="BuildTasksInternal\InternalBuildTasks.csproj" Condition="EXISTS('$(SPOCLIENT)\Framework\Tools\BuildTasksInternal\InternalBuildTasks.csproj')"/>
     <Project Include="BuildTasks\BuildTasks.csproj"/>
     <Project Include="BuildTasksNativeBuild\NativeBuildTasks.csproj"/>

--- a/Product/AllSDK/ItemTemplates/CSharp/AssemblyInfo/AssemblyInfoTemplateProject.csproj
+++ b/Product/AllSDK/ItemTemplates/CSharp/AssemblyInfo/AssemblyInfoTemplateProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>AssemblyInfo</NetMFTemplateName>
@@ -9,9 +9,14 @@
     <SccLocalPath>SAK</SccLocalPath>
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>12.0</OldToolsVersion>
   </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,8 +24,8 @@
     <ProjectGuid>{422D820B-8B80-4FF1-9828-3AB113C2ABC0}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>CSAssemblyInfo</RootNamespace>
+    <AssemblyName>CSAssemblyInfo</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>

--- a/Product/AllSDK/ItemTemplates/CSharp/Class/ClassTemplateProject.csproj
+++ b/Product/AllSDK/ItemTemplates/CSharp/Class/ClassTemplateProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>Class</NetMFTemplateName>
@@ -10,8 +10,8 @@
     <SccAuxPath>SAK</SccAuxPath>
     <SccProvider>SAK</SccProvider>
   </PropertyGroup>
-    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-    <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,8 +19,8 @@
     <ProjectGuid>{32FD8868-BC4E-4810-B811-66CF6B38FA02}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>CSClassTemplate</RootNamespace>
+    <AssemblyName>CSClassTemplate</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>

--- a/Product/AllSDK/ItemTemplates/VisualBasic/Class/VBClassTemplateProject.csproj
+++ b/Product/AllSDK/ItemTemplates/VisualBasic/Class/VBClassTemplateProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>Class</NetMFTemplateName>
@@ -11,7 +11,7 @@
     <SccProvider>SAK</SccProvider>
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
-  <!-- Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/ -->
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -19,8 +19,8 @@
     <ProjectGuid>{64BB93E1-F7F1-425E-89BF-1BDECEF523AC}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>VBClassTemplate</RootNamespace>
+    <AssemblyName>VBClassTemplate</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -40,12 +40,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vs71F7.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vs71F7.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/Product/AllSDK/ProjectTemplates/CSharp/EmulatorTemplate/EmulatorTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/CSharp/EmulatorTemplate/EmulatorTemplateProject.csproj
@@ -1,11 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>MFEmulator</NetMFTemplateName>
     <SPOCLIENT Condition="'$(SPOCLIENT)'==''">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), sdk.dirproj))</SPOCLIENT>
+    <FileUpgradeFlags>
+    </FileUpgradeFlags>
+    <UpgradeBackupLocation>
+    </UpgradeBackupLocation>
+    <OldToolsVersion>12.0</OldToolsVersion>
   </PropertyGroup>
   <!-- Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')"/ -->
   <PropertyGroup>
@@ -51,13 +56,12 @@
     <Content Include="Properties\AssemblyInfo.cs" />
     <Content Include="Properties\Resources.Designer.cs" />
     <Content Include="Properties\Resources.resx" />
-	<Content Include="Properties\Settings.Designer.cs" />
-	<Content Include="Properties\Settings.Settings" />
-	<Content Include="Emulator.config" />
-	<Content Include="Form1.cs" />
-	<Content Include="Form1.Designer.cs" />
+    <Content Include="Properties\Settings.Designer.cs" />
+    <Content Include="Properties\Settings.Settings" />
+    <Content Include="Emulator.config" />
+    <Content Include="Form1.cs" />
+    <Content Include="Form1.Designer.cs" />
     <Content Include="Program.cs" />
-	
     <Content Include="$(NetMFTemplateName).csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/Product/AllSDK/ProjectTemplates/CSharp/ExeTemplate/ExeTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/CSharp/ExeTemplate/ExeTemplateProject.csproj
@@ -19,8 +19,8 @@
     <ProjectGuid>{08FF08A7-6883-4875-BBC5-5F9405D59B4D}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>CSMFConsoleApplication</RootNamespace>
+    <AssemblyName>CSMFConsoleApplication</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -40,12 +40,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsAE7C.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsAE7C.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/Product/AllSDK/ProjectTemplates/CSharp/LibTemplate/LibTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/CSharp/LibTemplate/LibTemplateProject.csproj
@@ -19,8 +19,8 @@
     <ProjectGuid>{0F0DFBB2-249D-4769-BF7D-29885153CF87}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>CSMFClassLibrary</RootNamespace>
+    <AssemblyName>CSMFClassLibrary</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -40,12 +40,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsB8E5.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsB8E5.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/Product/AllSDK/ProjectTemplates/CSharp/WinTemplate/WinTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/CSharp/WinTemplate/WinTemplateProject.csproj
@@ -19,8 +19,8 @@
     <ProjectGuid>{D300D44B-0B0F-450F-B4A1-D4DCE9590F88}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>CSMFWindowApplication</RootNamespace>
+    <AssemblyName>CSMFWindowApplication</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>

--- a/Product/AllSDK/ProjectTemplates/VB/ExeTemplate/VBExeTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/VB/ExeTemplate/VBExeTemplateProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>MFConsoleApplication</NetMFTemplateName>
@@ -19,8 +19,8 @@
     <ProjectGuid>{898B220F-11FF-400D-B40C-588CF06DF856}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>VBMFConsoleApplication</RootNamespace>
+    <AssemblyName>VBMFConsoleApplication</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -40,12 +40,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsC76C.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsC76C.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">
@@ -65,6 +63,7 @@
   <ItemGroup>
     <VSTemplate Include="$(NetMFTemplateName).vstemplate">
       <OutputSubPath>Micro Framework</OutputSubPath>
+      <SubType>Designer</SubType>
     </VSTemplate>
   </ItemGroup>
   <ItemGroup />

--- a/Product/AllSDK/ProjectTemplates/VB/LibTemplate/VBLibTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/VB/LibTemplate/VBLibTemplateProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>MFClassLibrary</NetMFTemplateName>
@@ -19,8 +19,8 @@
     <ProjectGuid>{BC660833-4208-4D3E-B744-4AD17D502F8E}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>VBMFClassLibrary</RootNamespace>
+    <AssemblyName>VBMFClassLibrary</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -40,12 +40,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsE99.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vsE99.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/Product/AllSDK/ProjectTemplates/VB/WinTemplate/VBWinTemplateProject.csproj
+++ b/Product/AllSDK/ProjectTemplates/VB/WinTemplate/VBWinTemplateProject.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <MinimumVisualStudioVersion>12.0</MinimumVisualStudioVersion>
+    <MinimumVisualStudioVersion>14.0</MinimumVisualStudioVersion>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">11.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <NetMFTemplateName>MFWindowApplication</NetMFTemplateName>
@@ -19,8 +19,8 @@
     <ProjectGuid>{517662A3-1886-4811-818E-AB0333447656}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>$(NetMFTemplateName)</RootNamespace>
-    <AssemblyName>$(NetMFTemplateName)</AssemblyName>
+    <RootNamespace>VBMFWindowApplication</RootNamespace>
+    <AssemblyName>VBMFWindowApplication</AssemblyName>
     <PlatformTarget>x86</PlatformTarget>
     <Configuration Condition="'$(FLAVOR_WIN)'!=''">$(FLAVOR_WIN)</Configuration>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
@@ -40,12 +40,10 @@
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vs3D9B.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <CreateVsixContainer>False</CreateVsixContainer>
     <DeployExtension>False</DeployExtension>
-    <IntermediateOutputPath>C:\Users\smaillet\AppData\Local\Temp\vs3D9B.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.CoreUtility">

--- a/tools/Targets/Microsoft.SPOT.Build.Common.Targets
+++ b/tools/Targets/Microsoft.SPOT.Build.Common.Targets
@@ -93,7 +93,10 @@
   </Target>
 
   <Target Name="BuildChildren_Build" Condition="'@(Project)'!=''">
+    <Message Importance="high" Text="++$(MSBuildProjectFullPath) Building child projects:"/>
+    <Message Importance="high" Text="    %(Project.Identity)" />
     <MSBuild Projects="@(Project)" Targets="Build" Properties="$(MainProps)" />
+    <Message Importance="high" Text="--$(MSBuildProjectFullPath) Done building child projects"/>
   </Target>
 
   <Target Name="BuildChildren_Disasm" Condition="'@(Project)'!=''">


### PR DESCRIPTION
- removed VS express SKU support as it causes issues with publishing to VS gallery and we don't need it anymore now that the VS community edition is freely available.
- fixed VS14 integration solution and projects to allow build and debug with VS experimental Hive
- added missing buildTasks project to depenencies for VS integration solution
- added missing WinUsb project reference for VS integration
- Resolved circular dependency on build task projects
- removed project references to build task projects as they are needed to build other projects
- Create standalone solution to build the build task projects needed by other projects to allow building them independently of everything else. (NOTE: that msbuild.exe will normally leave an instance of itself running with all previously loaded tasks still loaded. Thus, to build the build tasks it may be required to kill the pending msbuild.exe instance(s) to release the DLLs [It will timeout on it's own after a few minutes as well])
- Added standard project configuration settings to project files
- restored direct <Reference> tags for assemblies since the command line build from Build_sdk won't process ProjectReferences properly (Fixing that is a complete re-write of the build)
- Added some dependency logging to the Common targets file to log child projects to help in tracking dependency issues.
- updated VSIX manifest to official RTM name of Visual Studio 2015
- Fixed solution configuration settings so it doesn't mix debug and release settings on a single solution configuration.
- Fixed WinUsb and Debugger CSPROJ files to set OutDir to the proper build output location