### PR TITLE
Update Certificate Ids for official signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ Listings/
 /DeviceCode/Targets/OS/Win32/DeviceCode/WinPcap_Eth/Dependencies/WpdPack/
 
 *.axfdump
+/crypto/lib

--- a/tools/Targets/Microsoft.SPOT.SDK.Targets
+++ b/tools/Targets/Microsoft.SPOT.SDK.Targets
@@ -13,13 +13,11 @@
     <OUTPUT_WIXOBJ_DIR_LE>$(OutputWiXObjRoot)Fragments\le\$(MSBuildProjectName)\</OUTPUT_WIXOBJ_DIR_LE>
     <OUTPUT_WIXOBJ_DIR_BE>$(OutputWiXObjRoot)Fragments\be\$(MSBuildProjectName)\</OUTPUT_WIXOBJ_DIR_BE>
     <DO_NOT_BUILD_DOCS>True</DO_NOT_BUILD_DOCS>
-    <CodeSignAuthenticodeCert>100040133</CodeSignAuthenticodeCert>
-    <!-- Temp using Corp cert for VSIX packages until MSOT obtains it's own cert
-         (Cleared with LCA so long as the contained binaries are signed with an MSOT publisher cert)
-    -->
-    <CodeSignOpcCert>160</CodeSignOpcCert>
-    <CodeSignStrangNameCert>150</CodeSignStrangNameCert>
-    <CodeSignApprovers>gokulk;richh</CodeSignApprovers>
+    <CodeSignAuthenticodeCert>400</CodeSignAuthenticodeCert>
+    <CodeSignOpcCert>100040160</CodeSignOpcCert>
+    <CodeSignStrongNameCert>272</CodeSignStrongNameCert>
+    <CodeSignApprovers>smaillet;mortezag</CodeSignApprovers>
+      
     <!--
     <VSIPInstalled>false</VSIPInstalled>
     <XBUILD_OUTDIR>$(SPOCLIENT)\UE\Public\Docs\Built</XBUILD_OUTDIR>


### PR DESCRIPTION
- Added git ignore for the binary only crypto libraries so they don'tget added into the tree
- Updated codesign certificate ids to current Microsoft SHA2 variants.