### PR TITLE
Fix for signing empty files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ Listings/
 
 *.axfdump
 /crypto/lib
+Firmware License (Crypto).rtf
+License (Crypto).rtf
+PKCryptoWelcome.rtf
+REDIST_CRYPTO.TXT
+ReleaseNotesCrypto.txt

--- a/CLR/Tools/MetaDataProcessor/MetaDataProcessor.cpp
+++ b/CLR/Tools/MetaDataProcessor/MetaDataProcessor.cpp
@@ -1571,7 +1571,7 @@ TinyCLR_Cleanup:
     {
         TINYCLR_HEADER();
 
-        CLR_RT_Buffer buf;
+        CLR_RT_Buffer buf(RSA_BLOCK_SIZE_BYTES);
         RSAKey        privateKey;
         CLR_RT_Buffer signature(RSA_BLOCK_SIZE_BYTES);
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 #.NET Micro Framework Interpreter  
 
-Welcome to the .NET Micro Framework interpreter GitHub repository. (Master Branch)
+[![Build status](http://netmfbuildstatus.cloudapp.net/BuildStatus.svc/Badge)](http://netmfbuildstatus.cloudapp.net/BuildStatus.svc/Report)
+
+Welcome to the .NET Micro Framework interpreter GitHub repository. 
 
 The Microsoft® .NET Micro Framework combines the reliability and efficiency of managed code with the premier development tools of Microsoft Visual Studio® to deliver exceptional productivity for developing embedded applications on small devices. The Microsoft .NET Micro Framework SDK supports development of code, including device I/O, in the C# language using a subset of the .NET libraries, and is fully integrated with the Microsoft Visual Studio® development environment. The .NET Micro Framework class library supports all major namespaces and types from the desktop framework, managed drivers support, Remote Firmware Updates and Cryptographic functions for Secure Devices. This GitHub project allows building the full SDK and device Firmware images including the lwIP open source TCP/IP stack and the OpenSSL distribution.
 
-##Master Branch
-The Master branch contains released source code that is updated when major milestones are released, including Beta builds. Active development is done in the [dev](https://github.com/NETMF/netmf-interpreter/tree/dev) branch. Thus the Master is considered fairly stable and never receives commits directly. (e.g. Any pull requests targeting the Master branch will be rejected automatically. All contributions should appear as a pull request to the dev branch) 
-
-### Wiki Docs
-Information on building the framework and internal development guides will appear on the [wiki](https://github.com/NETMF/netmf-interpreter/wiki). If you have Wiki content that is relevant to the NETMF development community or code that you would like to [contribute](https://github.com/NETMF/netmf-interpreter/wiki/Contributing) feel free to join in and participate in the future of the .NET Micro Framework! 
-
+## Wiki Docs
+Information on building the framework and internal development guides will appear on the [wiki](https://github.com/NETMF/netmf-interpreter/wiki). If you have content that is relevant to the NETMF development community that you would like to [contribute](https://github.com/NETMF/netmf-interpreter/wiki/Contributing) feel free to join in and participate in the future of the .NET Micro Framework. 


### PR DESCRIPTION
When signing empty files (0 lenght) Cmd_SignFile breaks. This happens because nothing is loaded from the file and latter when the code is cheking for the buffer size it breaks.
