### PR TITLE
Adding support to provide more useful and actionalble diagnostics for Crypto libs and wire protocol debugging

### DIFF
--- a/Application/TinyBooter/ConfigurationManager.cpp
+++ b/Application/TinyBooter/ConfigurationManager.cpp
@@ -68,7 +68,9 @@ void ConfigurationSectorManager::LocateConfigurationSector( UINT32 BlockUsage )
 
 void ConfigurationSectorManager::LoadConfiguration()
 {
-    if (m_device ==NULL) return;
+    if (m_device ==NULL)
+            return;
+        
     if (m_fSupportsXIP)
     {
         // Get the real address 
@@ -91,7 +93,8 @@ void ConfigurationSectorManager::WriteConfiguration( UINT32 writeOffset, BYTE *d
     BOOL eraseWrite = FALSE;
     UINT32 writeLengthInBytes ;
 
-    if (m_device ==NULL) return ;
+    if (m_device ==NULL)
+            return ;
 
     LoadConfiguration();
 
@@ -179,9 +182,10 @@ void ConfigurationSectorManager::EraseWriteConfigBlock( BYTE * data, UINT32 size
 
 BOOL ConfigurationSectorManager::IsBootLoaderRequired( INT32 &bootModeTimeout )
 {
-    const UINT32                c_Empty      = 0xFFFFFFFF;
+    const UINT32 c_Empty = 0xFFFFFFFF;
 
-    if(m_device == NULL) return FALSE;
+    if(m_device == NULL)
+            return FALSE;
 
     volatile UINT32* data = (volatile UINT32*)&m_configurationSector->BooterFlagArray[ 0 ];
 

--- a/Application/TinyBooter/CryptoInterface.cpp
+++ b/Application/TinyBooter/CryptoInterface.cpp
@@ -4,14 +4,9 @@
 
 #include "CryptoInterface.h"
 #include "ConfigurationManager.h"
-//--//
 
 extern UINT8* g_ConfigBuffer;
-extern int    g_ConfigBufferLength;
-
-
-//--//
-
+extern int g_ConfigBufferLength;
 
 CryptoState::CryptoState( UINT32 dataAddress, UINT32 dataLength, BYTE* sig, UINT32 sigLength, UINT32 sectorType ) : 
 #if defined(ARM_V1_2)
@@ -43,14 +38,16 @@ bool CryptoState::VerifySignature( UINT32 keyIndex )
     // IF THERE IS NO CONFIG SECTOR IN THE FLASH SECTOR TABLE, THEN WE DON'T HAVE KEYS, 
     // THEREFORE WE WILL NOT PERFORM SIGNATURE CHECKING.
     // 
-    if(g_PrimaryConfigManager.m_device == NULL) return true;
+    if(g_PrimaryConfigManager.m_device == NULL)
+        return true;
 
 
     switch(m_sectorType)
     {
     case BlockRange::BLOCKTYPE_DEPLOYMENT:
         // backwards compatibility
-        if(g_PrimaryConfigManager.GetTinyBooterVersion() != ConfigurationSector::c_CurrentVersionTinyBooter) return true;
+        if(g_PrimaryConfigManager.GetTinyBooterVersion() != ConfigurationSector::c_CurrentVersionTinyBooter)
+            return true;
 
         // if there is no key then we do not need to check the signature for the deployment sectors ONLY
         if(g_PrimaryConfigManager.CheckSignatureKeyEmpty( ConfigurationSector::c_DeployKeyDeployment ))
@@ -73,10 +70,11 @@ bool CryptoState::VerifySignature( UINT32 keyIndex )
             ASSERT(g_ConfigBufferLength > 0);
             ASSERT(g_ConfigBuffer != NULL);
 
-            if(g_ConfigBuffer == NULL || g_ConfigBufferLength <= 0) return false;
+            if(g_ConfigBuffer == NULL || g_ConfigBufferLength <= 0)
+                return false;
 
             // the g_ConfigBuffer contains the new configuration data
-            const ConfigurationSector* pNewCfg    = (const ConfigurationSector*)g_ConfigBuffer;
+            const ConfigurationSector* pNewCfg = (const ConfigurationSector*)g_ConfigBuffer;
 
             bool fCanWrite = false;
             bool fRet      = false;
@@ -125,7 +123,8 @@ bool CryptoState::VerifySignature( UINT32 keyIndex )
         // backwards compatibility
 
 
-        if(g_PrimaryConfigManager.GetTinyBooterVersion() != ConfigurationSector::c_CurrentVersionTinyBooter) return true;
+        if(g_PrimaryConfigManager.GetTinyBooterVersion() != ConfigurationSector::c_CurrentVersionTinyBooter)
+            return true;
 
         // if there is no key then we do not need to check the signature for the deployment sectors ONLY
         if (g_PrimaryConfigManager.CheckSignatureKeyEmpty( keyIndex ))
@@ -136,7 +135,6 @@ bool CryptoState::VerifySignature( UINT32 keyIndex )
         key = (RSAKey*)g_PrimaryConfigManager.GetDeploymentKeys( keyIndex );
 
         break;
-            
     };
 
     if(key == NULL)
@@ -151,7 +149,7 @@ bool CryptoState::VerifySignature( UINT32 keyIndex )
     {
         m_res = ::Crypto_StepRSAOperation( &m_handle );
     }
-    
+
     return m_res == CRYPTO_SUCCESS;
 }
 

--- a/Framework/Debugger/DebuggerEventSource.cs
+++ b/Framework/Debugger/DebuggerEventSource.cs
@@ -4,26 +4,164 @@ namespace Microsoft.SPOT.Debugger
 {
     using System;
     using System.Diagnostics.Tracing;
-    using Microsoft.SPOT.Debugger.WireProtocol;
+    using WireProtocol;
+    using System.Collections.Generic;
 
-    [EventSource( Name="MsOpenTech-NETMF-Debugger")]
+    [EventSource( Name="Microsoft-NETMF-Debugger")]
     internal class DebuggerEventSource : EventSource
     {
         public static DebuggerEventSource Log { get { return Log_.Value;  } }
         private static readonly Lazy<DebuggerEventSource> Log_ = new Lazy<DebuggerEventSource>( ()=>new DebuggerEventSource() );
 
-        [Event(1, Opcode=EventOpcode.Send )]
-        public void WireProtocolTxHeader( uint cmd, uint flags, ushort seq, ushort seqReply )
+#if TRACE
+        [Flags]
+        enum PacketFlags
         {
-            Trace.TraceInformation( "TX: {0:X08} {1:X08} {2:X04} {3:X04}", cmd, flags, seq, seqReply );
-            WriteCustomEvent( 1, cmd, flags, seq, seqReply );
+            None = 0,
+            NonCritical = 0x0001, // This doesn't need an acknowledge.
+            Reply = 0x0002, // This is the result of a command.
+            BadHeader = 0x0004,
+            BadPayload = 0x0008,
+            Spare0010 = 0x0010,
+            Spare0020 = 0x0020,
+            Spare0040 = 0x0040,
+            Spare0080 = 0x0080,
+            Spare0100 = 0x0100,
+            Spare0200 = 0x0200,
+            Spare0400 = 0x0400,
+            Spare0800 = 0x0800,
+            Spare1000 = 0x1000,
+            NoCaching = 0x2000,
+            NACK = 0x4000,
+            ACK = 0x8000,
+        }
+
+        private static Dictionary<uint, string> CommandNameMap = new Dictionary<uint, string>
+        {
+            [ Commands.c_Monitor_Ping ] = "Ping",
+            [ Commands.c_Monitor_Message ] = "Message",
+            [ Commands.c_Monitor_ReadMemory ] = "ReadMemory",
+            [ Commands.c_Monitor_WriteMemory ] = "WriteMemory",
+            [ Commands.c_Monitor_CheckMemory ] = "CheckMemory",
+            [ Commands.c_Monitor_EraseMemory ] = "EraseMemory",
+            [ Commands.c_Monitor_Execute ] = "Execute",
+            [ Commands.c_Monitor_Reboot ] = "Reboot",
+            [ Commands.c_Monitor_MemoryMap ] = "MemoryMap",
+            [ Commands.c_Monitor_ProgramExit ] = "ProgramExit",
+            [ Commands.c_Monitor_CheckSignature ] = "CheckSignature",
+            [ Commands.c_Monitor_DeploymentMap ] = "DeploymentMap",
+            [ Commands.c_Monitor_FlashSectorMap ] = "FlashSectorMap",
+            [ Commands.c_Monitor_SignatureKeyUpdate ] = "SignatureKeyUpdate",
+            [ Commands.c_Monitor_OemInfo ] = "OemInfo",
+            [ Commands.c_Debugging_Execution_BasePtr ] = "Execution_BasePtr",
+            [ Commands.c_Debugging_Execution_ChangeConditions ] = "Execution_ChangeConditions",
+            [ Commands.c_Debugging_Execution_SecurityKey ] = "Execution_SecurityKey",
+            [ Commands.c_Debugging_Execution_Unlock ] = "Execution_Unlock",
+            [ Commands.c_Debugging_Execution_Allocate ] = "Execution_Allocate",
+            [ Commands.c_Debugging_Execution_Breakpoints ] = "Execution_Breakpoints",
+            [ Commands.c_Debugging_Execution_BreakpointHit ] = "Execution_BreakpointHit",
+            [ Commands.c_Debugging_Execution_BreakpointStatus ] = "Execution_BreakpointStatus",
+            [ Commands.c_Debugging_Execution_QueryCLRCapabilities ] = "Execution_QueryCLRCapabilities",
+            [ Commands.c_Debugging_Execution_SetCurrentAppDomain ] = "Execution_SetCurrentAppDomain",
+            [ Commands.c_Debugging_Thread_Create ] = "Thread_Create",
+            [ Commands.c_Debugging_Thread_List ] = "Thread_List",
+            [ Commands.c_Debugging_Thread_Stack ] = "Thread_Stack",
+            [ Commands.c_Debugging_Thread_Kill ] = "Thread_Kill",
+            [ Commands.c_Debugging_Thread_Suspend ] = "Thread_Suspend",
+            [ Commands.c_Debugging_Thread_Resume ] = "Thread_Resume",
+            [ Commands.c_Debugging_Thread_GetException ] = "Thread_GetException",
+            [ Commands.c_Debugging_Thread_Unwind ] = "Thread_Unwind",
+            [ Commands.c_Debugging_Thread_CreateEx ] = "Thread_CreateEx",
+            [ Commands.c_Debugging_Thread_Get ] = "Thread_Get",
+            [ Commands.c_Debugging_Stack_Info ] = "Stack_Info",
+            [ Commands.c_Debugging_Stack_SetIP ] = "Stack_SetIP",
+            [ Commands.c_Debugging_Value_ResizeScratchPad ] = "Value_ResizeScratchPad",
+            [ Commands.c_Debugging_Value_GetStack ] = "Value_GetStack",
+            [ Commands.c_Debugging_Value_GetField ] = "Value_GetField",
+            [ Commands.c_Debugging_Value_GetArray ] = "Value_GetArray",
+            [ Commands.c_Debugging_Value_GetBlock ] = "Value_GetBlock",
+            [ Commands.c_Debugging_Value_GetScratchPad ] = "Value_GetScratchPad",
+            [ Commands.c_Debugging_Value_SetBlock ] = "Value_SetBlock",
+            [ Commands.c_Debugging_Value_SetArray ] = "Value_SetArray",
+            [ Commands.c_Debugging_Value_AllocateObject ] = "Value_AllocateObject",
+            [ Commands.c_Debugging_Value_AllocateString ] = "Value_AllocateString",
+            [ Commands.c_Debugging_Value_AllocateArray ] = "Value_AllocateArray",
+            [ Commands.c_Debugging_Value_Assign ] = "Value_Assign",
+            [ Commands.c_Debugging_TypeSys_Assemblies ] = "TypeSys_Assemblies",
+            [ Commands.c_Debugging_TypeSys_AppDomains ] = "TypeSys_AppDomains",
+            [ Commands.c_Debugging_Resolve_Assembly ] = "Resolve_Assembly",
+            [ Commands.c_Debugging_Resolve_Type ] = "Resolve_Type",
+            [ Commands.c_Debugging_Resolve_Field ] = "Resolve_Field",
+            [ Commands.c_Debugging_Resolve_Method ] = "Resolve_Method",
+            [ Commands.c_Debugging_Resolve_VirtualMethod ] = "Resolve_VirtualMethod",
+            [ Commands.c_Debugging_Resolve_AppDomain ] = "Resolve_AppDomain",
+            [ Commands.c_Debugging_MFUpdate_Start ] = "MFUpdate_Start",
+            [ Commands.c_Debugging_MFUpdate_AddPacket ] = "MFUpdate_AddPacket",
+            [ Commands.c_Debugging_MFUpdate_Install ] = "MFUpdate_Install",
+            [ Commands.c_Debugging_MFUpdate_AuthCmd ] = "MFUpdate_AuthCmd",
+            [ Commands.c_Debugging_MFUpdate_Authenticate ] = "MFUpdate_Authenticate",
+            [ Commands.c_Debugging_MFUpdate_GetMissingPkts ] = "MFUpdate_GetMissingPkts",
+            [ Commands.c_Debugging_UpgradeToSsl ] = "UpgradeToSsl",
+            [ Commands.c_Debugging_Lcd_NewFrame ] = "Lcd_NewFrame",
+            [ Commands.c_Debugging_Lcd_NewFrameData ] = "Lcd_NewFrameData",
+            [ Commands.c_Debugging_Lcd_GetFrame ] = "Lcd_GetFrame",
+            [ Commands.c_Debugging_Button_Report ] = "Button_Report",
+            [ Commands.c_Debugging_Button_Inject ] = "Button_Inject",
+            [ Commands.c_Debugging_Messaging_Query ] = "Messaging_Query",
+            [ Commands.c_Debugging_Messaging_Send ] = "Messaging_Send",
+            [ Commands.c_Debugging_Messaging_Reply ] = "Messaging_Reply",
+            [ Commands.c_Debugging_Logging_GetNumberOfRecords ] = "Logging_GetNumberOfRecords",
+            [ Commands.c_Debugging_Logging_GetRecord ] = "Logging_GetRecord",
+            [ Commands.c_Debugging_Logging_Erase ] = "Logging_Erase",
+            [ Commands.c_Debugging_Logging_GetRecords ] = "Logging_GetRecords",
+            [ Commands.c_Debugging_Deployment_Status ] = "Deployment_Status",
+            [ Commands.c_Debugging_Info_SetJMC ] = "Info_SetJMC",
+            [ Commands.c_Profiling_Command ] = "Profiling_Command",
+            [ Commands.c_Profiling_Stream ] = "Profiling_Stream"
+        };
+
+        string GetCommandName( uint cmd )
+        {
+            string retVal;
+            if( !CommandNameMap.TryGetValue( cmd, out retVal ) )
+                retVal = $"0x{cmd:X08}";
+
+            return retVal;
+        }
+#endif
+
+        [Event( 1, Opcode = EventOpcode.Send )]
+        public void WireProtocolTxHeader( uint crcHeader, uint crcData, uint cmd, uint flags, ushort seq, ushort seqReply, uint length )
+        {
+#if TRACE
+            Trace.TraceInformation( "TX: {0} flags=[{1}] hCRC: 0x{2:X08} pCRC: 0x{3:X08} seq: 0x{4:X04} replySeq: 0x{5:X04} len={6}"
+                                      , GetCommandName( cmd )
+                                      , ( PacketFlags )flags
+                                      , crcHeader
+                                      , crcData
+                                      , seq
+                                      , seqReply
+                                      , length
+                                      );
+#endif
+            WriteCustomEvent( 1, crcHeader, crcData, cmd, flags, seq, seqReply, length );
         }
 
         [Event( 2, Opcode = EventOpcode.Receive )]
-        public void WireProtocolRxHeader( uint cmd, uint flags, ushort seq, ushort seqReply )
+        public void WireProtocolRxHeader( uint crcHeader, uint crcData, uint cmd, uint flags, ushort seq, ushort seqReply, uint length )
         {
-            Trace.TraceInformation( "RX: {0:X08} {1:X08} {2:X04} {3:X04}", cmd, flags, seq, seqReply );
-            WriteCustomEvent( 2, cmd, flags, seq, seqReply );
+#if TRACE
+            Trace.TraceInformation( "RX: {0} flags=[{1}] hCRC: 0x{2:X08} pCRC: 0x{3:X08} seq: 0x{4:X04} replySeq: 0x{5:X04} len={6}"
+                                  , GetCommandName( cmd )
+                                  , ( PacketFlags )flags
+                                  , crcHeader
+                                  , crcData
+                                  , seq
+                                  , seqReply
+                                  , length
+                                  );
+#endif
+            WriteCustomEvent( 2, crcHeader, crcData, cmd, flags, seq, seqReply, length );
         }
 
         [Event( 3 )]
@@ -35,8 +173,15 @@ namespace Microsoft.SPOT.Debugger
         [Event(4)]
         public void EngineEraseMemory( uint address, uint length )
         {
-            Trace.TraceInformation( "EreaseMemory: @{0:X08}; LEN={1:X08}", address, length );
+            Trace.TraceInformation( "EraseMemory: @0x{0:X08}; LEN=0x{1:X08}", address, length );
             WriteEvent( 4, ( int )address, ( int )length );
+        }
+
+        [Event(5)]
+        public void EngineWriteMemory( uint address, int length )
+        {
+            Trace.TraceInformation( "WriteMemory: @0x{0:X08}; LEN=0x{1:X08}", address, length );
+            WriteEvent( 5, ( int )address, length );
         }
 
         private DebuggerEventSource()
@@ -44,18 +189,31 @@ namespace Microsoft.SPOT.Debugger
         }
 
         [NonEvent]
-        unsafe void WriteCustomEvent(int eventId, uint cmd, uint flags, ushort seq, ushort seqReply )
+        unsafe void WriteCustomEvent( int eventId, uint crcHeader, uint crcData, uint cmd, uint flags, ushort seq, ushort seqReply, uint length )
         {
-            EventData* pDataDesc = stackalloc EventData[ 4 ];
-            pDataDesc[ 0 ].DataPointer = (IntPtr)( &cmd );
-            pDataDesc[ 0 ].Size = sizeof( int );
-            pDataDesc[ 1 ].DataPointer = ( IntPtr )( &flags );
-            pDataDesc[ 1 ].Size = sizeof( int );
-            pDataDesc[ 2 ].DataPointer = ( IntPtr )( &seq );
-            pDataDesc[ 2 ].Size = sizeof( ushort );
-            pDataDesc[ 3 ].DataPointer = ( IntPtr )( &seqReply );
-            pDataDesc[ 3 ].Size = sizeof( ushort );
-            WriteEventCore( eventId, 4, pDataDesc );
+            EventData* pDataDesc = stackalloc EventData[ 7 ];
+            pDataDesc[ 0 ].DataPointer = ( IntPtr )( &crcHeader );
+            pDataDesc[ 0 ].Size = sizeof( uint );
+
+            pDataDesc[ 1 ].DataPointer = ( IntPtr )( &crcData );
+            pDataDesc[ 1 ].Size = sizeof( uint );
+
+            pDataDesc[ 2 ].DataPointer = (IntPtr)( &cmd );
+            pDataDesc[ 2 ].Size = sizeof( uint );
+
+            pDataDesc[ 3 ].DataPointer = ( IntPtr )( &flags );
+            pDataDesc[ 3 ].Size = sizeof( uint );
+
+            pDataDesc[ 4 ].DataPointer = ( IntPtr )( &seq );
+            pDataDesc[ 4 ].Size = sizeof( ushort );
+
+            pDataDesc[ 5 ].DataPointer = ( IntPtr )( &seqReply );
+            pDataDesc[ 5 ].Size = sizeof( ushort );
+
+            pDataDesc[ 6 ].DataPointer = ( IntPtr )( &length );
+            pDataDesc[ 6 ].Size = sizeof( uint );
+
+            WriteEventCore( eventId, 7, pDataDesc );
         }
     }
 }

--- a/Framework/Debugger/WireProtocol/Engine.cs
+++ b/Framework/Debugger/WireProtocol/Engine.cs
@@ -1659,6 +1659,7 @@ namespace Microsoft.SPOT.Debugger
 
                 cmd.PrepareForSend( address, buf, pos, len );
 
+                DebuggerEventSource.Log.EngineWriteMemory( address, len );
                 IncomingMessage reply = SyncMessage( Commands.c_Monitor_WriteMemory, 0, cmd );
 
                 if( !IncomingMessage.IsPositiveAcknowledge( reply ) )

--- a/Framework/Debugger/WireProtocol/MessageReassembler.cs
+++ b/Framework/Debugger/WireProtocol/MessageReassembler.cs
@@ -126,7 +126,7 @@ namespace Microsoft.SPOT.Debugger.WireProtocol
                         {
                             bool fReply = (m_base.m_header.m_flags & Flags.c_Reply) != 0;
 
-                            DebuggerEventSource.Log.WireProtocolRxHeader( m_base.m_header.m_cmd, m_base.m_header.m_flags, m_base.m_header.m_seq, m_base.m_header.m_seqReply );
+                            DebuggerEventSource.Log.WireProtocolRxHeader( m_base.m_header.m_crcHeader, m_base.m_header.m_crcData, m_base.m_header.m_cmd, m_base.m_header.m_flags, m_base.m_header.m_seq, m_base.m_header.m_seqReply, m_base.m_header.m_size );
 
                             if(m_base.m_header.m_size != 0)
                             {

--- a/Framework/Debugger/WireProtocol/OutgoingMessage.cs
+++ b/Framework/Debugger/WireProtocol/OutgoingMessage.cs
@@ -43,7 +43,14 @@ namespace Microsoft.SPOT.Debugger.WireProtocol
         {
             try
             {
-                DebuggerEventSource.Log.WireProtocolTxHeader( m_base.m_header.m_cmd, m_base.m_header.m_flags, m_base.m_header.m_seq, m_base.m_header.m_seqReply );
+                DebuggerEventSource.Log.WireProtocolTxHeader( m_base.m_header.m_crcHeader
+                                                            , m_base.m_header.m_crcData
+                                                            , m_base.m_header.m_cmd
+                                                            , m_base.m_header.m_flags
+                                                            , m_base.m_header.m_seq
+                                                            , m_base.m_header.m_seqReply
+                                                            , m_base.m_header.m_size
+                                                            );
                 return m_parent.QueueOutput( m_raw );
             }
             catch

--- a/Framework/Tools/MFDeploy/Library/MFConfigHelper.cs
+++ b/Framework/Tools/MFDeploy/Library/MFConfigHelper.cs
@@ -483,7 +483,8 @@ namespace Microsoft.NetMicroFramework.Tools.MFDeployTool.Engine
                     m_StaticConfig.Version.TinyBooter = 4;
                 }
 
-                if (m_StaticConfig.ConfigurationLength >= m_cfg_sector.m_size)    throw new MFInvalidConfigurationSectorException();
+                if (m_StaticConfig.ConfigurationLength >= m_cfg_sector.m_size)
+                    throw new MFInvalidConfigurationSectorException();
 
                 if (m_StaticConfig.Version.TinyBooter == 4)
                 {

--- a/Framework/Tools/MFDeploy/Library/MFCryptoWrapper.cs
+++ b/Framework/Tools/MFDeploy/Library/MFCryptoWrapper.cs
@@ -43,17 +43,22 @@ namespace dotNetMFCrypto
             VERIFYSIGNATURE
         }
 
-        [DllImport(@"Crypto.dll")]
+        [DllImport(@"Crypto.dll", CallingConvention = CallingConvention.Cdecl ) ]
         static public extern bool Crypto_Encrypt([In] byte[] Key, [In, Out] byte[] IV, int cbIVSize, [In] byte[] pPlainText, int cbPlainText, [Out] byte[] pCypherText, int cbCypherText);
-        [DllImport(@"Crypto.dll")]
+
+        [DllImport(@"Crypto.dll", CallingConvention = CallingConvention.Cdecl )]
         static public extern bool Crypto_Decrypt([In] byte[] Key, [In, Out] byte[] IV, int cbIVSize, [In] byte[] pCypherText, int cbCypherText, [Out] byte[] pPlainText, int cbPlainText);
-        [DllImport(@"Crypto.dll")]
+
+        [DllImport(@"Crypto.dll", CallingConvention = CallingConvention.Cdecl )]
         static public extern int Crypto_CreateZenithKey([In] byte[] seed, out ushort delta1, out ushort delta2);
-        [DllImport(@"Crypto.dll")]
+
+        [DllImport(@"Crypto.dll", CallingConvention = CallingConvention.Cdecl )]
         static public extern int Crypto_SignBuffer([In] byte[] buffer, int bufLen, [In] byte[] key, [Out] byte[] signature, int siglen);
-        [DllImport(@"Crypto.dll")]
+
+        [DllImport(@"Crypto.dll", CallingConvention = CallingConvention.Cdecl )]
         static public extern int Crypto_GeneratePrivateKey([In] byte[] seed, [Out] byte[] privateKey);
-        [DllImport(@"Crypto.dll")]
+
+        [DllImport(@"Crypto.dll", CallingConvention = CallingConvention.Cdecl )]
         static public extern int Crypto_PublicKeyFromPrivate([In] byte[] privkey, [Out] byte[] pubkey);
     }
 }

--- a/Solutions/MCBSTM32F400/DeviceCode/M29W640FB_Flash/M29W640FB_Flash_driver.cpp
+++ b/Solutions/MCBSTM32F400/DeviceCode/M29W640FB_Flash/M29W640FB_Flash_driver.cpp
@@ -154,7 +154,7 @@ BOOL M29W640FB_Flash_Driver::Write(void* context, ByteAddress Address, UINT32 Nu
     {
         return FALSE;
     }
-    
+    M29W640FB_WaitReady();
     return TRUE;
 }
 
@@ -259,6 +259,7 @@ BOOL M29W640FB_Flash_Driver::EraseBlock( void* context, ByteAddress Sector )
 
     M29W640FB_WaitReady();
     Driver_Flash0.EraseSector(Sector);
+    M29W640FB_WaitReady();
 
     return TRUE;
 }

--- a/Solutions/MCBSTM32F400/MCBSTM32F400.settings
+++ b/Solutions/MCBSTM32F400/MCBSTM32F400.settings
@@ -16,7 +16,7 @@
         <TCP_IP_STACK>LWIP_1_4_1_OS</TCP_IP_STACK>
     </PropertyGroup>
     <PropertyGroup>
-        <OEMSystemInfoString>Copyright (C) Microsoft Open Technologies Inc.</OEMSystemInfoString>
+        <OEMSystemInfoString>Copyright (C) Microsoft Corporation</OEMSystemInfoString>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Solutions/MCBSTM32F400/TinyCLR/TinyCLR.proj
+++ b/Solutions/MCBSTM32F400/TinyCLR/TinyCLR.proj
@@ -134,8 +134,8 @@
         <RequiredProjects Include="$(SPOCLIENT)\CLR\StartupLib\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Crypto_stub.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\Crypto\stubs\dotNetMF.proj" />
+        <DriverLibs Include="Crypto.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\Crypto\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
         <RequiredProjects Include="$(SPOCLIENT)\Solutions\MCBSTM32F400\DeviceCode\GlobalLock\dotNetMF.proj" />

--- a/Support/WireProtocol/WireProtocol.cpp
+++ b/Support/WireProtocol/WireProtocol.cpp
@@ -5,13 +5,19 @@
 #include "stdafx.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
+#define TRACE_ERRORS 1
+#define TRACE_HEADERS 2
+#define TRACE_STATE 4
+#define TRACE_NODATA 8
 
-#if 0
-#define TRACE0( msg, ...) hal_printf( msg ) 
-#define TRACE( msg, ...) hal_printf( msg, __VA_ARGS__ ) 
+#define TRACE_MASK (TRACE_ERRORS)
+
+#if TRACE_MASK != 0
+#define TRACE0( f, msg ) if((f) & TRACE_MASK ) debug_printf( msg ) 
+#define TRACE( f, msg, ...) if((f) & TRACE_MASK ) debug_printf( msg, __VA_ARGS__ ) 
 #else
-#define TRACE0(msg,...)
-#define TRACE(msg,...)
+#define TRACE0( f, msg,...)
+#define TRACE( f, msg,...)
 #endif
 
 void WP_Message::Initialize( WP_Controller* parent )
@@ -113,18 +119,26 @@ bool WP_Message::VerifyHeader()
     UINT32 crc = ::SwapEndian( m_header.m_crcHeader );
 #endif
     m_header.m_crcHeader = 0;
-    fRes = SUPPORT_ComputeCRC( (UINT8*)&m_header, sizeof(m_header), 0 ) == crc;
-
+    UINT32 computedCrc = SUPPORT_ComputeCRC( ( UINT8* )&m_header, sizeof( m_header ), 0 );
     m_header.m_crcHeader = crc;
+    fRes = computedCrc == crc;
+    if( !fRes )
+        TRACE( TRACE_ERRORS, "Header CRC check failed: computed: 0x%08X; got: 0x%08X\n", computedCrc, m_header.m_crcHeader );
 
     return fRes;
 }
 
 bool WP_Message::VerifyPayload()
 {
-    if(m_payload == NULL && m_header.m_size) return false;
+    if( m_payload == NULL && m_header.m_size )
+        return false;
 
-    return SUPPORT_ComputeCRC( m_payload, m_header.m_size, 0 ) == m_header.m_crcData;
+    UINT32 computedCrc = SUPPORT_ComputeCRC( m_payload, m_header.m_size, 0 );
+    bool fRes = ( computedCrc == m_header.m_crcData );
+    if( !fRes )
+        TRACE( TRACE_ERRORS, "Payload CRC check failed: computed: 0x%08X; got: 0x%08X\n", computedCrc, m_header.m_crcData );
+
+    return fRes;
 }
 
 void WP_Message::ReplyBadPacket( UINT32 flags )
@@ -134,9 +148,9 @@ void WP_Message::ReplyBadPacket( UINT32 flags )
     msg.Initialize( m_parent );
 
     msg.PrepareRequest( 0, WP_Flags::c_NonCritical | WP_Flags::c_NACK | flags, 0, NULL );
-
     m_parent->SendProtocolMessage( msg );
 }
