### PR TITLE
Fixed build issue for exxternal builds from repository

### DIFF
--- a/Framework/Tools/BuildTasksInternal/BuildSigner/BuildSignerSpotBuild.csproj
+++ b/Framework/Tools/BuildTasksInternal/BuildSigner/BuildSignerSpotBuild.csproj
@@ -35,6 +35,7 @@
     <Reference Include="CODESIGN.Submitter, Version=4.1.0.0, Culture=neutral, PublicKeyToken=3d8252bd1272440d, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(MSBuildProgramFiles32)\Microsoft Internal\Codesign.Submitter\CODESIGN.Submitter.dll</HintPath>
+      <HintPath>$(SPOROOT)\tools\x86\CODESIGN\CODESIGN.Submitter.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />


### PR DESCRIPTION
Fixes #333 
Added additional hint path for code sign submitter so that external builds can succeed (even though signing isn't performed externally the component is needed to complete building the msbuild task dll)
