### PR TITLE
Fix http tests issues

### DIFF
--- a/Test/Platform/Tests/CLR/System/Http/FunctionalTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/FunctionalTests.cs
@@ -197,9 +197,6 @@ namespace Microsoft.SPOT.Platform.Tests
 
             // Create request.
             HttpWebRequest request = HttpWebRequest.Create(uri) as HttpWebRequest;
-            // Set proxy information
-            WebProxy itgProxy = new WebProxy(HttpTests.Proxy, true);
-            request.Proxy = itgProxy;
             // Get response from server.
             WebResponse resp = null;
             try

--- a/Test/Platform/Tests/CLR/System/Http/HttpKnownHeaderNamesTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/HttpKnownHeaderNamesTests.cs
@@ -15,7 +15,14 @@ namespace Microsoft.SPOT.Platform.Tests
         public InitializeResult Initialize()
         {
             Log.Comment("Adding set up for the tests.");
-            // Add your functionality here.   
+            try
+            {
+                Microsoft.SPOT.Net.NetworkInformation.NetworkInterface[] nis = Microsoft.SPOT.Net.NetworkInformation.NetworkInterface.GetAllNetworkInterfaces();
+            }
+            catch
+            {
+                return InitializeResult.Skip;
+            }
 
             return InitializeResult.ReadyToGo;
         }
@@ -83,7 +90,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults TestSetHTTPRequestHeaderAfterCreateHTTP1_1()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -121,7 +128,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults ValidateAbleToSetPropertiesValueHTTP1_1()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -217,7 +224,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults TestSetHTTPRequestHeaderAfterCreateHTTP1_0()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -256,7 +263,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults ValidateAbleToSetPropertiesValueHTTP1_0()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1

--- a/Test/Platform/Tests/CLR/System/Http/HttpRequestHeaderTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/HttpRequestHeaderTests.cs
@@ -82,7 +82,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults ValidDefaultTestGetHTTPRequestHeaderAfterCreateHTTP1_1()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -166,7 +166,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults InValidDefaultTestGetHTTPRequestHeaderAfterCreateHTTP1_1_Https()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("https://127.0.0.1:443/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("https://"+ Utilities.GetLocalIpAddress() + ":443/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Negative Test case 1:");
@@ -309,7 +309,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults ValidDefaultTestGetHTTPRequestHeaderAfterCreateHTTP1_0()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -351,7 +351,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults ValidDefaultTestGetHTTPRequestHeaderAfterCreateHTTP1_0_HTTPS()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("https://127.0.0.1:443/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("https://"+ Utilities.GetLocalIpAddress() + ":443/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -393,7 +393,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults InValidDefaultTestGetHTTPRequestHeaderAfterCreateHTTP1_0_HTTPS()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("https://127.0.0.1:443/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("https://"+ Utilities.GetLocalIpAddress() + ":443/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Negative Test case 4:");

--- a/Test/Platform/Tests/CLR/System/Http/HttpServer.cs
+++ b/Test/Platform/Tests/CLR/System/Http/HttpServer.cs
@@ -65,6 +65,8 @@ namespace Microsoft.SPOT.Platform.Tests
                 s_CurrentPort++;
                 throw new Exception("StartServer failed");
             }
+
+            s_CurrentPort++;
         }
 
 

