### PR TITLE
STM32F4 RTC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ Listings/
 
 *.axfdump
 /crypto/lib
+Firmware License (Crypto).rtf
+License (Crypto).rtf
+PKCryptoWelcome.rtf
+REDIST_CRYPTO.TXT
+ReleaseNotesCrypto.txt

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Bootstrap/STM32F4_bootstrap.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_Bootstrap/STM32F4_bootstrap.cpp
@@ -19,6 +19,8 @@
 #include "..\stm32f2xx.h"
 #endif
 
+#include "..\..\..\..\..\pal\time\Time_driver.h"
+
 #ifndef FLASH
 #define FLASH               ((FLASH_TypeDef *) FLASH_R_BASE)
 #endif
@@ -276,8 +278,9 @@ void __section("SectionForBootstrapOperations") STM32F4_BootstrapCode()
     // remove Flash remap to Boot area to avoid problems with Monitor_Execute
     SYSCFG->MEMRMP = 1; // map System memory to Boot area
     
-#ifdef STM32F4_Enable_RTC
-    STM32F4_RTC_Initialize(); // enable RTC
+#ifdef STM32F4_RTC_ENABLE
+    Time_Uninitialize();
+    Time_Initialize(); 
 #endif
 
 }

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_RTC/RTC_decl.h
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_RTC/RTC_decl.h
@@ -10,9 +10,10 @@
 BOOL    RTC_Initialize  ( );
 INT64   RTC_GetTime     ( );
 void    RTC_SetTime     ( INT64 time );
+#ifndef STM32F4_RTC_ENABLE
 INT32   RTC_GetOffset   ( );
 void    RTC_SetOffset   ( INT32 offset );
-
+#endif
 //--//
 
 #endif // _DRIVERS_RTC_DECL_H_

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_RTC/STM32F4_RTC_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_RTC/STM32F4_RTC_functions.cpp
@@ -21,12 +21,149 @@
 #include "..\stm32f2xx.h"
 #endif
 
