### PR TITLE
STM32F4x9_Flash_driver.cpp also needs FLASH definition

### DIFF
--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/STM32F4_Flash.h
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/STM32F4_Flash.h
@@ -19,6 +19,10 @@
 
 //--//
 
+#ifndef FLASH
+#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
+#endif
+
 struct STM32F4_Flash_Driver
 {
 

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/STM32F4_Flash_driver.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Flash/STM32F4_Flash_driver.cpp
@@ -20,10 +20,6 @@
 #include "..\stm32f2xx.h"
 #endif
 
-#ifndef FLASH
-#define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
-#endif
-
     typedef UINT16 CHIP_WORD;
 
 #define FLASH_CR_PSIZE_BITS FLASH_CR_PSIZE_0 // 16 bit programming


### PR DESCRIPTION
STM32F4x9_Flash_driver.cpp also needs FLASH definition.
So I moved FLASH definition to the header file.