--- a/Test/Platform/Tests/CLR/System/Http/HttpStatusCodeTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/HttpStatusCodeTests.cs
@@ -44,7 +44,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -98,7 +98,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/Unauth.html");  //expect 401 - Unauthorized 
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/Unauth.html");  //expect 401 - Unauthorized 
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -150,7 +150,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotFound.html");  //expect 404 - NotFound  
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotFound.html");  //expect 404 - NotFound  
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -205,7 +205,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotExistUriPath.html");      
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotExistUriPath.html");      
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -258,7 +258,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -288,7 +288,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -361,7 +361,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/index.html");  //expect 300 - Ambiguous
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/index.html");  //expect 300 - Ambiguous
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -413,7 +413,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/Gateway.html");  //expect 502 - BadGateway
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/Gateway.html");  //expect 502 - BadGateway
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -467,7 +467,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/conflict.html");  //expect 409 - Conflict
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/conflict.html");  //expect 409 - Conflict
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -521,7 +521,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/moved.html");  //expect 301 - Moved
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/moved.html");  //expect 301 - Moved
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -575,7 +575,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/redirect.html");  //expect 302 - Redirect
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/redirect.html");  //expect 302 - Redirect
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -629,7 +629,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/payment.html");  //expect 402 - PaymentRequired
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/payment.html");  //expect 402 - PaymentRequired
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -683,7 +683,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/testTimeOut.html");  //expect 408 - RequestTimeout
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/testTimeOut.html");  //expect 408 - RequestTimeout
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -739,7 +739,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/local/webpages/mysubdir/index.html");  //expect 414 - RequestUriTooLong
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/local/webpages/mysubdir/index.html");  //expect 414 - RequestUriTooLong
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -795,7 +795,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/service.html");  //expect 503 - ServiceUnavailable
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/service.html");  //expect 503 - ServiceUnavailable
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -851,7 +851,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/tempRedir.html");  //expect 307 - TemporaryRedirect
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/tempRedir.html");  //expect 307 - TemporaryRedirect
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -906,7 +906,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/accepted.html");  //expect 202 - Accepted
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/accepted.html");  //expect 202 - Accepted
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -961,7 +961,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/badRequest.html");  //expect 400 - BadRequest
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/badRequest.html");  //expect 400 - BadRequest
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1016,7 +1016,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/continue.html");  //expect 100 - Continue
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/continue.html");  //expect 100 - Continue
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1073,7 +1073,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/created.html");  //expect 201 - Created
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/created.html");  //expect 201 - Created
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1128,7 +1128,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/expfailed.html");  //expect 417 - ExpectationFailed
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/expfailed.html");  //expect 417 - ExpectationFailed
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1183,7 +1183,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/forbidden.html");  //expect 403 - Forbidden
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/forbidden.html");  //expect 403 - Forbidden
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1238,7 +1238,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/found.html");  //expect 302 - Found
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/found.html");  //expect 302 - Found
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1293,7 +1293,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/gateway.html");  //expect  - GatewayTimeout
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/gateway.html");  //expect  - GatewayTimeout
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1348,7 +1348,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/gone.html");  //expect 410 - Gone
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/gone.html");  //expect 410 - Gone
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1402,7 +1402,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/httpversion.html");  //expect 505 - HttpVersionNotSupported
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/httpversion.html");  //expect 505 - HttpVersionNotSupported
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1457,7 +1457,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/iserror.html");  //expect 500 - InternalServerError
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/iserror.html");  //expect 500 - InternalServerError
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1512,7 +1512,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/lrequired.html");  //expect 411 - LengthRequired
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/lrequired.html");  //expect 411 - LengthRequired
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1567,7 +1567,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/method.html");  //expect 405 - MethodNotAllowed
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/method.html");  //expect 405 - MethodNotAllowed
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1622,7 +1622,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/NoContent.html");  //expect 204 - NoContent
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/NoContent.html");  //expect 204 - NoContent
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1677,7 +1677,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/nonauthInfo.html");  //expect 203 - NonAuthoritativeInformation
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/nonauthInfo.html");  //expect 203 - NonAuthoritativeInformation
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1732,7 +1732,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotAccept.html");  //expect  - NotAcceptable
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotAccept.html");  //expect  - NotAcceptable
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1787,7 +1787,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotImplement.html");  //expect 501 - NotImplemented
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotImplement.html");  //expect 501 - NotImplemented
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1842,7 +1842,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotModified.html");  //expect  - NotModified
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/NotModified.html");  //expect  - NotModified
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1897,7 +1897,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/PContent.html");  //expect 206 - PartialContent
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/PContent.html");  //expect 206 - PartialContent
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -1952,7 +1952,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/Precond.html");  //expect 412 - PreconditionFailed
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/Precond.html");  //expect 412 - PreconditionFailed
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2007,7 +2007,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/ProxyAuth.html");  //expect  - ProxyAuthenticationRequired
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/ProxyAuth.html");  //expect  - ProxyAuthenticationRequired
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2062,7 +2062,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/RMethod.html");  //expect  - RedirectMethod
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/RMethod.html");  //expect  - RedirectMethod
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2117,7 +2117,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/reqRange.html");  //expect 416 - RequestedRangeNotSatisfiable
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/reqRange.html");  //expect 416 - RequestedRangeNotSatisfiable
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2172,7 +2172,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/reqEntity.html");  //expect 413 - RequestEntityTooLarge
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/reqEntity.html");  //expect 413 - RequestEntityTooLarge
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2227,7 +2227,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/ResetContent.html");  //expect  - ResetContent
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/ResetContent.html");  //expect  - ResetContent
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2282,7 +2282,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/SeeOther.html");  //expect  - SeeOther
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/SeeOther.html");  //expect  - SeeOther
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2337,7 +2337,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/SwitchProt.html");  //expect  - SwitchingProtocols
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/SwitchProt.html");  //expect  - SwitchingProtocols
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2392,7 +2392,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/Unauth.html");  //expect  - Unauthorized
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/Unauth.html");  //expect  - Unauthorized
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2447,7 +2447,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/Unused.html");  //expect  - Unused
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/Unused.html");  //expect  - Unused
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2502,7 +2502,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webpages/UseProxy.html");  //expect  - UseProxy
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webpages/UseProxy.html");  //expect  - UseProxy
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "GET";
 