+#define RCC_LSE_TIMEOUT_VALUE           ((uint32_t)6000)  // 6000 ms
+#define LSI_TIMEOUT_VALUE               ((uint32_t)100)   // 100 ms
 
 BOOL RTC_Initialize()
 {
+#ifndef STM32F4_RTC_ENABLE
+
     PWR->CR |= PWR_CR_DBP; // enable RTC access
     RCC->BDCR |= RCC_BDCR_RTCSEL_0 | RCC_BDCR_LSEON | RCC_BDCR_RTCEN; // RTC & LSE on
     
+#else
+  
+    UINT64 ticksStart;
+    uint32_t tmpreg1 = 0;
+
+   	// enable power clock
+  	RCC->APB1ENR |= RCC_APB1ENR_PWREN;
+  	// also on sleep mode
+  	RCC->APB1LPENR |= RCC_APB1LPENR_PWRLPEN;
+     		
+    // enable access to the backup domain allowing access to RTC
+    PWR->CR |= PWR_CR_DBP;
+    
+#if defined(STM32F4_RTC_LSE)
+    // enable LSE
+    
+    if((RCC->BDCR & RCC_BDCR_RTCSEL) != RCC_BDCR_RTCSEL_LSE)
+    {
+        // Store the content of BDCR register before the reset of Backup Domain
+        // and clear RTC clock source
+        tmpreg1 = (RCC->BDCR & ~(RCC_BDCR_RTCSEL));
+        // RTC Clock selection can be changed only if the Backup Domain is reset
+        RCC->BDCR |= RCC_BDCR_BDRST;
+        RCC->BDCR &= ~RCC_BDCR_BDRST;
+        // Restore the Content of BDCR register
+        RCC->BDCR = tmpreg1;
+    }
+    
+    // Set LSEON bit
+    RCC->BDCR = RCC_BDCR_LSEON;
+
+    // Get Start Tick
+  	ticksStart = HAL_Time_CurrentTicks();
+
+    // wait for external low-speed oscillator valid
+    while(!(RCC->BDCR & RCC_BDCR_LSERDY))
+    {
+        if((HAL_Time_CurrentTicks()-ticksStart) > CPU_MillisecondsToTicks((UINT32)RCC_LSE_TIMEOUT_VALUE))
+        {
+            // external low-speed oscillator is not working or not fitted
+            return FALSE;
+        }    
+    }
+			
+		// Select the RTC Clock Source
+    RCC->BDCR |= RCC_BDCR_RTCSEL_LSE;   
+    
+#elif defined(STM32F4_RTC_LSE_BYPASS)
+    // enable LSE and bypass oscillator
+
+    // Set LSEBYP and LSEON bits
+    RCC->BDCR = RCC_BDCR_LSEBYP | RCC_BDCR_LSEON;
+
+    // Get Start Tick
+  	ticksStart = HAL_Time_CurrentTicks();
+
+    // wait for external low-speed oscillator valid
+    while(!(RCC->BDCR & RCC_BDCR_LSERDY))
+    {
+        if((HAL_Time_CurrentTicks()-ticksStart) > CPU_MillisecondsToTicks((UINT32)RCC_LSE_TIMEOUT_VALUE))
+        {
+            // external low-speed oscillator is not working or not fitted
+            return FALSE;
+        }    
+    }
+			
+    // Select the RTC Clock Source
+    RCC->BDCR |= RCC_BDCR_RTCSEL_LSE;
+
+#elif defined(STM32F4_RTC_LSI)
+    // enable LSI
+        
+    // enable internal low-power oscillator
+    RCC->CSR |= (uint32_t)RCC_CSR_LSION
+
+    // Get Start Tick
+    ticksStart = HAL_Time_CurrentTicks();
+        
+    // Wait till LSI is ready
+    while(!(RCC->CSR & RCC_CSR_LSIRDY))
+    {
+        if((HAL_Time_CurrentTicks()-ticksStart) > CPU_MillisecondsToTicks((UINT32)LSI_TIMEOUT_VALUE))
+        {
+            // external low-speed oscillator is not working
+            return FALSE;
+        } 
+    }
+		
+    // Select the RTC Clock Source
+    RCC->BDCR |= RCC_BDCR_RTCSEL_LSI;
+    
+#else
+// sanity check for RTC enabled but no selection of clock source
+#error RTC is enabled in configuration but there is no RTC clock source selected   
+#endif
+       		
+  	// Enable the RTC Clock
+    RCC->BDCR |= RCC_BDCR_RTCEN;   
+  	
+    // Disable the write protection for RTC registers
+    RTC->WPR = 0xCA;
+    RTC->WPR = 0x53;
+   
+    // Check if the Initialization mode is set
+    if (!(RTC->ISR & RTC_ISR_INITF))
+    {
+        // Set the Initialization mode
+        RTC->ISR |= (uint32_t)RTC_ISR_INIT;
+        
+        // Wait till RTC is in INIT state and if Time out is reached exit 
+        // according to the STM32 manual it's OK to wait without a timeout as it takes from 1 to 2 RTCCLK clock cycles to enter Initialization mode 
+        while(!(RTC->ISR & RTC_ISR_INITF));
+    }
+
+    // can be read from the shadow registers only if APB clock is at least 7 times the frequency of the RTC
+    // to avoid adding another check on this, RTC will always be read directly from registers
+    RTC->CR |= RTC_CR_BYPSHAD; 
+  
+    // Configure the RTC PRER
+    RTC->PRER = (uint32_t)0xFF;
+    RTC->PRER |= ((uint32_t)0x7F << 16);
+  
+    // Exit Initialization mode
+    RTC->ISR &= ~RTC_ISR_INIT;  
+    
+    // Enable the write protection for RTC registers
+    RTC->WPR = 0xFF; 
+	
+    // disable access to the backup domain
+    PWR->CR &= ~PWR_CR_DBP;
+    
+#endif
+   
     return TRUE;
 }
 