+
 bool WP_Message::Process()
 {
     UINT8* buf = (UINT8*)&m_header;
@@ -147,11 +161,11 @@ bool WP_Message::Process()
         switch(m_rxState)
         {
         case ReceiveState::Idle:
-            TRACE0("RxState==IDLE\n");
+            TRACE0( TRACE_STATE, "RxState==IDLE\n");
             return true;
 
         case ReceiveState::Initialize:
-            TRACE0("RxState==INIT\n");
+            TRACE0( TRACE_STATE, "RxState==INIT\n");
             Release();
 
             m_rxState = ReceiveState::WaitingForHeader;
@@ -160,10 +174,10 @@ bool WP_Message::Process()
             break;
 
         case ReceiveState::WaitingForHeader:
-            TRACE0("RxState==WaitForHeader\n");
+            TRACE0( TRACE_STATE, "RxState==WaitForHeader\n");
             if(m_parent->m_phy->ReceiveBytes( m_parent->m_state, m_pos, m_size ) == false)
             {
-                TRACE0("RxError - bailing out\n");
+                TRACE0( TRACE_NODATA, "ReceiveBytes returned false - bailing out\n");
                 return true;
             }
 
@@ -192,10 +206,10 @@ bool WP_Message::Process()
             break;
 
         case ReceiveState::ReadingHeader:
-            TRACE0("RxState==ReadingHeader\n");
+            TRACE0( TRACE_STATE, "RxState==ReadingHeader\n");
             if(m_parent->m_phy->ReceiveBytes( m_parent->m_state, m_pos, m_size ) == false)
             {
-                TRACE0("RxError - bailing out\n");
+                TRACE0( TRACE_NODATA, "ReceiveBytes returned false - bailing out\n");
                 return true;
             }
 
@@ -207,7 +221,7 @@ bool WP_Message::Process()
 
         case ReceiveState::CompleteHeader:
             {
-                TRACE0("RxState=CompleteHeader\n");
+                TRACE0( TRACE_STATE, "RxState=CompleteHeader\n");
 
                 bool fBadPacket=true;
                 if( VerifyHeader() )
@@ -215,6 +229,7 @@ bool WP_Message::Process()
 #if defined(BIG_ENDIAN)
                     SwapEndian();
 #endif
+                    TRACE( TRACE_HEADERS, "RXMSG: 0x%08X, 0x%08X, 0x%08X\n", m_header.m_cmd, m_header.m_flags, m_header.m_size );
                     if ( m_parent->m_app->ProcessHeader( m_parent->m_state, this ) )
                     {
                         fBadPacket = false;
@@ -253,7 +268,7 @@ bool WP_Message::Process()
 
         case ReceiveState::ReadingPayload:
             {
-                TRACE0("RxState=ReadingPayload\n");
+                TRACE0( TRACE_STATE, "RxState=ReadingPayload\n");
                 
                 UINT64 curTicks = HAL_Time_CurrentTicks();
 
@@ -266,7 +281,7 @@ bool WP_Message::Process()
                 
                     if(m_parent->m_phy->ReceiveBytes( m_parent->m_state, m_pos, m_size ) == false)
                     {
-                        TRACE0("RxError - Bailing out!\n");
+                        TRACE0( TRACE_NODATA, "ReceiveBytes returned false - bailing out\n");
                         return true;
                     }
 
@@ -277,14 +292,14 @@ bool WP_Message::Process()
                 }
                 else
                 {
-                    TRACE0("RxError: Payload InterCharacterTimeout exceeded\n");
+                    TRACE0( TRACE_ERRORS, "RxError: Payload InterCharacterTimeout exceeded\n");
                     m_rxState = ReceiveState::Initialize;
                 }
             }
             break;
 
         case ReceiveState::CompletePayload:
-            TRACE0("RsState=CompletePayload\n");
+            TRACE0( TRACE_STATE, "RxState=CompletePayload\n");
             if(VerifyPayload() == true)
             {
                 m_parent->m_app->ProcessPayload( m_parent->m_state, this );
@@ -299,7 +314,7 @@ bool WP_Message::Process()
 
 
         default:
-            TRACE0("RxState=UNKNOWN!!\n");
+            TRACE0( TRACE_ERRORS, "RxState=UNKNOWN!!\n");
             return false;
         }
     }
@@ -344,6 +359,7 @@ bool WP_Controller::AdvanceState()
 
 bool WP_Controller::SendProtocolMessage( const WP_Message& msg )
 {
+    TRACE( TRACE_HEADERS, "TXMSG: 0x%08X, 0x%08X, 0x%08X\n", msg.m_header.m_cmd, msg.m_header.m_flags, msg.m_header.m_size );
     return m_phy->TransmitMessage( m_state, &msg );
 }
 

--- a/crypto/dotNetMF.proj
+++ b/crypto/dotNetMF.proj
@@ -53,38 +53,38 @@
     <CryptoStub Condition="'$(COMPILER_TOOL)'  =='GCCOP'"   >true</CryptoStub>
 
     <CustomTargets Condition="'$(CryptoStub)'=='false'">CryptoLib</CustomTargets>
-    <CustomTargets Condition="'$(INSTRUCTION_SET)'=='x86'">CryptoLibX86</CustomTargets>
+    <CustomTargets Condition="'$(CryptoInstructionSet)'=='x86'">CryptoLibX86</CustomTargets>
   </PropertyGroup>
 
 
-  <PropertyGroup Condition="'$(INSTRUCTION_SET)'!='x86'">
-    <LibSrc                                                                >lib\$(INSTRUCTION_SET)\$(DOTNETMF_COMPILER)\crypto.$(LIB_EXT)</LibSrc>
-    <LibSrc Condition="'$(COMPILER_TOOL)'=='ARM' AND !EXISTS('$(LibSrc)')" >lib\$(INSTRUCTION_SET)\RVDS4.0\crypto.$(LIB_EXT)</LibSrc>
-    <LibSrc Condition="'$(COMPILER_TOOL)'=='GCC'"                          >lib\$(INSTRUCTION_SET)\RVDS3.1\crypto.$(LIB_EXT)</LibSrc>
-    <LibSrc Condition="'$(COMPILER_TOOL)'=='ARC'"                          >lib\$(INSTRUCTION_SET)\MTWR8.0\crypto.$(LIB_EXT)</LibSrc>
+  <PropertyGroup Condition="'$(CryptoInstructionSet)'!='x86'">
+    <LibSrc                                                                >lib\$(CryptoInstructionSet)\$(DOTNETMF_COMPILER)\crypto.$(LIB_EXT)</LibSrc>
+    <LibSrc Condition="'$(COMPILER_TOOL)'=='ARM' AND !EXISTS('$(LibSrc)')" >lib\$(CryptoInstructionSet)\RVDS4.0\crypto.$(LIB_EXT)</LibSrc>
+    <LibSrc Condition="'$(COMPILER_TOOL)'=='GCC' OR '$(COMPILER_TOOL)'=='MDK'">lib\$(CryptoInstructionSet)\RVDS3.1\crypto.$(LIB_EXT)</LibSrc>
+    <LibSrc Condition="'$(COMPILER_TOOL)'=='ARC'"                          >lib\$(CryptoInstructionSet)\MTWR8.0\crypto.$(LIB_EXT)</LibSrc>
     <LibSrc Condition="!EXISTS('$(LibSrc)')"                               >$(LIB_DIR)\crypto_stub.$(LIB_EXT)</LibSrc>
     <LibTo>crypto.$(LIB_EXT)</LibTo>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(INSTRUCTION_SET)'=='x86'">
-    <LibFiles Include="lib\$(INSTRUCTION_SET)\crypto.lib" Condition="EXISTS('lib\$(INSTRUCTION_SET)\crypto.lib')">
+  <ItemGroup Condition="'$(CryptoInstructionSet)'=='x86'">
+    <LibFiles Include="lib\$(CryptoInstructionSet)\crypto.lib" Condition="EXISTS('lib\$(CryptoInstructionSet)\crypto.lib')">
         <DestFile>crypto.lib</DestFile>
     </LibFiles>
-    <LibFiles Include="lib\$(INSTRUCTION_SET)\crypto.pdb" Condition="Exists('lib\$(INSTRUCTION_SET)\crypto.pdb')">
+    <LibFiles Include="lib\$(CryptoInstructionSet)\crypto.pdb" Condition="Exists('lib\$(CryptoInstructionSet)\crypto.pdb')">
         <DestFile>crypto.pdb</DestFile>
     </LibFiles>
-    <LibFiles Include="$(LIB_DIR)\crypto_stub.lib"        Condition="!Exists('lib\$(INSTRUCTION_SET)\crypto.lib')">
+    <LibFiles Include="$(LIB_DIR)\crypto_stub.lib"        Condition="!Exists('lib\$(CryptoInstructionSet)\crypto.lib')">
         <DestFile>crypto.lib</DestFile>
     </LibFiles>
   </ItemGroup>
 
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Targets" />
 
-  <ItemGroup Condition="'$(INSTRUCTION_SET)'!='x86'">
+  <ItemGroup Condition="'$(CryptoInstructionSet)'!='x86'">
     <ExtraCleanFiles Include="$(LIB_DIR)\$(LibTo)"/>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(INSTRUCTION_SET)'=='x86'">
+  <ItemGroup Condition="'$(CryptoInstructionSet)'=='x86'">
     <ExtraCleanFiles Include="@(LibFiles -> '$(LIB_DIR)\%(Filename)%(Extension)')" />
   </ItemGroup>
 

--- a/crypto/inc/crypto.h
+++ b/crypto/inc/crypto.h
@@ -159,8 +159,14 @@ extern ALIGN const RSABuffer dotNetMFPublicKeyModulus;
 // For RSA_VERIFYSIGNATURE pass the buffer in pSourceText and the signature in pDestText
 //
 
-CRYPTO_RESULT Crypto_StartRSAOperationWithKey(enum RSAOperations operation, RSAKey *pRSAKey, BYTE *pSourceText, DWORD cbSourceText, BYTE *pDestText, DWORD cbDestText,
-		   					   void **ppHandle);
+CRYPTO_RESULT Crypto_StartRSAOperationWithKey( enum RSAOperations operation
+                                             , RSAKey *pRSAKey
+                                             , BYTE *pSourceText
+                                             , DWORD cbSourceText
+                                             , BYTE *pDestText
+                                             , DWORD cbDestText
+                                             , void **ppHandle
+                                             );
 
 
 //


### PR DESCRIPTION
- Added code to tinybooter to dump out newkey, signature and current key on failure to verify signature on key updates to aid in diagnosing issues with Crypto library.
- fixed multiple issues of return or throw on smae line as conditional expression which make debugging difficult. (Some debuggers can't set breakpoints on line and column)
- for the crypto.lib project forced mapping MDK to the RVDS3.1 thumb2 crypto libraries.
- added more readable wire-protocal packet tracing, now prints the command id as a textual name along with a decoded form of the flags with textual names for all active flags to aid in debugging the communications.
- fixed DLLImports for the Crypto.dll to use CDecl calling convention to prevent issues with stack corruption and eliminate MDA exception while debugging.
- Fixed flash driver for MCBSTM32F400 to check for ready status after erase to ensure chip is in a valid state before continuing. Othereise the chip can get corrupted (particularly the Config sector)
- Added Addditional debug and ETW tracing for the NETMF wireprotocol in MFDeploy and VS integration.
- Added additional trace messaging support toe device side wire protocol to help in tracking any failures that might occur on a device.