@@ -2556,7 +2556,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1

--- a/Test/Platform/Tests/CLR/System/Http/HttpTests.csproj
+++ b/Test/Platform/Tests/CLR/System/Http/HttpTests.csproj
@@ -1,4 +1,5 @@
-﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.HttpTests</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -25,6 +26,7 @@
     <Compile Include="ProtocolViolationExceptionTests.cs" />
     <Compile Include="TestServer.cs" />
     <Compile Include="UriTests.cs" />
+    <Compile Include="Utilities.cs" />
     <Compile Include="WebExceptionTests.cs" />
     <Compile Include="WebHeaderCollectionTests.cs" />
     <Compile Include="WebProxyTests.cs" />

--- a/Test/Platform/Tests/CLR/System/Http/HttpVersionTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/HttpVersionTests.cs
@@ -40,22 +40,13 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            // Assign Proxy
-            Request.Proxy = new WebProxy(HttpTests.Proxy, true);
-
             HttpWebResponse myResponse = (HttpWebResponse)Request.GetResponse();
             Log.Comment("Version after assignment:" + Request.ProtocolVersion);
             Log.Comment("Response version:" + myResponse.ProtocolVersion);
 
-            if (Request.ProtocolVersion.Major != ExpectedVersion.Major && Request.ProtocolVersion.Minor != ExpectedVersion.Major)
+            if (Request.ProtocolVersion.Major != ExpectedVersion.Major || Request.ProtocolVersion.Minor != ExpectedVersion.Minor)
             {
                 Log.Exception("Expected Request Version " + ExpectedVersion);
-                result = MFTestResults.Fail;
-            }
-
-            if (myResponse.ProtocolVersion != HttpVersion.Version11)
-            {
-                Log.Exception("Expected Response Version 1.1");
                 result = MFTestResults.Fail;
             }
 
@@ -73,11 +64,6 @@ namespace Microsoft.SPOT.Platform.Tests
             try
             {
                 HttpWebRequest myRequest = (HttpWebRequest)WebRequest.Create("http://www.microsoft.com");
-                if (myRequest.ProtocolVersion != HttpVersion.Version11)
-                {
-                    Log.Exception("Expected Version 1.1, but got " + myRequest.ProtocolVersion);
-                    return MFTestResults.Fail;
-                }
                 result = Verify(myRequest, HttpVersion.Version11);
             }
             catch (Exception ex)

--- a/Test/Platform/Tests/CLR/System/Http/HttpWebRequestTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/HttpWebRequestTests.cs
@@ -25,7 +25,6 @@ namespace Microsoft.SPOT.Platform.Tests
                 return InitializeResult.Skip;
             }
 
-
             return InitializeResult.ReadyToGo;
         }
 