@@ -42,11 +179,17 @@ UINT32 RTC_BinToBcd(UINT32 bin)
 
 INT64 RTC_GetTime()
 {
-    if (!(RTC->ISR & RTC_ISR_INITS)) { // RTC not set up
+    if (!(RTC->ISR & RTC_ISR_INITS)) 
+    { 
+        // RTC not set up
         return 0;
     }
-    
+        
+#ifndef STM32F4_RTC_ENABLE
+
     while (!(RTC->ISR & RTC_ISR_RSF)); // wait for shadow register ready
+    
+#endif   
     
     UINT32 ss = ~RTC->SSR & 255; // sub seconds [s/256]
     UINT32 tr = RTC->TR; // time
@@ -65,6 +208,8 @@ INT64 RTC_GetTime()
 
 void RTC_SetTime( INT64 time )
 {
+#ifndef STM32F4_RTC_ENABLE
+
     RTC->WPR = 0xCA; // disable write protection
     RTC->WPR = 0x53;
     RTC->ISR = 0xFFFFFFFF; // enter Init mode
@@ -97,7 +242,52 @@ void RTC_SetTime( INT64 time )
     
     RTC->ISR = 0xFFFFFFFF & ~RTC_ISR_INIT; // exit Init mode
     RTC->WPR = 0xFF; // enable write protection
+
+#else
+
+    // enable access to the backup domain allowing access to RTC
+    PWR->CR |= PWR_CR_DBP;
+
+    RTC->WPR = 0xCA; // disable write protection
+    RTC->WPR = 0x53;
+    
+    // Set the Initialization mode
+    RTC->ISR |= (uint32_t)RTC_ISR_INIT;
+        
+    SYSTEMTIME sysTime;
+    Time_ToSystemTime(time, &sysTime);
+    UINT32 tr = RTC_BinToBcd(sysTime.wSecond)
+              | RTC_BinToBcd(sysTime.wMinute) << 8
+              | RTC_BinToBcd(sysTime.wHour) << 16;
+    UINT32 dr = RTC_BinToBcd(sysTime.wDay)
+              | RTC_BinToBcd(sysTime.wMonth) << 8
+              | (sysTime.wDayOfWeek ? sysTime.wDayOfWeek : 7) << 13
+              | RTC_BinToBcd(sysTime.wYear % 100) << 16;
+   
+    // Wait till RTC is in INIT state and if Time out is reached exit 
+    // according to the STM32 manual it's OK to wait without a timeout as it takes from 1 to 2 RTCCLK clock cycles to enter Initialization mode 
+    while(!(RTC->ISR & RTC_ISR_INITF));
+    
+    // 24h format
+    RTC->CR &= ~(RTC_CR_FMT);
+    // set time register
+    RTC->TR = tr;
+    // set date register
+    RTC->DR = dr;
+    
+    // Exit Initialization mode
+    RTC->ISR &= ~RTC_ISR_INIT;  
+    
+    // Enable the write protection for RTC registers
+    RTC->WPR = 0xFF; 
+    	
+    // disable access to the backup domain
+    PWR->CR &= ~PWR_CR_DBP;
+    
+#endif    
 }
+
+#ifndef STM32F4_RTC_ENABLE
 
 INT32 RTC_GetOffset()
 {
@@ -111,3 +301,5 @@ void RTC_SetOffset(INT32 offset)
     RTC->BKP0R = offset;
     RTC->WPR = 0xFF; // enable write protection
 }
+
+#endif

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 #.NET Micro Framework Interpreter  
 
-Welcome to the .NET Micro Framework interpreter GitHub repository. (Master Branch)
+[![Build status](http://netmfbuildstatus.cloudapp.net/BuildStatus.svc/Badge)](http://netmfbuildstatus.cloudapp.net/BuildStatus.svc/Report)
+
+Welcome to the .NET Micro Framework interpreter GitHub repository. 
 
 The Microsoft® .NET Micro Framework combines the reliability and efficiency of managed code with the premier development tools of Microsoft Visual Studio® to deliver exceptional productivity for developing embedded applications on small devices. The Microsoft .NET Micro Framework SDK supports development of code, including device I/O, in the C# language using a subset of the .NET libraries, and is fully integrated with the Microsoft Visual Studio® development environment. The .NET Micro Framework class library supports all major namespaces and types from the desktop framework, managed drivers support, Remote Firmware Updates and Cryptographic functions for Secure Devices. This GitHub project allows building the full SDK and device Firmware images including the lwIP open source TCP/IP stack and the OpenSSL distribution.
 
-##Master Branch
-The Master branch contains released source code that is updated when major milestones are released, including Beta builds. Active development is done in the [dev](https://github.com/NETMF/netmf-interpreter/tree/dev) branch. Thus the Master is considered fairly stable and never receives commits directly. (e.g. Any pull requests targeting the Master branch will be rejected automatically. All contributions should appear as a pull request to the dev branch) 
-
-### Wiki Docs
-Information on building the framework and internal development guides will appear on the [wiki](https://github.com/NETMF/netmf-interpreter/wiki). If you have Wiki content that is relevant to the NETMF development community or code that you would like to [contribute](https://github.com/NETMF/netmf-interpreter/wiki/Contributing) feel free to join in and participate in the future of the .NET Micro Framework! 
-
+## Wiki Docs
+Information on building the framework and internal development guides will appear on the [wiki](https://github.com/NETMF/netmf-interpreter/wiki). If you have content that is relevant to the NETMF development community that you would like to [contribute](https://github.com/NETMF/netmf-interpreter/wiki/Contributing) feel free to join in and participate in the future of the .NET Micro Framework. 

--- a/Solutions/MCBSTM32F400/TinyBooter/TinyBooter.proj
+++ b/Solutions/MCBSTM32F400/TinyBooter/TinyBooter.proj
@@ -194,8 +194,16 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\palevent\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Time_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" />
+        <DriverLibs Include="Time_pal.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'false'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" Condition="'$(USE_RTC)' == 'false'"/>
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="Time_pal_rtc.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\Time_Pal_Rtc\dotNetMF.proj"  Condition="'$(USE_RTC)' == 'true'"/>        
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="STM32F4_RTC.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\dotNetMF.proj" Condition="'$(USE_RTC)' == 'true'"/>        
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="TimeService_pal_stubs.$(LIB_EXT)" />

--- a/Solutions/MCBSTM32F400/TinyCLR/TinyCLR.proj
+++ b/Solutions/MCBSTM32F400/TinyCLR/TinyCLR.proj
@@ -31,6 +31,7 @@
         <CompressImageDatSym>TinyClr_Dat_Start</CompressImageDatSym>
         <CompressImageCfgSym>g_ConfigurationSector</CompressImageCfgSym>
         <USE_SSL Condition="'$(FLAVOR)'=='Release'">true</USE_SSL>
+        <USE_RTC>false</USE_RTC>        
     </PropertyGroup>
     <ItemGroup>
         <CompressImageSymdef Include="$(BIN_DIR)\$(AssemblyName).symdefs" />
@@ -247,8 +248,16 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\palevent\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Time_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" />
+        <DriverLibs Include="Time_pal.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'false'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" Condition="'$(USE_RTC)' == 'false'"/>
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="Time_pal_rtc.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\Time_Pal_Rtc\dotNetMF.proj"  Condition="'$(USE_RTC)' == 'true'"/>        
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="STM32F4_RTC.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\dotNetMF.proj" Condition="'$(USE_RTC)' == 'true'"/>        
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="FS_Config_stubs.$(LIB_EXT)" />

--- a/Solutions/MCBSTM32F400/TinyCLR_NONET/TinyCLR_NONET.proj
+++ b/Solutions/MCBSTM32F400/TinyCLR_NONET/TinyCLR_NONET.proj
@@ -30,6 +30,7 @@
         <CompressImageFlashSym>EntryPoint</CompressImageFlashSym>
         <CompressImageDatSym>TinyClr_Dat_Start</CompressImageDatSym>
         <CompressImageCfgSym>g_ConfigurationSector</CompressImageCfgSym>
+        <USE_RTC>false</USE_RTC>
     </PropertyGroup>
     <ItemGroup>
         <CompressImageSymdef Include="$(BIN_DIR)\$(AssemblyName).symdefs" />
@@ -215,8 +216,16 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\palevent\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Time_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" />
+        <DriverLibs Include="Time_pal.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'false'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" Condition="'$(USE_RTC)' == 'false'"/>
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="Time_pal_rtc.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\Time_Pal_Rtc\dotNetMF.proj"  Condition="'$(USE_RTC)' == 'true'"/>        
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="STM32F4_RTC.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\dotNetMF.proj" Condition="'$(USE_RTC)' == 'true'"/>        
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="FS_Config_stubs.$(LIB_EXT)" />

--- a/Solutions/MCBSTM32F400/platform_selector.h
+++ b/Solutions/MCBSTM32F400/platform_selector.h
@@ -66,6 +66,12 @@
 #define SLOW_CLOCKS_TEN_MHZ_GCD         1000000    // GCD(SLOW_CLOCKS_PER_SECOND, 10M)
 #define SLOW_CLOCKS_MILLISECOND_GCD     1000       // GCD(SLOW_CLOCKS_PER_SECOND, 1k)
 
+// RTC clock selection, required when solution has USE_RTC property set to TRUE
+//#define STM32F4_RTC_ENABLE              // STM32F4 RTC enabled
+//#define STM32F4_RTC_LSE                 // STM32F4 RTC clocked by external low power oscilator
+//#define STM32F4_RTC_LSE_BYPASS          // STM32F4 RTC bypass LSE oscilator
+//#define STM32F4_RTC_LSI                 // STM32F4 RTC clocked by internal low-speed internal RC 
+
 #define FLASH_MEMORY_Base               0x08000000
 #define FLASH_MEMORY_Size               0x00100000
 #define SRAM1_MEMORY_Base               0x68000000

--- a/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
@@ -23,6 +23,7 @@
         <ExtraTargets>$(ExtraTargets);CompressBin</ExtraTargets>
         <ScatterFileDefinition>scatterfile_bootloader_$(COMPILER_TOOL).$(SCATTER_EXT)</ScatterFileDefinition>
         <EXEScatterFileDefinition>scatterfile_bootloader_$(COMPILER_TOOL).$(SCATTER_EXT)</EXEScatterFileDefinition>
+        <USE_RTC>false</USE_RTC>
     </PropertyGroup>
     <ItemGroup />
     <ItemGroup>
@@ -194,8 +195,16 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\palevent\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Time_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" />
+        <DriverLibs Include="Time_pal.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'false'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" Condition="'$(USE_RTC)' == 'false'"/>
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="Time_pal_rtc.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\Time_Pal_Rtc\dotNetMF.proj"  Condition="'$(USE_RTC)' == 'true'"/>        
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="STM32F4_RTC.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\dotNetMF.proj" Condition="'$(USE_RTC)' == 'true'"/>        
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="TimeService_pal_stubs.$(LIB_EXT)" />

--- a/Solutions/STM32F4DISCOVERY/TinyCLR/TinyCLR.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyCLR/TinyCLR.proj
@@ -32,6 +32,7 @@
         <CompressImageCfgSym>g_ConfigurationSector</CompressImageCfgSym>
         <!-- newlib-nano does not support long-long and long-double formatting, use standard newlib instead -->
         <NewlibNano Condition="'$(COMPILER_TOOL)'=='GCC'">false</NewlibNano>
+        <USE_RTC>false</USE_RTC>
     </PropertyGroup>
     <ItemGroup>
         <CompressImageSymdef Include="$(BIN_DIR)\$(AssemblyName).symdefs" />
@@ -217,8 +218,16 @@
         <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\palevent\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Time_pal.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" />
+        <DriverLibs Include="Time_pal.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'false'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Pal\Time\dotNetMF.proj" Condition="'$(USE_RTC)' == 'false'"/>
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="Time_pal_rtc.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'"/>
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\Time_Pal_Rtc\dotNetMF.proj"  Condition="'$(USE_RTC)' == 'true'"/>        
+    </ItemGroup>
+    <ItemGroup>
+        <DriverLibs Include="STM32F4_RTC.$(LIB_EXT)" Condition="'$(USE_RTC)' == 'true'" />
+        <RequiredProjects Include="$(SPOCLIENT)\DeviceCode\Targets\Native\STM32F4\DeviceCode\STM32F4_RTC\dotNetMF.proj" Condition="'$(USE_RTC)' == 'true'"/>        
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="FS_Config_stubs.$(LIB_EXT)" />

--- a/Solutions/STM32F4DISCOVERY/platform_selector.h
+++ b/Solutions/STM32F4DISCOVERY/platform_selector.h
@@ -65,6 +65,12 @@
 #define SLOW_CLOCKS_TEN_MHZ_GCD           1000000   // GCD(SLOW_CLOCKS_PER_SECOND, 10M)
 #define SLOW_CLOCKS_MILLISECOND_GCD          1000   // GCD(SLOW_CLOCKS_PER_SECOND, 1k)
 
+// RTC clock selection, required when solution has USE_RTC property set to TRUE
+//#define STM32F4_RTC_ENABLE              // STM32F4 RTC enabled
+//#define STM32F4_RTC_LSE                 // STM32F4 RTC clocked by external low power oscilator
+//#define STM32F4_RTC_LSE_BYPASS          // STM32F4 RTC bypass LSE oscilator
+//#define STM32F4_RTC_LSI                 // STM32F4 RTC clocked by internal low-speed internal RC 
+
 #define FLASH_MEMORY_Base               0x08000000
 #define FLASH_MEMORY_Size               0x00100000
 #define SRAM1_MEMORY_Base               0x20000000


### PR DESCRIPTION
- add support for hardware RTC of STM32F4
- configuration follows available hardware options: 
  - internal RC
  - external low power oscillator
  - external low power with oscillator bypass
- the configuration is performed in platform_selector.h and tinybooter/tinyCLR proj files
- one of the important changes is that (providing the RTC pin is properly powered) the mcu doesn't loose time between reboots (actually the boot code won't zero the RTC if there is a valid value in the RTC registers)
- this was tested on a STM32F4 Discovery board fitted with a 32.768kHz crystal
