### PR TITLE
Cleanup for cloning

### DIFF
--- a/Application/MicroBooter/MicroBooter.proj
+++ b/Application/MicroBooter/MicroBooter.proj
@@ -13,8 +13,6 @@
     <Groups>MicroBooter</Groups>
     <Documentation>
     </Documentation>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Application/TinyBooter/TinyBooterDecompressorLib.proj
+++ b/Application/TinyBooter/TinyBooterDecompressorLib.proj
@@ -14,8 +14,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>True</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Application/TinyBooter/TinyBooterLib.proj
+++ b/Application/TinyBooter/TinyBooterLib.proj
@@ -14,8 +14,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>True</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/CLR/Core/Hardware/InterruptHandler/dotNetMF.proj
+++ b/CLR/Core/Hardware/InterruptHandler/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>InterruptHandler.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptHandler_CLR" Guid="{E49A8937-C6CD-44E3-B87D-BFB3C57755CA}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptHandler_CLR" Guid="{E49A8937-C6CD-44E3-B87D-BFB3C57755CA}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Hardware/InterruptHandler/dotNetMF_stub.proj
+++ b/CLR/Core/Hardware/InterruptHandler/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>InterruptHandler_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptHandler_CLR" Guid="{E49A8937-C6CD-44E3-B87D-BFB3C57755CA}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptHandler_CLR" Guid="{E49A8937-C6CD-44E3-B87D-BFB3C57755CA}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Hardware/dotNetMF.proj
+++ b/CLR/Core/Hardware/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Hardware.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Hardware_CLR" Guid="{B04A82F3-C442-4edf-91F1-DA3471F2DDDD}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Hardware_CLR" Guid="{B04A82F3-C442-4edf-91F1-DA3471F2DDDD}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Hardware/dotNetMF_stub.proj
+++ b/CLR/Core/Hardware/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Hardware_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Hardware_CLR" Guid="{B04A82F3-C442-4edf-91F1-DA3471F2DDDD}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Hardware_CLR" Guid="{B04A82F3-C442-4edf-91F1-DA3471F2DDDD}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/HeapPersistence/dotNetMF.proj
+++ b/CLR/Core/HeapPersistence/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>HeapPersistence.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Storage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="HeapPersistence_CLR" Guid="{D6BC8826-87C6-4213-9B02-EA60E6CC693E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="HeapPersistence_CLR" Guid="{D6BC8826-87C6-4213-9B02-EA60E6CC693E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/HeapPersistence/dotNetMF_stub.proj
+++ b/CLR/Core/HeapPersistence/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>HeapPersistence_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Storage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="HeapPersistence_CLR" Guid="{D6BC8826-87C6-4213-9B02-EA60E6CC693E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="HeapPersistence_CLR" Guid="{D6BC8826-87C6-4213-9B02-EA60E6CC693E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/I2C/dotNetMF.proj
+++ b/CLR/Core/I2C/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>I2C.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_CLR" Guid="{CE347E4C-378A-4F8B-9749-BD5C4732EDA2}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_CLR" Guid="{CE347E4C-378A-4F8B-9749-BD5C4732EDA2}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/I2C/dotNetMF_stub.proj
+++ b/CLR/Core/I2C/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>I2C_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_CLR" Guid="{CE347E4C-378A-4F8B-9749-BD5C4732EDA2}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_CLR" Guid="{CE347E4C-378A-4F8B-9749-BD5C4732EDA2}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/IOPort/dotNetMF.proj
+++ b/CLR/Core/IOPort/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>IOPort.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="NativeEventDispatcher_CLR" Guid="{97E5C70C-DC05-4D57-B944-0AB77AA1122C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="NativeEventDispatcher_CLR" Guid="{97E5C70C-DC05-4D57-B944-0AB77AA1122C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/IOPort/dotNetMF_stub.proj
+++ b/CLR/Core/IOPort/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>IOPort_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="NativeEventDispatcher_CLR" Guid="{97E5C70C-DC05-4D57-B944-0AB77AA1122C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="NativeEventDispatcher_CLR" Guid="{97E5C70C-DC05-4D57-B944-0AB77AA1122C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/RPC/dotNetMF.proj
+++ b/CLR/Core/RPC/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>RPC.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="RPC_CLR" Guid="{72EABE59-3FEF-4DCF-B541-A3790860A124}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="RPC_CLR" Guid="{72EABE59-3FEF-4DCF-B541-A3790860A124}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/RPC/dotNetMF_stub.proj
+++ b/CLR/Core/RPC/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>RPC_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="RPC_CLR" Guid="{72EABE59-3FEF-4DCF-B541-A3790860A124}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="RPC_CLR" Guid="{72EABE59-3FEF-4DCF-B541-A3790860A124}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Serialization/dotNetMF.proj
+++ b/CLR/Core/Serialization/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Serialization.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Serialization</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Serialization_CLR" Guid="{BC132DB8-6633-4C53-9C08-3A395EBCED0C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Serialization_CLR" Guid="{BC132DB8-6633-4C53-9C08-3A395EBCED0C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Serialization/dotNetMF_stub.proj
+++ b/CLR/Core/Serialization/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Serialization_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Serialization</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Serialization_CLR" Guid="{BC132DB8-6633-4C53-9C08-3A395EBCED0C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Serialization_CLR" Guid="{BC132DB8-6633-4C53-9C08-3A395EBCED0C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Stream/dotNetMF.proj
+++ b/CLR/Core/Stream/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Stream.$(LIB_EXT).manifest</ManifestFile>
     <Groups>IO</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Stream_CLR" Guid="{1B6EB6AA-1D7A-459C-A4A2-A20248101BC0}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Stream_CLR" Guid="{1B6EB6AA-1D7A-459C-A4A2-A20248101BC0}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Core/Stream/dotNetMF_stub.proj
+++ b/CLR/Core/Stream/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Stream_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>IO</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Stream_CLR" Guid="{1B6EB6AA-1D7A-459C-A4A2-A20248101BC0}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Stream_CLR" Guid="{1B6EB6AA-1D7A-459C-A4A2-A20248101BC0}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Debugger/dotNetMF.proj
+++ b/CLR/Debugger/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Debugger.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debugger</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_CLR" Guid="{F7BC2FA2-00B7-4CC3-97E1-7088CECF0C45}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_CLR" Guid="{F7BC2FA2-00B7-4CC3-97E1-7088CECF0C45}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Debugger/dotNetMF_extended.proj
+++ b/CLR/Debugger/dotNetMF_extended.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Debugger_extended.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debugger</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_flavor_CLR" Guid="{ED92B589-EA11-419F-96AC-821F49566DB1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_flavor_CLR" Guid="{ED92B589-EA11-419F-96AC-821F49566DB1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Debugger/dotNetMF_full.proj
+++ b/CLR/Debugger/dotNetMF_full.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Debugger_full.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debugger</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_flavor_CLR" Guid="{ED92B589-EA11-419F-96AC-821F49566DB1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_flavor_CLR" Guid="{ED92B589-EA11-419F-96AC-821F49566DB1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Debugger/dotNetMF_minimal.proj
+++ b/CLR/Debugger/dotNetMF_minimal.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Debugger_minimal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debugger</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_flavor_CLR" Guid="{ED92B589-EA11-419F-96AC-821F49566DB1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_flavor_CLR" Guid="{ED92B589-EA11-419F-96AC-821F49566DB1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Debugger/dotNetMF_stub.proj
+++ b/CLR/Debugger/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Debugger_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debugger</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_CLR" Guid="{F7BC2FA2-00B7-4CC3-97E1-7088CECF0C45}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Debugger_CLR" Guid="{F7BC2FA2-00B7-4CC3-97E1-7088CECF0C45}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Diagnostics/dotNetMF.proj
+++ b/CLR/Diagnostics/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Diagnostics.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Diagnostics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_CLR" Guid="{4E525F0B-5313-4CB2-9C7E-9133C5451FB4}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_CLR" Guid="{4E525F0B-5313-4CB2-9C7E-9133C5451FB4}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Diagnostics/dotNetMF_stub.proj
+++ b/CLR/Diagnostics/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Diagnostics_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Diagnostics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_CLR" Guid="{4E525F0B-5313-4CB2-9C7E-9133C5451FB4}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_CLR" Guid="{4E525F0B-5313-4CB2-9C7E-9133C5451FB4}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/Bmp/dotNetMF.proj
+++ b/CLR/Graphics/Bmp/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_Bmp.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_BMP_CLR" Guid="{D62FE1D7-09E2-4B30-80AD-D724DACDADA5}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_BMP_CLR" Guid="{D62FE1D7-09E2-4B30-80AD-D724DACDADA5}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/Bmp/dotNetMF_stub.proj
+++ b/CLR/Graphics/Bmp/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_Bmp_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_BMP_CLR" Guid="{D62FE1D7-09E2-4B30-80AD-D724DACDADA5}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_BMP_CLR" Guid="{D62FE1D7-09E2-4B30-80AD-D724DACDADA5}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/Gif/dotNetMF.proj
+++ b/CLR/Graphics/Gif/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_Gif.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_GIF_CLR" Guid="{E44003AC-2692-4343-A0D0-FA58BC2C2C31}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_GIF_CLR" Guid="{E44003AC-2692-4343-A0D0-FA58BC2C2C31}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/Gif/dotNetMF_stub.proj
+++ b/CLR/Graphics/Gif/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_Gif_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_GIF_CLR" Guid="{E44003AC-2692-4343-A0D0-FA58BC2C2C31}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_GIF_CLR" Guid="{E44003AC-2692-4343-A0D0-FA58BC2C2C31}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/Jpeg/dotNetMF.proj
+++ b/CLR/Graphics/Jpeg/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_Jpeg.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_JPG_CLR" Guid="{F7A2D3C6-F6A5-4102-9D94-0E0079442872}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_JPG_CLR" Guid="{F7A2D3C6-F6A5-4102-9D94-0E0079442872}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/Jpeg/dotNetMF_stub.proj
+++ b/CLR/Graphics/Jpeg/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_Jpeg_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_JPG_CLR" Guid="{F7A2D3C6-F6A5-4102-9D94-0E0079442872}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_JPG_CLR" Guid="{F7A2D3C6-F6A5-4102-9D94-0E0079442872}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/dotNetMF.proj
+++ b/CLR/Graphics/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_CLR" Guid="{F3485ACA-D80E-4881-B142-A9121193D95F}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_CLR" Guid="{F3485ACA-D80E-4881-B142-A9121193D95F}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Graphics/dotNetMF_stub.proj
+++ b/CLR/Graphics/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Graphics_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_CLR" Guid="{F3485ACA-D80E-4881-B142-A9121193D95F}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_CLR" Guid="{F3485ACA-D80E-4881-B142-A9121193D95F}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT/SPOT_Messaging/dotNetMF.proj
+++ b/CLR/Libraries/SPOT/SPOT_Messaging/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Messaging.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Messaging_CLR" Guid="{DB9E2EA5-712E-485A-AED5-9A944B99B86C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Messaging_CLR" Guid="{DB9E2EA5-712E-485A-AED5-9A944B99B86C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT/SPOT_Messaging/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT/SPOT_Messaging/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Messaging_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Messaging_CLR" Guid="{DB9E2EA5-712E-485A-AED5-9A944B99B86C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Messaging_CLR" Guid="{DB9E2EA5-712E-485A-AED5-9A944B99B86C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT/SPOT_Serialization/dotNetMF.proj
+++ b/CLR/Libraries/SPOT/SPOT_Serialization/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Serialization.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Serialization</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Serialization_CLR" Guid="{5944DE0A-3A13-401E-A853-1C01341B4752}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Serialization_CLR" Guid="{5944DE0A-3A13-401E-A853-1C01341B4752}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT/SPOT_Serialization/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT/SPOT_Serialization/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Serialization_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Serialization</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Serialization_CLR" Guid="{5944DE0A-3A13-401E-A853-1C01341B4752}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Serialization_CLR" Guid="{5944DE0A-3A13-401E-A853-1C01341B4752}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Graphics/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Graphics/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Graphics.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Graphics_CLR" Guid="{6E04CE5E-46B5-4608-9CA3-6E17842DA36F}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Graphics_CLR" Guid="{6E04CE5E-46B5-4608-9CA3-6E17842DA36F}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Graphics/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Graphics/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Graphics_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Graphics_CLR" Guid="{6E04CE5E-46B5-4608-9CA3-6E17842DA36F}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Graphics_CLR" Guid="{6E04CE5E-46B5-4608-9CA3-6E17842DA36F}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>SPOT_Hardware_OneWire.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_OneWire_CLR" Guid="{49949C30-83BE-4812-B689-130A6D43A4A3}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_OneWire_CLR" Guid="{49949C30-83BE-4812-B689-130A6D43A4A3}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF.proj
@@ -31,8 +31,6 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <HasLibraryCategory>True</HasLibraryCategory>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>CLR\Libraries\SPOT_Hardware\SPOT_OneWire</Directory>
     <OutputType>Library</OutputType>
     <VCProjName>Lib_SPOT_Hardware_OneWire</VCProjName>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF_stub.proj
@@ -11,7 +11,7 @@
     <ManifestFile>SPOT_Hardware_OneWire_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_OneWire_CLR" Guid="{49949C30-83BE-4812-B689-130A6D43A4A3}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_OneWire_CLR" Guid="{49949C30-83BE-4812-B689-130A6D43A4A3}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/dotNetMF_stub.proj
@@ -31,8 +31,6 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>True</IsStub>
     <HasLibraryCategory>True</HasLibraryCategory>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>CLR\Libraries\SPOT_Hardware\SPOT_OneWire</Directory>
     <OutputType>Library</OutputType>
     <VCProjName>Lib_SPOT_Hardware_OneWire</VCProjName>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF.proj
@@ -32,8 +32,6 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <HasLibraryCategory>True</HasLibraryCategory>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>CLR\Libraries\SPOT_Hardware\SPOT_serial</Directory>
     <OutputType>Library</OutputType>
     <VCProjName>Lib_SPOT_Hardware_SerialPort</VCProjName>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Hardware_SerialPort.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_Serial_CLR" Guid="{FE9B7E92-76BC-484C-93D1-D31D3C3CEC65}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_Serial_CLR" Guid="{FE9B7E92-76BC-484C-93D1-D31D3C3CEC65}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Hardware_SerialPort_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_Serial_CLR" Guid="{FE9B7E92-76BC-484C-93D1-D31D3C3CEC65}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_Serial_CLR" Guid="{FE9B7E92-76BC-484C-93D1-D31D3C3CEC65}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_Serial/dotNetMF_stub.proj
@@ -32,8 +32,6 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>True</IsStub>
     <HasLibraryCategory>True</HasLibraryCategory>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>CLR\Libraries\SPOT_Hardware\SPOT_Serial</Directory>
     <OutputType>Library</OutputType>
     <VCProjName>Lib_SPOT_Hardware_SerialPort_stub</VCProjName>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_Usb/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_Usb/dotNetMF.proj
@@ -36,8 +36,6 @@
     <IsStub>False</IsStub>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
     <HasLibraryCategory>True</HasLibraryCategory>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>CLR\Libraries\SPOT_Hardware\SPOT_Usb</Directory>
     <OutputType>Library</OutputType>
     <VCProjName>Lib_SPOT_Hardware</VCProjName>

--- a/CLR/Libraries/SPOT_Hardware/SPOT_Usb/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_Usb/dotNetMF_stub.proj
@@ -36,8 +36,6 @@
     <IsStub>True</IsStub>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
     <HasLibraryCategory>True</HasLibraryCategory>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>CLR\Libraries\SPOT_Hardware\SPOT_Usb</Directory>
     <OutputType>Library</OutputType>
     <VCProjName>Lib_SPOT_Hardware_Usb_stub</VCProjName>

--- a/CLR/Libraries/SPOT_Hardware/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Hardware/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Hardware.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_CLR" Guid="{0403BA1B-73CE-45F8-8C65-0BBA5E1F7176}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_CLR" Guid="{0403BA1B-73CE-45F8-8C65-0BBA5E1F7176}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Hardware/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Hardware/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Hardware_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Hardware</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_CLR" Guid="{0403BA1B-73CE-45F8-8C65-0BBA5E1F7176}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Hardware_CLR" Guid="{0403BA1B-73CE-45F8-8C65-0BBA5E1F7176}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_IO/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_IO/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_IO.$(LIB_EXT).manifest</ManifestFile>
     <Groups>IO</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_IO_CLR" Guid="{BE315479-72F7-4C61-8DDF-F08424A0B0E3}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_IO_CLR" Guid="{BE315479-72F7-4C61-8DDF-F08424A0B0E3}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_IO/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_IO/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_IO_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>IO</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_IO_CLR" Guid="{BE315479-72F7-4C61-8DDF-F08424A0B0E3}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_IO_CLR" Guid="{BE315479-72F7-4C61-8DDF-F08424A0B0E3}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Net/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Net/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Net.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_CLR" Guid="{CC7F14B8-899B-4952-9447-567FB1276F55}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_CLR" Guid="{CC7F14B8-899B-4952-9447-567FB1276F55}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Net/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Net/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Net_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_CLR" Guid="{CC7F14B8-899B-4952-9447-567FB1276F55}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_CLR" Guid="{CC7F14B8-899B-4952-9447-567FB1276F55}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Net_Security/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Net_Security/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Net_Security.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_Security_CLR" Guid="{F2293567-5089-478B-8808-CA66EBDA7F06}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_Security_CLR" Guid="{F2293567-5089-478B-8808-CA66EBDA7F06}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Net_Security/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Net_Security/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Net_Security_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_Security_CLR" Guid="{F2293567-5089-478B-8808-CA66EBDA7F06}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Net_Security_CLR" Guid="{F2293567-5089-478B-8808-CA66EBDA7F06}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_TimeService/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_TimeService/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_TimeService.$(LIB_EXT).manifest</ManifestFile>
     <Groups>TimeService</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_TimeService_CLR" Guid="{D2494B68-C8A7-4aad-A087-C17FF83DF840}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_TimeService_CLR" Guid="{D2494B68-C8A7-4aad-A087-C17FF83DF840}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_TimeService/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_TimeService/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_TimeService_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_TimeService_CLR" Guid="{D2494B68-C8A7-4aad-A087-C17FF83DF840}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_TimeService_CLR" Guid="{D2494B68-C8A7-4aad-A087-C17FF83DF840}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Touch/dotNetMF.proj
+++ b/CLR/Libraries/SPOT_Touch/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Touch.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Touch_CLR" Guid="{AE2B7179-9F3F-411C-9CE7-46F4278C9AB1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Touch_CLR" Guid="{AE2B7179-9F3F-411C-9CE7-46F4278C9AB1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Libraries/SPOT_Touch/dotNetMF_stub.proj
+++ b/CLR/Libraries/SPOT_Touch/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPOT_Touch_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Touch_CLR" Guid="{AE2B7179-9F3F-411C-9CE7-46F4278C9AB1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPOT_Touch_CLR" Guid="{AE2B7179-9F3F-411C-9CE7-46F4278C9AB1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Messaging/dotNetMF.proj
+++ b/CLR/Messaging/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Messaging.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Messaging_CLR" Guid="{5EC01C82-A2F2-4A0F-B412-C8451F0EC70C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Messaging_CLR" Guid="{5EC01C82-A2F2-4A0F-B412-C8451F0EC70C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CLR/Messaging/dotNetMF_stub.proj
+++ b/CLR/Messaging/dotNetMF_stub.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Messaging_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Messaging_CLR" Guid="{5EC01C82-A2F2-4A0F-B412-C8451F0EC70C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Messaging_CLR" Guid="{5EC01C82-A2F2-4A0F-B412-C8451F0EC70C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/CMSIS/CMSIS/RTOS/RTX/dotNetMF.proj
+++ b/CMSIS/CMSIS/RTOS/RTX/dotNetMF.proj
@@ -12,7 +12,7 @@
         <ManifestFile>CMSIS_RTX.$(LIB_EXT).manifest</ManifestFile>
         <Groups>OS\CMSIS_RTOS</Groups>
         <LibraryCategory>
-            <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="OS" Guid="{F0C31986-B463-437E-9814-EDAB2BE46109}" ProjectPath="" Conditional="" xmlns="">
+            <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="OS" Guid="{F0C31986-B463-437E-9814-EDAB2BE46109}" Conditional="" xmlns="">
                 <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
             </MFComponent>
         </LibraryCategory>

--- a/DeviceCode/Cores/arm/Processors/CortexMx/TinyHal/dotNetMF.proj
+++ b/DeviceCode/Cores/arm/Processors/CortexMx/TinyHal/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>TinyHal_Cortex.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL_Cortex" Guid="{37C37BC0-3CA6-4C1C-A26F-4761A7BA3C05}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL_Cortex" Guid="{37C37BC0-3CA6-4C1C-A26F-4761A7BA3C05}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Cores/arm/Processors/CortexMx/TinyHal/dotNetMF_loader.proj
+++ b/DeviceCode/Cores/arm/Processors/CortexMx/TinyHal/dotNetMF_loader.proj
@@ -11,7 +11,7 @@
     <ManifestFile>TinyHal_loader_Cortex.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL_Cortex" Guid="{00EC00D8-0033-0051-8B5A-918BF68043EF}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL_Cortex" Guid="{00EC00D8-0033-0051-8B5A-918BF68043EF}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Backlight/GPIO/dotNetMF.proj
+++ b/DeviceCode/Drivers/Backlight/GPIO/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>gpio_backlight.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Backlight</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_HAL" Guid="{3431C48D-5ED3-4896-8F85-110D2D09CDBD}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_HAL" Guid="{3431C48D-5ED3-4896-8F85-110D2D09CDBD}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Backlight/SPI/dotNetMF.proj
+++ b/DeviceCode/Drivers/Backlight/SPI/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>spi_backlight.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Backlight</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_HAL" Guid="{3431C48D-5ED3-4896-8F85-110D2D09CDBD}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_HAL" Guid="{3431C48D-5ED3-4896-8F85-110D2D09CDBD}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Backlight/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/Backlight/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>backlight_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Backlight</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_HAL" Guid="{3431C48D-5ED3-4896-8F85-110D2D09CDBD}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_HAL" Guid="{3431C48D-5ED3-4896-8F85-110D2D09CDBD}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryCharger/Charger_DualStatus/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryCharger/Charger_DualStatus/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Charger_DualStatus.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryCharger_HAL" Guid="{381CBCC8-A737-4DD2-A821-6ABF0F908305}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryCharger_HAL" Guid="{381CBCC8-A737-4DD2-A821-6ABF0F908305}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryCharger/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryCharger/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterycharger_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryCharger_HAL" Guid="{381CBCC8-A737-4DD2-A821-6ABF0F908305}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryCharger_HAL" Guid="{381CBCC8-A737-4DD2-A821-6ABF0F908305}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryMeasurement/AD7466/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryMeasurement/AD7466/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>AD7466.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryMeasurement_HAL" Guid="{DE74246C-056C-4CCE-A37E-8C900F645076}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryMeasurement_HAL" Guid="{DE74246C-056C-4CCE-A37E-8C900F645076}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryMeasurement/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryMeasurement/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymeasurement_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryMeasurement_HAL" Guid="{DE74246C-056C-4CCE-A37E-8C900F645076}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryMeasurement_HAL" Guid="{DE74246C-056C-4CCE-A37E-8C900F645076}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/IML200425_2/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/IML200425_2/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_IML200425_2.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/ML1A_2/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/ML1A_2/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_ML1A_2.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/ML2_2/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/ML2_2/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_ML2_2.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/ML3_2/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/ML3_2/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_ML3_2.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/MR11_2367/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/MR11_2367/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_Mr11_2367.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/PD2430/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/PD2430/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_Pd2430.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/PD3032/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/PD3032/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_Pd3032.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BatteryModel/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/BatteryModel/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>batterymodel_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BatteryModel_HAL" Guid="{114C68EB-FDAB-4691-8630-E7DBF31D7F3D}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BlockStorage/Flash/AM29DL_16/dotNetMF.proj
+++ b/DeviceCode/Drivers/BlockStorage/Flash/AM29DL_16/dotNetMF.proj
@@ -20,7 +20,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>1</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BlockStorage/Flash/AM29DL_32/dotNetMF.proj
+++ b/DeviceCode/Drivers/BlockStorage/Flash/AM29DL_32/dotNetMF.proj
@@ -20,7 +20,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BlockStorage/Flash/I28F_16/dotNetMF.proj
+++ b/DeviceCode/Drivers/BlockStorage/Flash/I28F_16/dotNetMF.proj
@@ -20,7 +20,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BlockStorage/Flash/SST39WF_16/dotNetMF.proj
+++ b/DeviceCode/Drivers/BlockStorage/Flash/SST39WF_16/dotNetMF.proj
@@ -20,7 +20,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BlockStorage/SD/Stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/BlockStorage/SD/Stubs/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ProjectPath>$(SPOCLIENT)\DeviceCode\Drivers\Blockstorage\SD\stubs\dotNetMF.proj</ProjectPath>
     <Groups>BlockStorage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SDConfig_HAL" Guid="{55D65695-3439-42fc-A727-15802883E1CC}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SDConfig_HAL" Guid="{55D65695-3439-42fc-A727-15802883E1CC}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/BlockStorage/WearLeveling/dotNetMF.proj
+++ b/DeviceCode/Drivers/BlockStorage/WearLeveling/dotNetMF.proj
@@ -20,7 +20,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="WearLeveling_HAL" Guid="{8A00410F-E25A-443d-839B-738EB3EA5833}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="WearLeveling_HAL" Guid="{8A00410F-E25A-443d-839B-738EB3EA5833}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/A025DL02/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/A025DL02/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>A025DL02.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/A025DL02/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/A025DL02/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>A025DL02_Config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="A025DL02_Config_HAL" Guid="{437A877C-77A1-4ced-8F07-F599EDDB202C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="A025DL02_Config_HAL" Guid="{437A877C-77A1-4ced-8F07-F599EDDB202C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/HD66773R/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/HD66773R/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>HD66773R.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>1</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/LQ035Q7DB02/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/LQ035Q7DB02/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>LQ035Q7DB02.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/SSD1289/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/SSD1289/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>SSD1289.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/TD022SHEB2/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TD022SHEB2/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TD022SHEB2.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/TD035STEB1/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TD035STEB1/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TD035STEB1.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/TX09D71VM1CCA/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TX09D71VM1CCA/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TX09D71VM1CCA.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/TX09D71VM1CCA/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TX09D71VM1CCA/stubs/dotNetMF.proj
@@ -35,8 +35,6 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>True</IsStub>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
-    <CustomSpecific>
-    </CustomSpecific>
     <Directory>DeviceCode\Drivers\Display\TX09D71VM1CCA\stubs</Directory>
     <OutputType>Library</OutputType>
     <PlatformIndependentBuild>false</PlatformIndependentBuild>

--- a/DeviceCode/Drivers/Display/TextFonts/Font8x15/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TextFonts/Font8x15/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>Display_Font8x15.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Display_Font_HAL" Guid="{7910B444-6A1B-4C80-ABBD-3160BF15AB22}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Display_Font_HAL" Guid="{7910B444-6A1B-4C80-ABBD-3160BF15AB22}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/TextFonts/Font8x8/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/TextFonts/Font8x8/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>Display_Font8x8.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Display_Font_HAL" Guid="{7910B444-6A1B-4C80-ABBD-3160BF15AB22}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Display_Font_HAL" Guid="{7910B444-6A1B-4C80-ABBD-3160BF15AB22}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Display/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/Display/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>lcd_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCD_HAL" Guid="{9F6063F2-7ED0-49F7-95A3-2A2D2219EEAB}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Ethernet/enc28j60/dotNetMF.proj
+++ b/DeviceCode/Drivers/Ethernet/enc28j60/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ETHERNET_enc28j60.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Ethernet/enc28j60_lwip/dotNetMF.proj
+++ b/DeviceCode/Drivers/Ethernet/enc28j60_lwip/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ETHERNET_enc28j60.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Ethernet/loopback/dotNetMF.proj
+++ b/DeviceCode/Drivers/Ethernet/loopback/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ETHERNET_loopback.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetLoopback_HAL" Guid="{63642AC7-9164-48AA-AC2D-524D6FBE21CE}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetLoopback_HAL" Guid="{63642AC7-9164-48AA-AC2D-524D6FBE21CE}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Ethernet/loopback_lwip/dotNetMF.proj
+++ b/DeviceCode/Drivers/Ethernet/loopback_lwip/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ETHERNET_loopback_lwip.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetLoopback_HAL" Guid="{63642AC7-9164-48AA-AC2D-524D6FBE21CE}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetLoopback_HAL" Guid="{63642AC7-9164-48AA-AC2D-524D6FBE21CE}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/FS/FAT/dotNetMF.proj
+++ b/DeviceCode/Drivers/FS/FAT/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>FS_FAT.$(LIB_EXT).manifest</ManifestFile>
     <Groups>FileSystem</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_HAL" Guid="{44AE482B-2B33-4247-B160-EB58EEA8063A}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_HAL" Guid="{44AE482B-2B33-4247-B160-EB58EEA8063A}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/FS/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/FS/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>FS_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>FileSystem</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_HAL" Guid="{44AE482B-2B33-4247-B160-EB58EEA8063A}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_HAL" Guid="{44AE482B-2B33-4247-B160-EB58EEA8063A}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/LargeBuffer/Stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/LargeBuffer/Stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>LargeBuffer_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LargeBuffer_HAL" Guid="{BFCCBFAA-10EA-48d6-AB9F-C22438533E9E}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LargeBuffer_HAL" Guid="{BFCCBFAA-10EA-48d6-AB9F-C22438533E9E}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>3</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/LargeBuffer/Test/dotNetMF.proj
+++ b/DeviceCode/Drivers/LargeBuffer/Test/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>LargeBuffer_hal_test.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LargeBuffer_HAL" Guid="{BFCCBFAA-10EA-48d6-AB9F-C22438533E9E}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LargeBuffer_HAL" Guid="{BFCCBFAA-10EA-48d6-AB9F-C22438533E9E}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>3</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Sample/Backlight/SPI/SPI_Backlight_config.proj
+++ b/DeviceCode/Drivers/Sample/Backlight/SPI/SPI_Backlight_config.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SPI_Backlight_Config.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Backlight\Sample</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_config_HAL" Guid="{97CD7AE6-EC5F-466E-9E9F-FB6FF570853B}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_config_HAL" Guid="{97CD7AE6-EC5F-466E-9E9F-FB6FF570853B}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Sample/Display/A025DL02/A025DL02_config.proj
+++ b/DeviceCode/Drivers/Sample/Display/A025DL02/A025DL02_config.proj
@@ -12,7 +12,7 @@
     <ManifestFile>A025DL02_Config.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Sample/Display/LQ035Q7DB02/LQ035Q7DB02_config.proj
+++ b/DeviceCode/Drivers/Sample/Display/LQ035Q7DB02/LQ035Q7DB02_config.proj
@@ -12,7 +12,7 @@
     <ManifestFile>LQ035Q7DB02_Config.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Sample/Display/TD022SHEB2/TD022SHEB2_config.proj
+++ b/DeviceCode/Drivers/Sample/Display/TD022SHEB2/TD022SHEB2_config.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TD022SHEB2_Config.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display\Sample</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Sample/Display/TD035STEB1/TD035STEB1_config.proj
+++ b/DeviceCode/Drivers/Sample/Display/TD035STEB1/TD035STEB1_config.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TD035STEB1_Config.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display\Sample</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Backlight/GPIO/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Backlight/GPIO/dotNetMF.proj
@@ -13,7 +13,7 @@
     <ManifestFile>GPIO_Backlight_Config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Backlight</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_GPIO_config_HAL" Guid="{C7F4D6E8-A4E2-4B1C-9133-F8AD8B54581E}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_GPIO_config_HAL" Guid="{C7F4D6E8-A4E2-4B1C-9133-F8AD8B54581E}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Backlight/SPI/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Backlight/SPI/dotNetMF.proj
@@ -13,7 +13,7 @@
     <ManifestFile>SPI_Backlight_Config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Backlight</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_SPI_config_HAL" Guid="{97CD7AE6-EC5F-466E-9E9F-FB6FF570853B}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Backlight_SPI_config_HAL" Guid="{97CD7AE6-EC5F-466E-9E9F-FB6FF570853B}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/BlockStorage/AddDevices/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/BlockStorage/AddDevices/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ProjectPath>$(SPOCLIENT)\DeviceCode\drivers\stubs\Blockstorage\addDevices\dotNetMF.proj</ProjectPath>
     <Groups>BlockStorage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageAddDevices_HAL" Guid="{D1C1D946-18A1-4f12-807A-A182C4059D86}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageAddDevices_HAL" Guid="{D1C1D946-18A1-4f12-807A-A182C4059D86}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/BlockStorage/Config/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/BlockStorage/Config/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ProjectPath>$(SPOCLIENT)\DeviceCode\Drivers\stubs\Blockstorage\Config\dotNetMF.proj</ProjectPath>
     <Groups>BlockStorage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Display/LCDController/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Display/LCDController/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>LCDController_Config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Display</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_Config_HAL" Guid="{616E5384-4D7D-4299-A98F-BD5C887693BC}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/GlobalLock/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/GlobalLock/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>GlobalLock_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GlobalLock_HAL" Guid="{922F4FB8-850A-4DA1-9308-18F117BCA656}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GlobalLock_HAL" Guid="{922F4FB8-850A-4DA1-9308-18F117BCA656}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Network/Config/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Network/Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Network_config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Network_Config_HAL" Guid="{14DA2330-C44D-4F5B-AE85-534E24AEC5B2}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Network_Config_HAL" Guid="{14DA2330-C44D-4F5B-AE85-534E24AEC5B2}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Network/Ethernet/ENC28J60_Config/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Network/Ethernet/ENC28J60_Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ENC28J60_config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network\ENC28J60</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="ENC28J60_Config_HAL" Guid="{57018C75-E2DB-4726-B275-A7C24F8EF388}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="ENC28J60_Config_HAL" Guid="{57018C75-E2DB-4726-B275-A7C24F8EF388}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Network/Ethernet/ENC28J60_LWIP_Config/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Network/Ethernet/ENC28J60_LWIP_Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ENC28J60_LWIP_config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network\ENC28J60</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="ENC28J60_Config_LWIP_HAL" Guid="{DD104859-675B-41E8-9885-092EBEDE8309}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="ENC28J60_Config_LWIP_HAL" Guid="{DD104859-675B-41E8-9885-092EBEDE8309}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Network/Ethernet/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Network/Ethernet/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ethernetdriver_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Network/Loopback/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Network/Loopback/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ETHERNET_loopback_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetLoopback_HAL" Guid="{63642AC7-9164-48AA-AC2D-524D6FBE21CE}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetLoopback_HAL" Guid="{63642AC7-9164-48AA-AC2D-524D6FBE21CE}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_DA/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_DA/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_DA_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Analog_DA_HAL" Guid="{54DABCD1-8C9D-485c-8C48-8ECEE7D27454}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Analog_DA_HAL" Guid="{54DABCD1-8C9D-485c-8C48-8ECEE7D27454}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_DMA/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_DMA/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_dma_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="DMA_HAL" Guid="{E16D3D03-A668-4609-9DF0-0279761DD1F3}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="DMA_HAL" Guid="{E16D3D03-A668-4609-9DF0-0279761DD1F3}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_EBIU/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_EBIU/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_ebiu_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EBIU_HAL" Guid="{C5A1CBF5-5A1A-409E-B8D5-CEF0CBF4E571}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EBIU_HAL" Guid="{C5A1CBF5-5A1A-409E-B8D5-CEF0CBF4E571}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_I2C/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_I2C/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_i2c_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_HAL" Guid="{718988E9-6E5B-4A91-A3A6-B4BD777AA998}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_HAL" Guid="{718988E9-6E5B-4A91-A3A6-B4BD777AA998}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_INTC/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_INTC/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_intc_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptController_HAL" Guid="{08148BEE-6B1F-4050-AA21-510CA7F2FF98}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptController_HAL" Guid="{08148BEE-6B1F-4050-AA21-510CA7F2FF98}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_LCD/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_LCD/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_LCD_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_HAL" Guid="{33387DE1-392B-4467-88FB-6E7299420E99}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LCDController_HAL" Guid="{33387DE1-392B-4467-88FB-6E7299420E99}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_MMU/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_MMU/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_mmu_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="MMU_HAL" Guid="{5A321647-9897-48FA-BA76-0361A369F87C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="MMU_HAL" Guid="{5A321647-9897-48FA-BA76-0361A369F87C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_PCU/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_PCU/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_pcu_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PCU_HAL" Guid="{9FAB2A04-7B32-4E3C-BF5E-DB478C032029}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PCU_HAL" Guid="{9FAB2A04-7B32-4E3C-BF5E-DB478C032029}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_PWM/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_PWM/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_pwm_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PWM_HAL" Guid="{53DABCD1-8C9D-485c-8C48-8ECEE7D27453}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PWM_HAL" Guid="{53DABCD1-8C9D-485c-8C48-8ECEE7D27453}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_PerfCounter/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_PerfCounter/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_performancecounter_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PerformanceCounter_HAL" Guid="{B5F79C0F-4657-47CE-B4CC-91EB1BFE4BDC}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PerformanceCounter_HAL" Guid="{B5F79C0F-4657-47CE-B4CC-91EB1BFE4BDC}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_PreStackInit/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_PreStackInit/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>cpu_prestackinit_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PreStackInit_HAL" Guid="{5A9E3217-7D6D-40de-A685-28BA44D31E9A}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PreStackInit_HAL" Guid="{5A9E3217-7D6D-40de-A685-28BA44D31E9A}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_SPI/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_SPI/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_spi_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPI_HAL" Guid="{705CCD97-0A0F-410D-B535-78B862D742B1}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPI_HAL" Guid="{705CCD97-0A0F-410D-B535-78B862D742B1}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_USART/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_USART/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_usart_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_HAL" Guid="{D85D3BB5-7C82-496D-B7CD-489AAD0F8484}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_HAL" Guid="{D85D3BB5-7C82-496D-B7CD-489AAD0F8484}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_USB/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_USB/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_usb_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_WATCHDOG/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_WATCHDOG/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_watchdog_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Watchdog_HAL" Guid="{692ae099-7a29-4eef-bd2e-5bb2ccce9f87}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Watchdog_HAL" Guid="{692ae099-7a29-4eef-bd2e-5bb2ccce9f87}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_analog/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_analog/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_analog_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="analog_HAL" Guid="{99DABCD1-8C9D-485c-8C48-8ECEE7D27499}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="analog_HAL" Guid="{99DABCD1-8C9D-485c-8C48-8ECEE7D27499}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_bootstrap/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_bootstrap/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_bootstrap_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Bootstrap_HAL" Guid="{15AB3FEB-4D7A-40AD-B1A0-4BF663A6EF93}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Bootstrap_HAL" Guid="{15AB3FEB-4D7A-40AD-B1A0-4BF663A6EF93}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_cache/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_cache/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>cpu_cache_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Cache_HAL" Guid="{A2A79401-1EB1-4A05-A857-A49E041F6D42}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Cache_HAL" Guid="{A2A79401-1EB1-4A05-A857-A49E041F6D42}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_cmu/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_cmu/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_cmu_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="CMU_HAL" Guid="{BF3D0C85-D50D-43BE-AFEA-C72A9C834664}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="CMU_HAL" Guid="{BF3D0C85-D50D-43BE-AFEA-C72A9C834664}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_gpio/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_gpio/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_gpio_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GPIO_HAL" Guid="{33AB74F7-8DD4-4766-95A8-E221B80F611C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GPIO_HAL" Guid="{33AB74F7-8DD4-4766-95A8-E221B80F611C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_power/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_power/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_power_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Power_HAL" Guid="{9FF2AE69-79CF-4C0B-8732-F813272EC8C5}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Power_HAL" Guid="{9FF2AE69-79CF-4C0B-8732-F813272EC8C5}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/Processor/stubs_time/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_time/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>cpu_time_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/TempForGCC/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/TempForGCC/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>gcc_hal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/TouchPanel/Config/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/TouchPanel/Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TouchPanel_Config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_Config_HAL" Guid="{757A56B0-8619-4BDB-97FB-C6EFB2338BA8}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_Config_HAL" Guid="{757A56B0-8619-4BDB-97FB-C6EFB2338BA8}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/USB_Config/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/USB_Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>usb_pal_config_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Stubs/VirtualKey/dotNetMF.proj
+++ b/DeviceCode/Drivers/Stubs/VirtualKey/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>virtualkey_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>VirtualKey</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="VirtualKey_HAL" Guid="{38306596-D3F6-49D2-95AD-C9D0C47C92D5}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="VirtualKey_HAL" Guid="{38306596-D3F6-49D2-95AD-C9D0C47C92D5}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Thermistor/dotNetMF.proj
+++ b/DeviceCode/Drivers/Thermistor/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Thermistor.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Thermistor_HAL" Guid="{005E7165-B501-4F4D-949D-9AC48AA408EC}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Thermistor_HAL" Guid="{005E7165-B501-4F4D-949D-9AC48AA408EC}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/Thermistor/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/Thermistor/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>thermistor_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Battery\stubs</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Thermistor_HAL" Guid="{005E7165-B501-4F4D-949D-9AC48AA408EC}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Thermistor_HAL" Guid="{005E7165-B501-4F4D-949D-9AC48AA408EC}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/TouchPanel/ADS7843/dotNetMF.proj
+++ b/DeviceCode/Drivers/TouchPanel/ADS7843/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ADS7843.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_HAL" Guid="{257467FB-F3EC-4E66-81C7-5A2095D0D447}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_HAL" Guid="{257467FB-F3EC-4E66-81C7-5A2095D0D447}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/TouchPanel/TSC2046/dotNetMF.proj
+++ b/DeviceCode/Drivers/TouchPanel/TSC2046/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TSC2046.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_HAL" Guid="{257467FB-F3EC-4E66-81C7-5A2095D0D447}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_HAL" Guid="{257467FB-F3EC-4E66-81C7-5A2095D0D447}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/TouchPanel/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/TouchPanel/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>touchpanel_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_HAL" Guid="{257467FB-F3EC-4E66-81C7-5A2095D0D447}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchScreen_HAL" Guid="{257467FB-F3EC-4E66-81C7-5A2095D0D447}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Drivers/sockets/stubs/dotNetMF.proj
+++ b/DeviceCode/Drivers/sockets/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>sockets_hal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_HAL" Guid="{3AF2F099-7D6F-47BC-9227-4D8DA598AF43}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_HAL" Guid="{3AF2F099-7D6F-47BC-9227-4D8DA598AF43}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Initialization/dotNetMF.proj
+++ b/DeviceCode/Initialization/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>system_initialization_hal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Initialization/dotNetMF_loader.proj
+++ b/DeviceCode/Initialization/dotNetMF_loader.proj
@@ -11,7 +11,7 @@
     <ManifestFile>system_initialization_hal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Analog/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Analog/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="analog_HAL" Guid="{99DABCD1-8C9D-485c-8C48-8ECEE7D27499}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="analog_HAL" Guid="{99DABCD1-8C9D-485c-8C48-8ECEE7D27499}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Bootstrap/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Bootstrap/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Bootstrap_HAL" Guid="{15AB3FEB-4D7A-40AD-B1A0-4BF663A6EF93}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Bootstrap_HAL" Guid="{15AB3FEB-4D7A-40AD-B1A0-4BF663A6EF93}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_DA/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_DA/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Analog_DA_HAL" Guid="{54DABCD1-8C9D-485c-8C48-8ECEE7D27454}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Analog_DA_HAL" Guid="{54DABCD1-8C9D-485c-8C48-8ECEE7D27454}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Flash/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Flash/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_GPIO/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_GPIO/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GPIO_HAL" Guid="{33AB74F7-8DD4-4766-95A8-E221B80F611C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GPIO_HAL" Guid="{33AB74F7-8DD4-4766-95A8-E221B80F611C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_I2C/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_I2C/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_HAL" Guid="{718988E9-6E5B-4A91-A3A6-B4BD777AA998}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_HAL" Guid="{718988E9-6E5B-4A91-A3A6-B4BD777AA998}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_IntC/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_IntC/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptController_HAL" Guid="{08148BEE-6B1F-4050-AA21-510CA7F2FF98}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptController_HAL" Guid="{08148BEE-6B1F-4050-AA21-510CA7F2FF98}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_PWM/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_PWM/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PWM_HAL" Guid="{53DABCD1-8C9D-485c-8C48-8ECEE7D27453}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PWM_HAL" Guid="{53DABCD1-8C9D-485c-8C48-8ECEE7D27453}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Power/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Power/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Power_HAL" Guid="{9FF2AE69-79CF-4C0B-8732-F813272EC8C5}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Power_HAL" Guid="{9FF2AE69-79CF-4C0B-8732-F813272EC8C5}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_SPI/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_SPI/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPI_HAL" Guid="{705CCD97-0A0F-410D-B535-78B862D742B1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPI_HAL" Guid="{705CCD97-0A0F-410D-B535-78B862D742B1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Time/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_Time/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_USART/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_USART/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_HAL" Guid="{D85D3BB5-7C82-496D-B7CD-489AAD0F8484}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_HAL" Guid="{D85D3BB5-7C82-496D-B7CD-489AAD0F8484}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_USB/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_USB/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Analog/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="analog_HAL" Guid="{99DABCD1-8C9D-485c-8C48-8ECEE7D27499}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="analog_HAL" Guid="{99DABCD1-8C9D-485c-8C48-8ECEE7D27499}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Bootstrap/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Bootstrap/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Bootstrap_HAL" Guid="{15AB3FEB-4D7A-40AD-B1A0-4BF663A6EF93}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Bootstrap_HAL" Guid="{15AB3FEB-4D7A-40AD-B1A0-4BF663A6EF93}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_DA/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_DA/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Analog_DA_HAL" Guid="{54DABCD1-8C9D-485c-8C48-8ECEE7D27454}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Analog_DA_HAL" Guid="{54DABCD1-8C9D-485c-8C48-8ECEE7D27454}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_ETH_lwip_OS/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>STM32F4_ETH_lwip_os.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\STM32F4</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="EthernetDriver_HAL" Guid="{7FD79853-56A2-4CB8-843B-57939B7468F4}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/dotNetMF_x9.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/dotNetMF_x9.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1E}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_GPIO/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_GPIO/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GPIO_HAL" Guid="{33AB74F7-8DD4-4766-95A8-E221B80F611C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="GPIO_HAL" Guid="{33AB74F7-8DD4-4766-95A8-E221B80F611C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_I2C/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_I2C/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_HAL" Guid="{718988E9-6E5B-4A91-A3A6-B4BD777AA998}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_HAL" Guid="{718988E9-6E5B-4A91-A3A6-B4BD777AA998}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_IntC/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_IntC/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptController_HAL" Guid="{08148BEE-6B1F-4050-AA21-510CA7F2FF98}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="InterruptController_HAL" Guid="{08148BEE-6B1F-4050-AA21-510CA7F2FF98}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_PWM/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_PWM/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PWM_HAL" Guid="{53DABCD1-8C9D-485c-8C48-8ECEE7D27453}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PWM_HAL" Guid="{53DABCD1-8C9D-485c-8C48-8ECEE7D27453}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Power/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Power/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Power_HAL" Guid="{9FF2AE69-79CF-4C0B-8732-F813272EC8C5}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Power_HAL" Guid="{9FF2AE69-79CF-4C0B-8732-F813272EC8C5}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_RTC/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_RTC/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Random/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Random/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Random_HAL" Guid="{00850090-00A0-0060-9C83-444778DDBE82}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Random_HAL" Guid="{00850090-00A0-0060-9C83-444778DDBE82}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_SPI/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_SPI/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPI_HAL" Guid="{705CCD97-0A0F-410D-B535-78B862D742B1}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SPI_HAL" Guid="{705CCD97-0A0F-410D-B535-78B862D742B1}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Time/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Time/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Time_HAL" Guid="{5E34988C-B17B-48F5-B849-A612F3DE93B9}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_USART/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_USART/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_HAL" Guid="{D85D3BB5-7C82-496D-B7CD-489AAD0F8484}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_HAL" Guid="{D85D3BB5-7C82-496D-B7CD-489AAD0F8484}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_USB/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_USB/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_security/dotNetMF.proj
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_security/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Security_HAL" Guid="{41BB0D3E-2800-488A-B0B9-A453932205CF}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Security_HAL" Guid="{41BB0D3E-2800-488A-B0B9-A453932205CF}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/Targets/OS/CMSIS_RTOS/DeviceCode/lwip_1_4_1_os/arch/dotNetMF.proj
+++ b/DeviceCode/Targets/OS/CMSIS_RTOS/DeviceCode/lwip_1_4_1_os/arch/dotNetMF.proj
@@ -11,7 +11,7 @@
         <Documentation />
         <Groups>Network</Groups>
         <LibraryCategory>
-          <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LWIP_SysArch" Guid="{1E8D7B61-F062-45B2-A1E3-790DB1C6F4BA}" ProjectPath="" Conditional="" xmlns="">
+          <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="LWIP_SysArch" Guid="{1E8D7B61-F062-45B2-A1E3-790DB1C6F4BA}" Conditional="" xmlns="">
             <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
           </MFComponent>
         </LibraryCategory>

--- a/DeviceCode/pal/AsyncProcCall/dotNetMF.proj
+++ b/DeviceCode/pal/AsyncProcCall/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>asyncproccall_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Threading</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="AsyncProc_PAL" Guid="{2B215A8E-3692-4AED-B5AA-2A3BBBEF77A1}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="AsyncProc_PAL" Guid="{2B215A8E-3692-4AED-B5AA-2A3BBBEF77A1}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/AsyncProcCall/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/AsyncProcCall/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>asyncproccall_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Threading</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="AsyncProc_PAL" Guid="{2B215A8E-3692-4AED-B5AA-2A3BBBEF77A1}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="AsyncProc_PAL" Guid="{2B215A8E-3692-4AED-B5AA-2A3BBBEF77A1}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/BlockStorage/dotNetMF.proj
+++ b/DeviceCode/pal/BlockStorage/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>blockstorage_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Storage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_PAL" Guid="{762EA1E3-8DDC-480A-A6C7-4A6F1998B30A}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_PAL" Guid="{762EA1E3-8DDC-480A-A6C7-4A6F1998B30A}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/BlockStorage/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/BlockStorage/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>blockstorage_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Storage</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_PAL" Guid="{762EA1E3-8DDC-480A-A6C7-4A6F1998B30A}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_PAL" Guid="{762EA1E3-8DDC-480A-A6C7-4A6F1998B30A}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Buttons/dotNetMF.proj
+++ b/DeviceCode/pal/Buttons/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Buttons_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Buttons</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Buttons_PAL" Guid="{B383D746-6B38-40B5-841A-409CB239A00F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Buttons_PAL" Guid="{B383D746-6B38-40B5-841A-409CB239A00F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Buttons/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/Buttons/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Buttons_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Buttons</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Buttons_PAL" Guid="{B383D746-6B38-40B5-841A-409CB239A00F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Buttons_PAL" Guid="{B383D746-6B38-40B5-841A-409CB239A00F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/dotNetMF.proj
+++ b/DeviceCode/pal/COM/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>COM_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="COM_PAL" Guid="{C951E04C-4A79-47CF-82A4-1DA8E2F3E073}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="COM_PAL" Guid="{C951E04C-4A79-47CF-82A4-1DA8E2F3E073}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/i2c/dotNetMF.proj
+++ b/DeviceCode/pal/COM/i2c/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>i2c_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>I2C</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_PAL" Guid="{C59B06DB-3D96-4A47-94AA-CA5C30B4A2C1}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_PAL" Guid="{C59B06DB-3D96-4A47-94AA-CA5C30B4A2C1}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/i2c/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/COM/i2c/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>i2c_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>I2C</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_PAL" Guid="{C59B06DB-3D96-4A47-94AA-CA5C30B4A2C1}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="I2C_PAL" Guid="{C59B06DB-3D96-4A47-94AA-CA5C30B4A2C1}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/sockets/Ssl/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/COM/sockets/Ssl/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ssl_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SSL_PAL" Guid="{61CDC260-7D46-4660-826F-D212AC8B7608}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SSL_PAL" Guid="{61CDC260-7D46-4660-826F-D212AC8B7608}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/sockets/openssl/dotNetMF.proj
+++ b/DeviceCode/pal/COM/sockets/openssl/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>openssl_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SSL_PAL" Guid="{61CDC260-7D46-4660-826F-D212AC8B7608}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SSL_PAL" Guid="{61CDC260-7D46-4660-826F-D212AC8B7608}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/sockets/openssl/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/COM/sockets/openssl/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ssl_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SSL_PAL" Guid="{61CDC260-7D46-4660-826F-D212AC8B7608}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SSL_PAL" Guid="{61CDC260-7D46-4660-826F-D212AC8B7608}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/COM/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>COM_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Communication</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="COM_PAL" Guid="{C951E04C-4A79-47CF-82A4-1DA8E2F3E073}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="COM_PAL" Guid="{C951E04C-4A79-47CF-82A4-1DA8E2F3E073}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/usart/dotNetMF.proj
+++ b/DeviceCode/pal/COM/usart/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>usart_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USART</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_PAL" Guid="{7468E981-2091-407B-ABAC-5F24649E0EE8}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_PAL" Guid="{7468E981-2091-407B-ABAC-5F24649E0EE8}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/usart/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/COM/usart/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>usart_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USART</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_PAL" Guid="{7468E981-2091-407B-ABAC-5F24649E0EE8}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USART_PAL" Guid="{7468E981-2091-407B-ABAC-5F24649E0EE8}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/usb/dotNetMF.proj
+++ b/DeviceCode/pal/COM/usb/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>usb_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_PAL" Guid="{A25658BA-4C02-45bb-AD8C-191DCD99D8F0}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_PAL" Guid="{A25658BA-4C02-45bb-AD8C-191DCD99D8F0}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/COM/usb/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/COM/usb/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>usb_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_PAL" Guid="{A25658BA-4C02-45BB-AD8C-191DCD99D8F0}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_PAL" Guid="{A25658BA-4C02-45BB-AD8C-191DCD99D8F0}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Diagnostics/dotNetMF.proj
+++ b/DeviceCode/pal/Diagnostics/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>diagnostics_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Diagnostics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_PAL" Guid="{5F6BDDAA-3409-49DE-9AFE-342B7AAEF9E4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_PAL" Guid="{5F6BDDAA-3409-49DE-9AFE-342B7AAEF9E4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Diagnostics/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/Diagnostics/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>diagnostics_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Diagnostics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_PAL" Guid="{5F6BDDAA-3409-49DE-9AFE-342B7AAEF9E4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Diagnostics_PAL" Guid="{5F6BDDAA-3409-49DE-9AFE-342B7AAEF9E4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Double/dotNetMF.proj
+++ b/DeviceCode/pal/Double/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>native_double_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Math</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Native_Double" Guid="{4163381F-413A-4E29-8594-81541FB0F317}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Native_Double" Guid="{4163381F-413A-4E29-8594-81541FB0F317}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Gesture/dotNetMF.proj
+++ b/DeviceCode/pal/Gesture/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Gesture_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Gesture_PAL" Guid="{19509D5C-151D-4853-9C5D-DB7622D69562}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Gesture_PAL" Guid="{19509D5C-151D-4853-9C5D-DB7622D69562}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Gesture/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/Gesture/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Gesture_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Gesture_pal_stubs" Guid="{19509D5C-151D-4853-9C5D-DB7622D69562}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Gesture_pal_stubs" Guid="{19509D5C-151D-4853-9C5D-DB7622D69562}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Ink/dotNetMF.proj
+++ b/DeviceCode/pal/Ink/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Ink_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Ink_PAL" Guid="{D6E9B6C7-B280-4b0f-91B1-3AA8E65375A7}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Ink_PAL" Guid="{D6E9B6C7-B280-4b0f-91B1-3AA8E65375A7}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/Ink/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/Ink/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Ink_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Ink_PAL" Guid="{D6E9B6C7-B280-4b0f-91B1-3AA8E65375A7}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Ink_PAL" Guid="{D6E9B6C7-B280-4b0f-91B1-3AA8E65375A7}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/OneWire/Stubs/dotNetMF.proj
+++ b/DeviceCode/pal/OneWire/Stubs/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>onewire_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Library</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="OneWire_PAL" Guid="{8B4E8B4B-774D-4F2F-AA52-085848AA8D70}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="OneWire_PAL" Guid="{8B4E8B4B-774D-4F2F-AA52-085848AA8D70}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/OneWire/dotNetMF.proj
+++ b/DeviceCode/pal/OneWire/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>onewire_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Library</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="OneWire_PAL" Guid="{8B4E8B4B-774D-4F2F-AA52-085848AA8D70}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="OneWire_PAL" Guid="{8B4E8B4B-774D-4F2F-AA52-085848AA8D70}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/tinyclr/dotNetMF.proj
+++ b/DeviceCode/pal/OpenSSL/OpenSSL_1_0_0/tinyclr/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>ssl_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_ssl_PAL" Guid="{E34A68CD-2676-422B-BE70-419E3306039D}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_ssl_PAL" Guid="{E34A68CD-2676-422B-BE70-419E3306039D}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/SimpleHeap/dotNetMF.proj
+++ b/DeviceCode/pal/SimpleHeap/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SimpleHeap.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_PAL" Guid="{50C71E02-13E2-4A29-B72D-B1D61F73D808}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_PAL" Guid="{50C71E02-13E2-4A29-B72D-B1D61F73D808}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/SimpleHeap/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/SimpleHeap/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SimpleHeap_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_PAL" Guid="{50C71E02-13E2-4A29-B72D-B1D61F73D808}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_PAL" Guid="{50C71E02-13E2-4A29-B72D-B1D61F73D808}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/SimpleHeap_config/Stubs/dotNetMF.proj
+++ b/DeviceCode/pal/SimpleHeap_config/Stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SimpleHeap_config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_Config_PAL" Guid="{459ACB2E-257C-4B90-B4A5-63DD8E3CBC0F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_Config_PAL" Guid="{459ACB2E-257C-4B90-B4A5-63DD8E3CBC0F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/SimpleHeap_config/dotNetMF.proj
+++ b/DeviceCode/pal/SimpleHeap_config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SimpleHeap_config.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_Config_PAL" Guid="{459ACB2E-257C-4B90-B4A5-63DD8E3CBC0F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SimpleHeap_Config_PAL" Guid="{459ACB2E-257C-4B90-B4A5-63DD8E3CBC0F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/StateDebounce/dotNetMF.proj
+++ b/DeviceCode/pal/StateDebounce/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>StateDebounce_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debounce</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="StateDebounce_PAL" Guid="{B3B337F1-2C64-4D62-9A86-D3C2BB0A083D}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="StateDebounce_PAL" Guid="{B3B337F1-2C64-4D62-9A86-D3C2BB0A083D}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/StateDebounce/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/StateDebounce/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>StateDebounce_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Debounce</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="StateDebounce_PAL" Guid="{B3B337F1-2C64-4D62-9A86-D3C2BB0A083D}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="StateDebounce_PAL" Guid="{B3B337F1-2C64-4D62-9A86-D3C2BB0A083D}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/TouchPanel/dotNetMF.proj
+++ b/DeviceCode/pal/TouchPanel/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>TouchPanel_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchPanel_PAL" Guid="{5AC5FC3B-97C5-4370-884B-FD190EDC58CB}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchPanel_PAL" Guid="{5AC5FC3B-97C5-4370-884B-FD190EDC58CB}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/TouchPanel/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/TouchPanel/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>touchpanel_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchPanel_PAL" Guid="{5AC5FC3B-97C5-4370-884B-FD190EDC58CB}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TouchPanel_PAL" Guid="{5AC5FC3B-97C5-4370-884B-FD190EDC58CB}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/configuration/dotNetMF.proj
+++ b/DeviceCode/pal/configuration/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>config_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Config_PAL" Guid="{EC117871-1E2D-49EC-B0D1-C4BDBF573127}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Config_PAL" Guid="{EC117871-1E2D-49EC-B0D1-C4BDBF573127}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/configuration/dotNetMF_loader.proj
+++ b/DeviceCode/pal/configuration/dotNetMF_loader.proj
@@ -11,7 +11,7 @@
     <ManifestFile>config_pal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Config_PAL" Guid="{EC117871-1E2D-49EC-B0D1-C4BDBF573127}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Config_PAL" Guid="{EC117871-1E2D-49EC-B0D1-C4BDBF573127}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/configuration/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/configuration/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>config_pal_Stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Config_PAL" Guid="{EC117871-1E2D-49EC-B0D1-C4BDBF573127}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Config_PAL" Guid="{EC117871-1E2D-49EC-B0D1-C4BDBF573127}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/events/dotNetMF.proj
+++ b/DeviceCode/pal/events/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>events_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Events_PAL" Guid="{B4D32D3C-D574-4A85-B582-37F711D8B7E7}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Events_PAL" Guid="{B4D32D3C-D574-4A85-B582-37F711D8B7E7}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/events/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/events/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>events_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Events_PAL" Guid="{B4D32D3C-D574-4A85-B582-37F711D8B7E7}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Events_PAL" Guid="{B4D32D3C-D574-4A85-B582-37F711D8B7E7}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/fs/dotNetMF.proj
+++ b/DeviceCode/pal/fs/dotNetMF.proj
@@ -13,7 +13,7 @@
     <ManifestFile>fs_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>FileSystem</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_PAL" Guid="{BDB863C1-C7D0-4aac-8389-5BA89628B1DA}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_PAL" Guid="{BDB863C1-C7D0-4aac-8389-5BA89628B1DA}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/fs/stubs/Config/dotNetMF.proj
+++ b/DeviceCode/pal/fs/stubs/Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>FS_Config_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>FileSystem</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_Config_PAL" Guid="{581729D7-D732-4fe3-961D-3898022F12FA}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_Config_PAL" Guid="{581729D7-D732-4fe3-961D-3898022F12FA}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/fs/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/fs/stubs/dotNetMF.proj
@@ -13,7 +13,7 @@
     <ManifestFile>fs_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>FileSystem</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_PAL" Guid="{BDB863C1-C7D0-4aac-8389-5BA89628B1DA}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="FileSystem_PAL" Guid="{BDB863C1-C7D0-4aac-8389-5BA89628B1DA}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/graphics/dotNetMF.proj
+++ b/DeviceCode/pal/graphics/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>graphics_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_PAL" Guid="{9E379C2B-74CD-4003-A557-389AA48CD6F0}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_PAL" Guid="{9E379C2B-74CD-4003-A557-389AA48CD6F0}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/graphics/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/graphics/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>graphics_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Graphics</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_PAL" Guid="{9E379C2B-74CD-4003-A557-389AA48CD6F0}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Graphics_PAL" Guid="{9E379C2B-74CD-4003-A557-389AA48CD6F0}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/heap/dotNetMF.proj
+++ b/DeviceCode/pal/heap/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>heap_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Heap_PAL" Guid="{EC718439-8D24-47C7-9555-9C4D314D1C9C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Heap_PAL" Guid="{EC718439-8D24-47C7-9555-9C4D314D1C9C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/heap/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/heap/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>heap_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Heap_PAL" Guid="{EC718439-8D24-47C7-9555-9C4D314D1C9C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Heap_PAL" Guid="{EC718439-8D24-47C7-9555-9C4D314D1C9C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/io/dotNetMF.proj
+++ b/DeviceCode/pal/io/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>io_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>GPIO</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="IO_PAL" Guid="{3E2D9EF7-3582-4DA3-B48F-DAAEC92E4A8E}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="IO_PAL" Guid="{3E2D9EF7-3582-4DA3-B48F-DAAEC92E4A8E}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/io/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/io/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>io_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>GPIO</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="IO_PAL" Guid="{3E2D9EF7-3582-4DA3-B48F-DAAEC92E4A8E}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="IO_PAL" Guid="{3E2D9EF7-3582-4DA3-B48F-DAAEC92E4A8E}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/lwip_1_4_1_os/SocketsDriver/dotNetMF.proj
+++ b/DeviceCode/pal/lwip_1_4_1_os/SocketsDriver/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>SocketsDriver_pal_lwip_os.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SocketDriver_PAL_LWIP" Guid="{9DB86889-471A-4743-9ACF-1AED838973FB}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SocketDriver_PAL_LWIP" Guid="{9DB86889-471A-4743-9ACF-1AED838973FB}" Conditional="" xmlns="">
         <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
       </MFComponent>
     </LibraryCategory>

--- a/DeviceCode/pal/lwip_1_4_1_os/SocketsDriver/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/lwip_1_4_1_os/SocketsDriver/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>socketsDriver_pal_lwip_os_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SocketDriver_PAL_LWIP" Guid="{9DB86889-471A-4743-9ACF-1AED838973FB}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="SocketDriver_PAL_LWIP" Guid="{9DB86889-471A-4743-9ACF-1AED838973FB}" Conditional="" xmlns="">
         <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
       </MFComponent>
     </LibraryCategory>

--- a/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_dhcp.proj
+++ b/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_dhcp.proj
@@ -12,7 +12,7 @@
     <ManifestFile>sockets_hal_dhcp_LWIP_os.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_dhcp_PAL" Guid="{2F810E63-C9B2-4938-9876-152FB11B80F6}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_dhcp_PAL" Guid="{2F810E63-C9B2-4938-9876-152FB11B80F6}" Conditional="" xmlns="">
         <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
       </MFComponent>
     </LibraryCategory>

--- a/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_sockets.proj
+++ b/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_sockets.proj
@@ -12,7 +12,7 @@
     <ManifestFile>sockets_hal_sockets_lwIP_os.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="NetworkStack_PAL" Guid="{53634488-41DF-4696-8186-5EA5F846BA14}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="NetworkStack_PAL" Guid="{53634488-41DF-4696-8186-5EA5F846BA14}" Conditional="" xmlns="">
         <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
       </MFComponent>
     </LibraryCategory>

--- a/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_tcp.proj
+++ b/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_tcp.proj
@@ -12,7 +12,7 @@
     <ManifestFile>sockets_hal_tcp_lwIP_os.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_tcp_PAL" Guid="{B0EE5842-6FC6-4BFC-8C58-29C26D6B9CB0}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_tcp_PAL" Guid="{B0EE5842-6FC6-4BFC-8C58-29C26D6B9CB0}" Conditional="" xmlns="">
         <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
       </MFComponent>
     </LibraryCategory>

--- a/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_udp.proj
+++ b/DeviceCode/pal/lwip_1_4_1_os/lwip/src/dotNetMF_udp.proj
@@ -12,7 +12,7 @@
     <ManifestFile>sockets_hal_udp_lwIP_os.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_udp_PAL" Guid="{F3CFF2CB-AF06-4F82-B3B9-D743FC8F248D}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Sockets_udp_PAL" Guid="{F3CFF2CB-AF06-4F82-B3B9-D743FC8F248D}" Conditional="" xmlns="">
         <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
       </MFComponent>
     </LibraryCategory>

--- a/DeviceCode/pal/palevent/Stubs/dotnetmf.proj
+++ b/DeviceCode/pal/palevent/Stubs/dotnetmf.proj
@@ -12,7 +12,7 @@
     <ManifestFile>palevent_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="palevent_pal_stubs" Guid="{66157F36-5C7E-4415-8CA4-51AD6B636A94}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="palevent_pal_stubs" Guid="{66157F36-5C7E-4415-8CA4-51AD6B636A94}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/palevent/dotNetMF.proj
+++ b/DeviceCode/pal/palevent/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>palevent_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Touch</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="palevent_PAL" Guid="{66157F36-5C7E-4415-8CA4-51AD6B636A94}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="palevent_PAL" Guid="{66157F36-5C7E-4415-8CA4-51AD6B636A94}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/piezo/dotNetMF.proj
+++ b/DeviceCode/pal/piezo/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>piezo_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Sound</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Piezo_PAL" Guid="{EE16C87B-8873-4E48-AB7D-026B270558E9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Piezo_PAL" Guid="{EE16C87B-8873-4E48-AB7D-026B270558E9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/piezo/stubs/Config/dotNetMF.proj
+++ b/DeviceCode/pal/piezo/stubs/Config/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>piezo_config_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Sound</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PiezoConfig_PAL" Guid="{4D93804C-A10C-4CF8-AE9F-2988B12E4A2C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="PiezoConfig_PAL" Guid="{4D93804C-A10C-4CF8-AE9F-2988B12E4A2C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/piezo/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/piezo/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>piezo_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Sound</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Piezo_PAL" Guid="{EE16C87B-8873-4E48-AB7D-026B270558E9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Piezo_PAL" Guid="{EE16C87B-8873-4E48-AB7D-026B270558E9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/tinycrt/dotNetMF.proj
+++ b/DeviceCode/pal/tinycrt/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>tinycrt_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyCRT_PAL" Guid="{D364E9C9-BF40-4D93-84DF-372BCF3975D3}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyCRT_PAL" Guid="{D364E9C9-BF40-4D93-84DF-372BCF3975D3}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/tinycrt/dotNetMF_loader.proj
+++ b/DeviceCode/pal/tinycrt/dotNetMF_loader.proj
@@ -11,7 +11,7 @@
     <ManifestFile>tinycrt_pal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyCRT_PAL" Guid="{D364E9C9-BF40-4D93-84DF-372BCF3975D3}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyCRT_PAL" Guid="{D364E9C9-BF40-4D93-84DF-372BCF3975D3}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/tinycrt/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/tinycrt/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>tinycrt_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyCRT_PAL" Guid="{D364E9C9-BF40-4D93-84DF-372BCF3975D3}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyCRT_PAL" Guid="{D364E9C9-BF40-4D93-84DF-372BCF3975D3}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/watchdog/dotNetMF.proj
+++ b/DeviceCode/pal/watchdog/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Watchdog_pal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Watchdog</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Watchdog_PAL" Guid="{1EC30B63-843C-45d8-942A-6A868336CF8F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Watchdog_PAL" Guid="{1EC30B63-843C-45d8-942A-6A868336CF8F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/DeviceCode/pal/watchdog/stubs/dotNetMF.proj
+++ b/DeviceCode/pal/watchdog/stubs/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Watchdog_pal_stubs.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Watchdog</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Watchdog_PAL" Guid="{1EC30B63-843C-45d8-942A-6A868336CF8F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Watchdog_PAL" Guid="{1EC30B63-843C-45d8-942A-6A868336CF8F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Framework/Features/DAConverter_HAL.libcatproj
+++ b/Framework/Features/DAConverter_HAL.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">HAL</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/Debugger_flavor_CLR.libcatproj
+++ b/Framework/Features/Debugger_flavor_CLR.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">CLR</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/Display_Font_HAL.libcatproj
+++ b/Framework/Features/Display_Font_HAL.libcatproj
@@ -14,7 +14,7 @@
     <FilePath>$(SPOCLIENT)\DeviceCode\Drivers\Display\TextFonts\Font8x8\dotnetMF.proj</FilePath>
   </Templates>
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/Initialization_HAL.libcatproj
+++ b/Framework/Features/Initialization_HAL.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">HAL</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">System</Groups>
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/SPOT_Touch_CLR.libcatproj
+++ b/Framework/Features/SPOT_Touch_CLR.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">CLR</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/TinyHal_HAL.libcatproj
+++ b/Framework/Features/TinyHal_HAL.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">HAL</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">System</Groups>
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/WireProtocol_support.libcatproj
+++ b/Framework/Features/WireProtocol_support.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">Support</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/Framework/Features/crc_support.libcatproj
+++ b/Framework/Features/crc_support.libcatproj
@@ -8,7 +8,7 @@
   <Level xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">Support</Level>
   <Groups xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
   <Documentation xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd" />
-  <StubLibrary ProjectPath="" Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
+  <StubLibrary Conditional="" xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
     <VersionDependency>
       <Major>4</Major>
       <Minor>0</Minor>

--- a/ProjectTemplates/MicroBooter/MicroBooter.proj
+++ b/ProjectTemplates/MicroBooter/MicroBooter.proj
@@ -17,8 +17,6 @@
     </Groups>
     <Documentation>
     </Documentation>
-    <CustomSpecific>
-    </CustomSpecific>
     <IsStub>False</IsStub>
     <Directory>Solutions\$(PLATFORM)\MicroBooter</Directory>
     <IsClrProject>False</IsClrProject>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>M29W640FB_blconfig_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/dotNetMF.proj
@@ -26,7 +26,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>MCBSTM32F400</CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/M29W640FB/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>Block storage configuration for external NOR flash M29W640FB on the MCBSTM32F400</Description>
     <Level>HAL</Level>
     <LibraryFile>M29W640FB_blconfig_MCBSTM32F400.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Blockstorage\M29W640FB\dotNetMF.proj</ProjectPath>
     <ManifestFile>M29W640FB_blconfig_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>Block storage configuration for MCBSTM32F400</Description>
     <Level>HAL</Level>
     <LibraryFile>STM32F4_blconfig_MCBSTM32F400.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Blockstorage\STM32F4\dotNetMF.proj</ProjectPath>
     <ManifestFile>STM32F4_blconfig_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>STM32F4_blconfig_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
@@ -26,7 +26,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>MCBSTM32F400</CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>BlockStorage_AddDevices_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageAddDevices_HAL" Guid="{D1C1D946-18A1-4f12-807A-A182C4059D86}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageAddDevices_HAL" Guid="{D1C1D946-18A1-4f12-807A-A182C4059D86}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
@@ -26,7 +26,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>MCBSTM32F400</CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>Block storage add device driver for MCBSTM32F400</Description>
     <Level>HAL</Level>
     <LibraryFile>BlockStorage_AddDevices_MCBSTM32F400.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Blockstorage\addDevices\dotNetMF.proj</ProjectPath>
     <ManifestFile>BlockStorage_AddDevices_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/CMSIS_RTX_Config/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/CMSIS_RTX_Config/dotNetMF.proj
@@ -12,7 +12,7 @@
         <ManifestFile>CMSIS_RTX_CONFIG.$(LIB_EXT).manifest</ManifestFile>
         <Groups>OS\CMSIS_RTOS</Groups>
         <LibraryCategory>
-            <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="RTX_Config" Guid="{3E87A1F9-5576-4DD3-808B-69088BA54B91}" ProjectPath="" Conditional="" xmlns="">
+            <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="RTX_Config" Guid="{3E87A1F9-5576-4DD3-808B-69088BA54B91}" Conditional="" xmlns="">
                 <ComponentType xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">LibraryCategory</ComponentType>
             </MFComponent>
         </LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/CMSIS_RTX_Config/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/CMSIS_RTX_Config/dotNetMF.proj
@@ -8,7 +8,6 @@
         <Description>CMSIS-RTX OS Config</Description>
         <Level>HAL</Level>
         <LibraryFile>CMSIS_RTX_CONFIG.$(LIB_EXT)</LibraryFile>
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\CMSIS_RTX_Config\dotNetMF.proj</ProjectPath>
         <ManifestFile>CMSIS_RTX_CONFIG.$(LIB_EXT).manifest</ManifestFile>
         <Groups>OS\CMSIS_RTOS</Groups>
         <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Crypto/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Crypto/dotNetMF.proj
@@ -8,7 +8,6 @@
     <Description>PKCS11 Crypto configuration for MCBSTM32F400</Description>
     <Level>HAL</Level>
     <LibraryFile>Crypto_config_MCBSTM32F400.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Crypto\dotNetMF.proj</ProjectPath>
     <ManifestFile>Crypto_config_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Crypto/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Crypto/dotNetMF.proj
@@ -28,7 +28,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>MCBSTM32F400</CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/MCBSTM32F400/DeviceCode/GlobalLock/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/GlobalLock/dotNetMF.proj
@@ -7,7 +7,6 @@
         <Description>GlobalLock library for CMSIS-RTOS</Description>
         <Level>HAL</Level>
         <LibraryFile>GlobalLock_hal_RTOS.$(LIB_EXT)</LibraryFile>
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\GlobalLock\dotNetMF.proj</ProjectPath>
         <ManifestFile>GlobalLock_hal_RTOS.$(LIB_EXT).manifest</ManifestFile>
         <Documentation>
         </Documentation>

--- a/Solutions/MCBSTM32F400/DeviceCode/Init/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Init/dotNetMF.proj
@@ -15,8 +15,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/MCBSTM32F400/DeviceCode/Init/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Init/dotNetMF.proj
@@ -1,6 +1,5 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Init\dotnetmf.proj</ProjectPath>
     <AssemblyName>IO_Init_MCBSTM32F400</AssemblyName>
     <Size>
     </Size>

--- a/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>MCBSTM32F400_initialization_hal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF.proj
@@ -8,7 +8,6 @@
     <Description>System initialization library for MCBSTM32F400</Description>
     <Level>HAL</Level>
     <LibraryFile>MCBSTM32F400_initialization_hal.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Initialization\dotNetMF.proj</ProjectPath>
     <ManifestFile>MCBSTM32F400_initialization_hal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF_loader.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF_loader.proj
@@ -8,7 +8,6 @@
     <Description>System initialization library for MCBSTM32F400 (for boot loaders)</Description>
     <Level>HAL</Level>
     <LibraryFile>MCBSTM32F400_initialization_hal_loader.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Initialization\dotNetMF_loader.proj</ProjectPath>
     <ManifestFile>MCBSTM32F400_initialization_hal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF_loader.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Initialization/dotNetMF_loader.proj
@@ -12,7 +12,7 @@
     <ManifestFile>MCBSTM32F400_initialization_hal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/M29W640FB_Flash/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/M29W640FB_Flash/dotNetMF.proj
@@ -19,7 +19,7 @@
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1D}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorage_HAL" Guid="{B87F1565-3D64-4531-A84B-2F9C2B221D1D}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/M29W640FB_Flash/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/M29W640FB_Flash/dotNetMF.proj
@@ -1,6 +1,5 @@
 ﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\M29W640FB_Flash\dotNetMF.proj</ProjectPath>
     <ProjectGuid>{ADD1DC98-CBE4-494B-92E7-F982B9E01A4B}</ProjectGuid>
     <AssemblyName>M29W640FB_Flash</AssemblyName>
     <Size>

--- a/Solutions/MCBSTM32F400/DeviceCode/Network_Config_HAL/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Network_Config_HAL/dotNetMF.proj
@@ -8,7 +8,6 @@
     <Description>Network configuration MCBSTM32F400 library</Description>
     <Level>HAL</Level>
     <LibraryFile>Network_Config_HAL_MCBSTM32F400.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\Network_Config_HAL\dotNetMF.proj</ProjectPath>
     <ManifestFile>Network_Config_HAL_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/Network_Config_HAL/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/Network_Config_HAL/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>Network_Config_HAL_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Network</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Network_Config_HAL" Guid="{14DA2330-C44D-4F5B-AE85-534E24AEC5B2}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Network_Config_HAL" Guid="{14DA2330-C44D-4F5B-AE85-534E24AEC5B2}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF.proj
@@ -8,7 +8,6 @@
         <Description>MCBSTM32F400 tinyhal library</Description>
         <Level>HAL</Level>
         <LibraryFile>MCBSTM32F400_tinyhal.$(LIB_EXT)</LibraryFile>
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\TinyHal\dotNetMF.proj</ProjectPath>
         <ManifestFile>MCBSTM32F400_tinyhal.$(LIB_EXT).manifest</ManifestFile>
         <Groups>System</Groups>
         <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF.proj
@@ -12,7 +12,7 @@
         <ManifestFile>MCBSTM32F400_tinyhal.$(LIB_EXT).manifest</ManifestFile>
         <Groups>System</Groups>
         <LibraryCategory>
-          <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL" Guid="{37C37BC0-3CA6-4C1C-A26F-4761A7BA3C05}" ProjectPath="" Conditional="" xmlns="">
+          <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL" Guid="{37C37BC0-3CA6-4C1C-A26F-4761A7BA3C05}" Conditional="" xmlns="">
             <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
               <Major>4</Major>
               <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF_loader.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF_loader.proj
@@ -11,7 +11,7 @@
         <ManifestFile>MCBSTM32F400_tinyhal.$(LIB_EXT).manifest_loader</ManifestFile>
     <Groups>system</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL_Cortex" Guid="{37C37BC0-3CA6-4C1C-A26F-4761A7BA3C05}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="TinyHal_HAL_Cortex" Guid="{37C37BC0-3CA6-4C1C-A26F-4761A7BA3C05}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF_loader.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/TinyHal/dotNetMF_loader.proj
@@ -7,7 +7,6 @@
     <Description>MCBSTM32F400 tinyhal library loader</Description>
     <Level>HAL</Level>
         <LibraryFile>MCBSTM32F400_tinyhal_loader.$(LIB_EXT)</LibraryFile>
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\TinyHal\dotNetMF_loader.proj</ProjectPath>
         <ManifestFile>MCBSTM32F400_tinyhal.$(LIB_EXT).manifest_loader</ManifestFile>
     <Groups>system</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/DeviceCode/USB/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/USB/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>usb_pal_config_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/MCBSTM32F400/DeviceCode/USB/dotNetMF.proj
+++ b/Solutions/MCBSTM32F400/DeviceCode/USB/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>USB PAL configuration for MCBSTM32F400 solution</Description>
     <Level>PAL</Level>
     <LibraryFile>usb_pal_config_MCBSTM32F400.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\USB\dotnetmf.proj</ProjectPath>
     <ManifestFile>usb_pal_config_MCBSTM32F400.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\MCBSTM32F400</Groups>
     <LibraryCategory>

--- a/Solutions/MCBSTM32F400/MicroBooter/MicroBooter.proj
+++ b/Solutions/MCBSTM32F400/MicroBooter/MicroBooter.proj
@@ -9,7 +9,6 @@
     <IsClrProject>False</IsClrProject>
     <InteropFeatures />
     <ExtraAssemblies />
-    <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\MicroBooter\MicroBooter.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\MCBSTM32F400\MCBSTM32F400.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>
@@ -17,7 +16,6 @@
   <PropertyGroup>
     <Size />
     <Level />
-    <ProjectPath>$(SPOCLIENT)\ProjectTemplates\MicroBooter\MicroBooter.proj</ProjectPath>
     <ManifestFile />
     <Groups />
     <IsStub>False</IsStub>

--- a/Solutions/MCBSTM32F400/MicroBooter/MicroBooter.proj
+++ b/Solutions/MCBSTM32F400/MicroBooter/MicroBooter.proj
@@ -20,7 +20,6 @@
     <ProjectPath>$(SPOCLIENT)\ProjectTemplates\MicroBooter\MicroBooter.proj</ProjectPath>
     <ManifestFile />
     <Groups />
-    <CustomSpecific />
     <IsStub>False</IsStub>
     <reducesize>true</reducesize>
     <OutputType>Executable</OutputType>

--- a/Solutions/MCBSTM32F400/TinyBooter/TinyBooter.proj
+++ b/Solutions/MCBSTM32F400/TinyBooter/TinyBooter.proj
@@ -9,7 +9,6 @@
         <IsClrProject>False</IsClrProject>
         <InteropFeatures />
         <ExtraAssemblies />
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\TinyBooter\TinyBooter.proj</ProjectPath>
         <MFSettingsFile>$(SPOCLIENT)\Solutions\MCBSTM32F400\MCBSTM32F400.settings</MFSettingsFile>
         <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
         <reducesize>true</reducesize>

--- a/Solutions/MCBSTM32F400/TinyCLR/TinyCLR.proj
+++ b/Solutions/MCBSTM32F400/TinyCLR/TinyCLR.proj
@@ -9,7 +9,6 @@
         <IsClrProject>True</IsClrProject>
         <InteropFeatures />
         <ExtraAssemblies />
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\TinyCLR\TinyCLR.proj</ProjectPath>
         <MFSettingsFile>$(SPOCLIENT)\Solutions\MCBSTM32F400\MCBSTM32F400.settings</MFSettingsFile>
         <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
         <reducesize>false</reducesize>

--- a/Solutions/MCBSTM32F400/TinyCLR_NONET/TinyCLR_NONET.proj
+++ b/Solutions/MCBSTM32F400/TinyCLR_NONET/TinyCLR_NONET.proj
@@ -9,7 +9,6 @@
         <IsClrProject>True</IsClrProject>
         <InteropFeatures />
         <ExtraAssemblies />
-        <ProjectPath>$(SPOCLIENT)\Solutions\MCBSTM32F400\TinyCLR_NONET\TinyCLR_NONET.proj</ProjectPath>
         <MFSettingsFile>$(SPOCLIENT)\Solutions\MCBSTM32F400\MCBSTM32F400_NONET.settings</MFSettingsFile>
         <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
         <reducesize>false</reducesize>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
@@ -26,7 +26,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>STM32F4DISCOVERY</CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>Block storage configuration for STM32F4DISCOVERY</Description>
     <Level>HAL</Level>
     <LibraryFile>STM32F4_blconfig_STM32F4DISCOVERY.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\DeviceCode\Blockstorage\STM32F4\dotNetMF.proj</ProjectPath>
     <ManifestFile>STM32F4_blconfig_STM32F4DISCOVERY.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\STM32F4DISCOVERY</Groups>
     <LibraryCategory>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/STM32F4/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>STM32F4_blconfig_STM32F4DISCOVERY.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\STM32F4DISCOVERY</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageConfig_HAL" Guid="{497F59BB-55D3-404e-B958-A6284806D184}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
@@ -26,7 +26,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>STM32F4DISCOVERY</CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>BlockStorage_AddDevices_STM32F4DISCOVERY.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\STM32F4DISCOVERY</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageAddDevices_HAL" Guid="{D1C1D946-18A1-4f12-807A-A182C4059D86}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="BlockStorageAddDevices_HAL" Guid="{D1C1D946-18A1-4f12-807A-A182C4059D86}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Blockstorage/addDevices/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>Block storage add device driver for STM32F4DISCOVERY</Description>
     <Level>HAL</Level>
     <LibraryFile>BlockStorage_AddDevices_STM32F4DISCOVERY.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\DeviceCode\Blockstorage\addDevices\dotNetMF.proj</ProjectPath>
     <ManifestFile>BlockStorage_AddDevices_STM32F4DISCOVERY.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\STM32F4DISCOVERY</Groups>
     <LibraryCategory>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Init/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Init/dotNetMF.proj
@@ -15,8 +15,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Init/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Init/dotNetMF.proj
@@ -1,6 +1,5 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\DeviceCode\Init\dotnetmf.proj</ProjectPath>
     <AssemblyName>IO_Init_STM32F4DISCOVERY</AssemblyName>
     <Size>
     </Size>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF.proj
@@ -12,7 +12,7 @@
     <ManifestFile>STM32F4DISCOVERY_initialization_hal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF.proj
@@ -8,7 +8,6 @@
     <Description>System initialization library for STM32F4DISCOVERY</Description>
     <Level>HAL</Level>
     <LibraryFile>STM32F4DISCOVERY_initialization_hal.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\DeviceCode\Initialization\dotNetMF.proj</ProjectPath>
     <ManifestFile>STM32F4DISCOVERY_initialization_hal.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF_loader.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF_loader.proj
@@ -8,7 +8,6 @@
     <Description>System initialization library for STM32F4DISCOVERY (for boot loaders)</Description>
     <Level>HAL</Level>
     <LibraryFile>STM32F4DISCOVERY_initialization_hal_loader.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\DeviceCode\Initialization\dotNetMF_loader.proj</ProjectPath>
     <ManifestFile>STM32F4DISCOVERY_initialization_hal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF_loader.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/Initialization/dotNetMF_loader.proj
@@ -12,7 +12,7 @@
     <ManifestFile>STM32F4DISCOVERY_initialization_hal_loader.$(LIB_EXT).manifest</ManifestFile>
     <Groups>System</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Initialization_HAL" Guid="{34EDFFBE-0FB6-49CC-A673-03BD96EDE0A9}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/USB/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/USB/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>usb_pal_config_STM32F4DISCOVERY.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\STM32F4DISCOVERY</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/STM32F4DISCOVERY/DeviceCode/USB/dotNetMF.proj
+++ b/Solutions/STM32F4DISCOVERY/DeviceCode/USB/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>USB PAL configuration for STM32F4DISCOVERY solution</Description>
     <Level>PAL</Level>
     <LibraryFile>usb_pal_config_STM32F4DISCOVERY.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\DeviceCode\USB\dotnetmf.proj</ProjectPath>
     <ManifestFile>usb_pal_config_STM32F4DISCOVERY.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Solutions\STM32F4DISCOVERY</Groups>
     <LibraryCategory>

--- a/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
@@ -9,7 +9,6 @@
         <IsClrProject>False</IsClrProject>
         <InteropFeatures />
         <ExtraAssemblies />
-        <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\TinyBooter\TinyBooter.proj</ProjectPath>
         <MFSettingsFile>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\STM32F4DISCOVERY.settings</MFSettingsFile>
         <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
         <reducesize>true</reducesize>

--- a/Solutions/STM32F4DISCOVERY/TinyCLR/TinyCLR.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyCLR/TinyCLR.proj
@@ -9,7 +9,6 @@
         <IsClrProject>True</IsClrProject>
         <InteropFeatures />
         <ExtraAssemblies />
-        <ProjectPath>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\TinyCLR\TinyCLR.proj</ProjectPath>
         <MFSettingsFile>$(SPOCLIENT)\Solutions\STM32F4DISCOVERY\STM32F4DISCOVERY.settings</MFSettingsFile>
         <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
         <reducesize>false</reducesize>

--- a/Solutions/Template/DeviceCode/USB_Config_PAL/dotNetMF.proj
+++ b/Solutions/Template/DeviceCode/USB_Config_PAL/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>USB_Config_PAL_TEMPLATE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/Template/DeviceCode/USB_Config_PAL/dotNetMF.proj
+++ b/Solutions/Template/DeviceCode/USB_Config_PAL/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>USB configuration TEMPLATE library</Description>
     <Level>PAL</Level>
     <LibraryFile>USB_Config_PAL_TEMPLATE.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\DeviceCode\USB_Config_PAL\dotNetMF.proj</ProjectPath>
     <ManifestFile>USB_Config_PAL_TEMPLATE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>

--- a/Solutions/Template/DeviceCode/USB_HAL/dotNetMF.proj
+++ b/Solutions/Template/DeviceCode/USB_HAL/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>USB TEMPLATE library</Description>
     <Level>HAL</Level>
     <LibraryFile>USB_HAL_TEMPLATE.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\DeviceCode\USB_HAL\dotNetMF.proj</ProjectPath>
     <ManifestFile>USB_HAL_TEMPLATE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\TEMPLATE</Groups>
     <LibraryCategory>

--- a/Solutions/Template/DeviceCode/USB_HAL/dotNetMF.proj
+++ b/Solutions/Template/DeviceCode/USB_HAL/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>USB_HAL_TEMPLATE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\TEMPLATE</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/Template/NativeSample/NativeSample.proj
+++ b/Solutions/Template/NativeSample/NativeSample.proj
@@ -13,7 +13,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\NativeSample\NativeSample.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template\Template.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template/PortBooter/portBooter.proj
+++ b/Solutions/Template/PortBooter/portBooter.proj
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\PortBooter\portBooter.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template\Template.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template/PortBooter/portBooterloader.proj
+++ b/Solutions/Template/PortBooter/portBooterloader.proj
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\PortBooter\portBooterloader.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template\Template.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template/TinyBooter/TinyBooter.proj
+++ b/Solutions/Template/TinyBooter/TinyBooter.proj
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\TinyBooter\TinyBooter.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template\Template.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template/TinyBooter/TinyBooterDecompressor.proj
+++ b/Solutions/Template/TinyBooter/TinyBooterDecompressor.proj
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\TinyBooter\TinyBooterDecompressor.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template\Template.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template/TinyCLR/TinyCLR.proj
+++ b/Solutions/Template/TinyCLR/TinyCLR.proj
@@ -13,7 +13,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template\TinyCLR\TinyCLR.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template\Template.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template_BE/DeviceCode/USB_Config_PAL/dotNetMF.proj
+++ b/Solutions/Template_BE/DeviceCode/USB_Config_PAL/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>USB configuration TEMPLATE_BE library</Description>
     <Level>PAL</Level>
     <LibraryFile>USB_Config_PAL_TEMPLATE_BE.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template_BE\DeviceCode\USB_Config_PAL\dotNetMF.proj</ProjectPath>
     <ManifestFile>USB_Config_PAL_TEMPLATE_BE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>

--- a/Solutions/Template_BE/DeviceCode/USB_Config_PAL/dotNetMF.proj
+++ b/Solutions/Template_BE/DeviceCode/USB_Config_PAL/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>USB_Config_PAL_TEMPLATE_BE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>USB</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_Config_PAL" Guid="{A03C06C1-23D7-493a-99C1-7E060BA5E7C4}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/Template_BE/DeviceCode/USB_HAL/dotNetMF.proj
+++ b/Solutions/Template_BE/DeviceCode/USB_HAL/dotNetMF.proj
@@ -7,7 +7,6 @@
     <Description>USB TEMPLATE library</Description>
     <Level>HAL</Level>
     <LibraryFile>USB_HAL_TEMPLATE_BE.$(LIB_EXT)</LibraryFile>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template_BE\DeviceCode\USB_HAL\dotNetMF.proj</ProjectPath>
     <ManifestFile>USB_HAL_TEMPLATE_BE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\TEMPLATE</Groups>
     <LibraryCategory>

--- a/Solutions/Template_BE/DeviceCode/USB_HAL/dotNetMF.proj
+++ b/Solutions/Template_BE/DeviceCode/USB_HAL/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>USB_HAL_TEMPLATE_BE.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Processor\TEMPLATE</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="USB_HAL" Guid="{D5D07F9F-0BB9-4077-836B-580C4E7A734C}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Solutions/Template_BE/NativeSample/NativeSample.proj
+++ b/Solutions/Template_BE/NativeSample/NativeSample.proj
@@ -13,7 +13,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template_BE\NativeSample\NativeSample.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template_BE\Template_BE.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template_BE/PortBooter/portBooter.proj
+++ b/Solutions/Template_BE/PortBooter/portBooter.proj
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template_BE\PortBooter\portBooter.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template_BE\Template_BE.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template_BE/PortBooter/portBooterloader.proj
+++ b/Solutions/Template_BE/PortBooter/portBooterloader.proj
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template_BE\PortBooter\portBooterloader.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template_BE\Template_BE.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Template_BE/TinyCLR/TinyCLR.proj
+++ b/Solutions/Template_BE/TinyCLR/TinyCLR.proj
@@ -13,7 +13,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Template_BE\TinyCLR\TinyCLR.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Template_BE\Template_BE.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Solutions/Windows2/TinyCLR/TinyCLR.proj
+++ b/Solutions/Windows2/TinyCLR/TinyCLR.proj
@@ -13,7 +13,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Windows2\TinyCLR\TinyCLR.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
     <!--LNK4199: /DELAYLOAD:dllname ignored; no imports found from dllname -->

--- a/Solutions/Windows2/TinyCLR/TinyCLR.proj.port
+++ b/Solutions/Windows2/TinyCLR/TinyCLR.proj.port
@@ -5,7 +5,6 @@
     <ProjectGuid>E7D5455B-4FE3-42AF-8F44-AFB687DF5A87</ProjectGuid>
     <OutputType>DLL</OutputType>
     <Directory>Solutions\Windows2\TinyCLR</Directory>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Windows2\TinyCLR\TinyCLR.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <IsClrProject>True</IsClrProject>
   </PropertyGroup>

--- a/Solutions/Windows2/TinyCLR/TinyCLR.proj_no_floating_point
+++ b/Solutions/Windows2/TinyCLR/TinyCLR.proj_no_floating_point
@@ -12,7 +12,6 @@
     </InteropFeatures>
     <ExtraAssemblies>
     </ExtraAssemblies>
-    <ProjectPath>$(SPOCLIENT)\Solutions\Windows2\TinyCLR\TinyCLR.proj</ProjectPath>
     <MFSettingsFile>$(SPOCLIENT)\Solutions\Windows2\Windows2.settings</MFSettingsFile>
     <IsSolutionWizardVisible>True</IsSolutionWizardVisible>
   </PropertyGroup>

--- a/Support/WireProtocol/dotNetMF.proj
+++ b/Support/WireProtocol/dotNetMF.proj
@@ -13,7 +13,7 @@
     <Groups>
     </Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="WireProtocol_Support" Guid="{91AA2579-1BB8-4db7-806A-9999817E6274}" ProjectPath="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="WireProtocol_Support" Guid="{91AA2579-1BB8-4db7-806A-9999817E6274}" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/Support/WireProtocol/dotNetMF.proj
+++ b/Support/WireProtocol/dotNetMF.proj
@@ -28,8 +28,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>True</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Support/crc/dotNetMF.proj
+++ b/Support/crc/dotNetMF.proj
@@ -29,8 +29,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>True</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/Support/crc/dotNetMF.proj
+++ b/Support/crc/dotNetMF.proj
@@ -14,7 +14,7 @@
     <Groups>
     </Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="CRC_Support" Guid="{AC264A78-6B0B-4d51-AB92-A3283460055E}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="CRC_Support" Guid="{AC264A78-6B0B-4d51-AB92-A3283460055E}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/crypto/dotNetMF.proj
+++ b/crypto/dotNetMF.proj
@@ -12,7 +12,7 @@
     <Groups>
     </Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Crypto" Guid="{997AE9B5-A4A7-4540-AACA-6D8D2110E19F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Crypto" Guid="{997AE9B5-A4A7-4540-AACA-6D8D2110E19F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>

--- a/crypto/dotNetMF.proj
+++ b/crypto/dotNetMF.proj
@@ -27,8 +27,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>False</IsStub>

--- a/crypto/stubs/dotNetMF.proj
+++ b/crypto/stubs/dotNetMF.proj
@@ -26,8 +26,6 @@
     <Documentation>
     </Documentation>
     <PlatformIndependent>False</PlatformIndependent>
-    <CustomSpecific>
-    </CustomSpecific>
     <Required>False</Required>
     <IgnoreDefaultLibPath>False</IgnoreDefaultLibPath>
     <IsStub>True</IsStub>

--- a/crypto/stubs/dotNetMF.proj
+++ b/crypto/stubs/dotNetMF.proj
@@ -11,7 +11,7 @@
     <ManifestFile>Crypto_stub.$(LIB_EXT).manifest</ManifestFile>
     <Groups>Cryptography</Groups>
     <LibraryCategory>
-      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Crypto" Guid="{997AE9B5-A4A7-4540-AACA-6D8D2110E19F}" ProjectPath="" Conditional="" xmlns="">
+      <MFComponent xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema" Name="Crypto" Guid="{997AE9B5-A4A7-4540-AACA-6D8D2110E19F}" Conditional="" xmlns="">
         <VersionDependency xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">
           <Major>4</Major>
           <Minor>0</Minor>


### PR DESCRIPTION
As discussed in #278, deleted unused \<CustomSpecific> tags, empty ProjectPath attributes and unused \<ProjectPath> tags from solution projects files.

As it turned out, \<ProjectPath> is only referenced from CLR\Tools\PlatformDesigner\*, which is not used anymore, so I believe \<ProjectPath> can be safely removed (from the rest of files, along with ProjectPath attribute) ?