@@ -69,14 +68,14 @@ namespace Microsoft.SPOT.Platform.Tests
             {
                 Log.Comment("Create string request");
                 string URL = null;
-                try 
-                { 
+                try
+                {
                     HttpWebRequest strRequest = (HttpWebRequest)HttpWebRequest.Create(URL);
                     Log.Exception("Expected ArgumentNullException");
                     result = MFTestResults.Fail;
                 }
-                catch (Exception ex) 
-                { 
+                catch (Exception ex)
+                {
                     /* pass case */
                     if (!HttpTests.ValidateException(ex, typeof(ArgumentNullException)))
                         result = MFTestResults.Fail;
@@ -84,8 +83,8 @@ namespace Microsoft.SPOT.Platform.Tests
 
                 Log.Comment("Create URI request");
                 Uri uri = null;
-                try 
-                { 
+                try
+                {
                     HttpWebRequest uriRequest = (HttpWebRequest)HttpWebRequest.Create(uri);
                     Log.Exception("Expected ArgumentNullException");
                     result = MFTestResults.Fail;
@@ -114,8 +113,8 @@ namespace Microsoft.SPOT.Platform.Tests
             {
                 Log.Comment("Create string request");
                 string URL = "";
-                try 
-                { 
+                try
+                {
                     HttpWebRequest strRequest = (HttpWebRequest)HttpWebRequest.Create(URL);
                     Log.Exception("Expected ArgumentException");
                     result = MFTestResults.Fail;
@@ -159,7 +158,7 @@ namespace Microsoft.SPOT.Platform.Tests
                 {
                     Log.Exception("Expected bytes=-1, but got " + wr.Headers["Range"]);
                     result = MFTestResults.Fail;
-                } 
+                }
                 Log.Comment("AddRange(100, 500)");
                 wr = (HttpWebRequest)WebRequest.Create(HttpTests.MSUrl);
                 wr.AddRange(100, 500);
@@ -216,8 +215,8 @@ namespace Microsoft.SPOT.Platform.Tests
             {
                 Log.Comment("invalid from - AddRange(-1, 500)");
                 wr = (HttpWebRequest)WebRequest.Create(HttpTests.MSUrl);
-                try 
-                { 
+                try
+                {
                     wr.AddRange(-1, 500);
                     Log.Exception("Expected ArgumentOutOfRangeException");
                     result = MFTestResults.Fail;
@@ -339,7 +338,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults AcceptHeaderTest()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create(HttpTests.MSUrl);;
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create(HttpTests.MSUrl); ;
             try
             {
                 Log.Comment("Initial value should be null");
@@ -470,13 +469,13 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults SetHeadersAfterRequest()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpTestServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://" + Utilities.GetLocalIpAddress() + ":" + HttpTestServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
-            HttpTestServer server = new HttpTestServer("http", ref result) 
-            { 
+            HttpTestServer server = new HttpTestServer("http", ref result)
+            {
                 RequestUri = wr.RequestUri,
                 RequestHeaders = wr.Headers,
-                ResponseString = "<html><body>SetHeadersAfterRequest</body></html>" 
+                ResponseString = "<html><body>SetHeadersAfterRequest</body></html>"
             };
 
             try
@@ -569,7 +568,8 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults FunctionalChunkTests()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpTestServer.s_CurrentPort.ToString() + "/");
+            string currentPort = HttpTestServer.s_CurrentPort.ToString();
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + currentPort + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.KeepAlive = true;
             HttpTestServer server = new HttpTestServer("http", ref result)
@@ -606,10 +606,10 @@ namespace Microsoft.SPOT.Platform.Tests
                         result = MFTestResults.Fail;
                         Log.Exception("[Client] Expected stream, but got null");
                     }
-                }      
+                }
 
                 Log.Comment("Send Chunked");
-                wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpTestServer.s_CurrentPort.ToString() + "/");
+                wr = (HttpWebRequest)WebRequest.Create("http://" + Utilities.GetLocalIpAddress() + ":" + currentPort + "/");
                 wr.UserAgent = ".Net Micro Framwork Device/4.0";
                 wr.SendChunked = true;
                 server.SendChunked = true;

--- a/Test/Platform/Tests/CLR/System/Http/TestServer.cs
+++ b/Test/Platform/Tests/CLR/System/Http/TestServer.cs
@@ -45,6 +45,8 @@ namespace Microsoft.SPOT.Platform.Tests
                 s_CurrentPort++;
                 throw new Exception("Unable to start server");
             }
+
+            s_CurrentPort++;
         }
 
         public void StopServer()

--- a/Test/Platform/Tests/CLR/System/Http/Utilities.cs
+++ b/Test/Platform/Tests/CLR/System/Http/Utilities.cs
@@ -1,0 +1,28 @@
+using System;
+using Microsoft.SPOT;
+using Microsoft.SPOT.Net.NetworkInformation;
+using System.Threading;
+
+namespace Microsoft.SPOT.Platform.Tests
+{
+    class Utilities
+    {
+        internal static string GetLocalIpAddress()
+        {
+            while (true)
+            {
+                var netifs = NetworkInterface.GetAllNetworkInterfaces();
+                foreach (var itf in netifs)
+                {
+                    if (itf.IPAddress == "0.0.0.0" || itf.IPAddress == "127.0.0.1")
+                        continue;
+
+                    Debug.Print("Found IP: " + itf.IPAddress);
+                    return itf.IPAddress;
+                }
+
+                Thread.Sleep(1000);
+            }
+        }
+    }
+}

--- a/Test/Platform/Tests/CLR/System/Http/WebExceptionTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/WebExceptionTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.SPOT.Platform.Tests
                 return InitializeResult.Skip;
             }
 
-
             return InitializeResult.ReadyToGo;
         }
 
@@ -74,7 +73,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/ConnClose.html");  //expect ConnectionClosed
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/ConnClose.html");  //expect ConnectionClosed
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -122,7 +121,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/KeepAliveFailure.html");  //expect KeepAliveFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/KeepAliveFailure.html");  //expect KeepAliveFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -170,7 +169,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/Pending.html");  //expect Pending
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/Pending.html");  //expect Pending
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -217,7 +216,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/PipelineFailure.html");  //expect PipelineFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/PipelineFailure.html");  //expect PipelineFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -264,7 +263,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/ProxyNameResolutionFailure.html");  //expect ProxyNameResolutionFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/ProxyNameResolutionFailure.html");  //expect ProxyNameResolutionFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -312,7 +311,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/ReceiveFailure.html");  //expect ReceiveFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/ReceiveFailure.html");  //expect ReceiveFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -360,7 +359,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/RequestCanceled.html");  //expect RequestCanceled
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/RequestCanceled.html");  //expect RequestCanceled
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -408,7 +407,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/SecureChannelFailure.html");  //expect SecureChannelFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/SecureChannelFailure.html");  //expect SecureChannelFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -456,7 +455,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/SendFailure.html");  //expect SendFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/SendFailure.html");  //expect SendFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -504,7 +503,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/Success.html");  //expect Success
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/Success.html");  //expect Success
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -552,7 +551,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/Timeout.html");  //expect Timeout
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/Timeout.html");  //expect Timeout
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -600,7 +599,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/TrustFailure.html");  //expect TrustFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/TrustFailure.html");  //expect TrustFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -648,7 +647,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/ConnectFailure.html");  //expect ConnectFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/ConnectFailure.html");  //expect ConnectFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -696,7 +695,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/NameResolutionFailure.html");  //expect NameResolutionFailure
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/NameResolutionFailure.html");  //expect NameResolutionFailure
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -744,7 +743,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/ProtocolError.html");  //expect ProtocolError
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/ProtocolError.html");  //expect ProtocolError
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 
@@ -792,7 +791,7 @@ namespace Microsoft.SPOT.Platform.Tests
             MFTestResults result = MFTestResults.Pass;
 
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/webexception/ServerProtocolViolation.html");  //expect ServerProtocolViolation
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/webexception/ServerProtocolViolation.html");  //expect ServerProtocolViolation
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
             wr.Method = "HEAD";
 

--- a/Test/Platform/Tests/CLR/System/Http/WebHeaderCollectionTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/WebHeaderCollectionTests.cs
@@ -119,7 +119,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -162,7 +162,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -204,7 +204,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults TestWebHeaderCollectionAddLegal2()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -301,7 +301,7 @@ namespace Microsoft.SPOT.Platform.Tests
         {
             MFTestResults result = MFTestResults.Pass;
 
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");  //expect 200 - OK
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1
@@ -343,7 +343,7 @@ namespace Microsoft.SPOT.Platform.Tests
         public MFTestResults TestWebHeaderCollectionRemove()
         {
             MFTestResults result = MFTestResults.Pass;
-            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+            HttpWebRequest wr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
             wr.UserAgent = ".Net Micro Framwork Device/4.0";
 
             Log.Comment("Initial version: " + wr.ProtocolVersion);  //Default version is 1.1

--- a/Test/Platform/Tests/CLR/System/Http/WebResponseTests.cs
+++ b/Test/Platform/Tests/CLR/System/Http/WebResponseTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.SPOT.Platform.Tests
                 return InitializeResult.Skip;
             }
 
-
             return InitializeResult.ReadyToGo;
         }
 
@@ -43,7 +42,7 @@ namespace Microsoft.SPOT.Platform.Tests
             try
             {
                 Log.Comment("WebResponse Test");
-                HttpWebRequest wrStr = (HttpWebRequest)WebRequest.Create("http://127.0.0.1:" + HttpServer.s_CurrentPort.ToString() + "/");
+                HttpWebRequest wrStr = (HttpWebRequest)WebRequest.Create("http://"+ Utilities.GetLocalIpAddress() + ":" + HttpServer.s_CurrentPort.ToString() + "/");
 
                 HttpServer server = new HttpServer("http", ref result)
                 {


### PR DESCRIPTION
- Use a utility method to return local host address instead of using 127.0.0.1
- Remove WebProxy from http requests
- A few other minor fixes