### PR TITLE
VisualBasic.NET Build and Debug in VS2015

### DIFF
--- a/Framework/CorDebug/VsProject.cs
+++ b/Framework/CorDebug/VsProject.cs
@@ -88,7 +88,7 @@ namespace Microsoft.SPOT.Debugger
             public const string c_RESOLVE_RUNTIME_DEPENDENCIES_TARGETBE = "ResolveRuntimeDependenciesBE";
             public const string c_RESOLVE_RUNTIME_DEPENDENCIES_TASK = "ResolveRuntimeDependencies";
             public const string c_RESOLVE_REFERENCES_TARGET = "ResolveReferences";
-                
+
             private string[] m_assemblyReferences;
             private string m_assembly;
             private string m_startProgam;
@@ -133,7 +133,7 @@ namespace Microsoft.SPOT.Debugger
             public string[] GetDependencies( bool fIncludeStartProgram, bool fPE, bool fTargetIsBigEndian, string frameworkVersion )
             {
                 Hashtable table = new Hashtable();
-                
+
                 //Make sure this runs even for RunWithoutBuilding....how to do that???
                 AddDependencies( table, new string[] { this.m_assembly } );
                 AddDependencies( table, this.m_assemblyReferences );
@@ -147,9 +147,9 @@ namespace Microsoft.SPOT.Debugger
                 // the build system in some versions of VS+MSBuild will assume that, while other
                 // versions will explicitly reference it with the InProject item property set to
                 // false so it won't show in the IDE. By testing for it and adding it if not found
-                // both cases are covered. 
+                // both cases are covered.
                 var q = from path in table.OfType<string>( )
-                        where 0 == string.Compare( Path.GetFileName( path ), "mscorlib.dll", StringComparison.InvariantCultureIgnoreCase )
+                        where string.Equals( Path.GetFileName( path ), "mscorlib.dll", StringComparison.OrdinalIgnoreCase )
                         select path;
                 if( !q.Any())
                 {
@@ -160,7 +160,7 @@ namespace Microsoft.SPOT.Debugger
                 ArrayList deps = new ArrayList( table.Values );
 
                 string[] depsArray = (string[])deps.ToArray( typeof( string ) );
-               
+
                 if(fPE)
                 {
                     for(int iAssembly = 0; iAssembly < depsArray.Length; iAssembly++)
@@ -439,7 +439,7 @@ namespace Microsoft.SPOT.Debugger
         private string FilterProjectPropertyPages(string property, PropPageSubset subset)
         {
             Utility.CLSIDList clsidList = new Utility.CLSIDList((string)property);
-            
+
             //Signing tab does not work for two reasons.  One, our cfg does not implement IVsPublishableProjectCfg
             //The designer fails in this case.
             //Secondly, we are not currently signing our assemblies.  So trying to sign an applicaiton assembly
@@ -625,11 +625,11 @@ namespace Microsoft.SPOT.Debugger
 
         protected override void SetInnerProject(IntPtr innerIUnknown)
         {
-            // 
+            //
             // This was changed to support VS2012 - The FlavoredProject base class we were using
             // was throwing a COM exception, so we switched to use the newer FlavoredProjectBase class
             // which uses an IntPtr instead of a managed object for this class.  The following method
-            // converts the IUnknown IntPtr into a managed object from which we can convert into the 
+            // converts the IUnknown IntPtr into a managed object from which we can convert into the
             // following interfaces.
             //
             object inner = Marshal.GetUniqueObjectForIUnknown(innerIUnknown);
@@ -926,10 +926,10 @@ namespace Microsoft.SPOT.Debugger
 
         internal static bool TargetFrameworkExactMatch( Debugger.WireProtocol.Commands.Debugging_Resolve_Assembly.Version left, Version right)
         {
-            if(left.iMajorVersion   == right.Major         && 
-               left.iMinorVersion   == right.Minor         && 
+            if(left.iMajorVersion   == right.Major         &&
+               left.iMinorVersion   == right.Minor         &&
                left.iBuildNumber    == right.Build         &&
-               left.iRevisionNumber == right.Revision 
+               left.iRevisionNumber == right.Revision
                )
             {
                 return true;
@@ -958,7 +958,7 @@ namespace Microsoft.SPOT.Debugger
         public int CreateProjectFlavorCfg( IVsCfg pBaseProjectCfg, out IVsProjectFlavorCfg ppFlavorCfg )
         {
             InitBuildHost();
-            
+
             ppFlavorCfg = new VsProjectFlavorCfg( this, pBaseProjectCfg );
 
             return Utility.COM_HResults.S_OK;

--- a/Framework/Debugger/WinUsb/WinUsb.csproj
+++ b/Framework/Debugger/WinUsb/WinUsb.csproj
@@ -24,7 +24,12 @@
     <SccProvider>SAK</SccProvider>
     <OutDir>$(BUILD_TREE_SERVER)\DLL\</OutDir>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
+        <RunCodeAnalysis>false</RunCodeAnalysis>
+        <CodeAnalysisRuleSet>Debugger.ruleset</CodeAnalysisRuleSet>
+        <CodeAnalysisIgnoreGeneratedCode>false</CodeAnalysisIgnoreGeneratedCode>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <DebugSymbols>true</DebugSymbols>
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>,DEBUG,TRACE,TINYCLR_BUILD_SERVER,TINYCLR_USESTRONGNAMES</DefineConstants>

--- a/Framework/IDE/Targets/v4.4/VisualBasic.targets
+++ b/Framework/IDE/Targets/v4.4/VisualBasic.targets
@@ -6,11 +6,31 @@
     <AssemblyFoldersSuffix Condition=" '$(AssemblyFoldersSuffix)' == '' ">AssemblyFoldersEx</AssemblyFoldersSuffix>
     <GenerateManifests>true</GenerateManifests>
     <TargetCompactFramework>true</TargetCompactFramework>
-    <!-- override Roslyn compiler(s) as it doesn't support runtimes without generics-->
+    <!-- Force compiler specifcally to the .NET 4.x version as using newer Roslyn compiler requires 
+        additional work in NETMF to get the compiler to generate code supported by the runtime 
+    -->
     <VbcToolExe>vbc.exe</VbcToolExe>
     <VbcToolPath>$([MSBuild]::GetRegistryValueFromView('HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\.NETFramework', 'InstallRoot', null, RegistryView.Registry32))v4.0.30319</VbcToolPath>
   </PropertyGroup>
-  
+  <!-- This target sets up the VB Runtime support required to build against NETMF correctly -->
+  <Target Name="SetupVBRuntime" AfterTargets="GetFrameworkPaths">
+      <PropertyGroup>
+          <!-- Force the NETMF VB runtime DLL-->
+          <VBRuntime>$(TargetFrameworkDirectory)\Microsoft.VisualBasic.dll</VBRuntime>
+          <MyType Condition="'$(MyType)'==''">Empty</MyType>
+      </PropertyGroup>
+      <ItemGroup>
+          <!--
+          Add a reference to the VB DLL so that emulator deployment can see it
+          Emulator deployment works by examining the project's references to 
+          determine which assemblies to deploy, therfore a reference or project
+          reference must exist for all required dependencies.
+          -->
+          <Reference Include="Microsoft.VisualBasic">
+              <InProject>false</InProject>
+          </Reference>
+      </ItemGroup>
+  </Target>
   <Import Project="$(MSBuildToolsPath)\Microsoft.VisualBasic.targets" />
   <Import Project="Device.targets" />
 </Project>

--- a/Product/AllSDK/ProjectTemplates/VB/ExeTemplate/MFConsoleApplication.vbproj
+++ b/Product/AllSDK/ProjectTemplates/VB/ExeTemplate/MFConsoleApplication.vbproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>

--- a/Product/AllSDK/ProjectTemplates/VB/LibTemplate/MFClassLibrary.vbproj
+++ b/Product/AllSDK/ProjectTemplates/VB/LibTemplate/MFClassLibrary.vbproj
@@ -16,7 +16,7 @@
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <DebugSymbols>true</DebugSymbols>
         <DebugType>full</DebugType>
-        <Optimize>true</Optimize>
+        <Optimize>false</Optimize>
         <OutputPath>bin\Debug\</OutputPath>
         <DefineDebug>true</DefineDebug>
         <DefineTrace>true</DefineTrace>

--- a/Product/AllSDK/ProjectTemplates/VB/WinTemplate/MFWindowApplication.vbproj
+++ b/Product/AllSDK/ProjectTemplates/VB/WinTemplate/MFWindowApplication.vbproj
@@ -16,7 +16,7 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>true</Optimize>
+    <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
     <DefineDebug>true</DefineDebug>
     <DefineTrace>true</DefineTrace>

--- a/build_sdk.cmd
+++ b/build_sdk.cmd
@@ -9,6 +9,8 @@ if "%1" == "-?" goto :ShowUsage
 if /i "%1" == "/h" goto :ShowUsage
 if /i "%1" == "-h" goto :ShowUsage
 
+if "%FLAVOR_SDK%" == "" FLAVOR_SDK=RTM
+
 if /i "%VSSDK140Install%"=="" goto :MissingVSSDK
 if NOT EXIST "%VSSDK140Install%" goto :MissingVSSDK
 
@@ -33,13 +35,13 @@ call setenv_vs.cmd 14
 SET PORT_BUILD=
 
 ECHO Building PreSDK ...
-call Msbuild sdk.dirproj /nr:false /t:Build /p:BuildNumber=%BUILD_VERSION% /p:FLAVOR=RTM  /clp:verbosity=minimal /flp:verbosity=detailed;LogFile=sdkpre.log
+call Msbuild sdk.dirproj /nr:false /t:Build /p:BuildNumber=%BUILD_VERSION% /p:FLAVOR=%FLAVOR_SDK%  /clp:verbosity=minimal /flp:verbosity=detailed;LogFile=sdkpre.log
 
 ECHO Building SDK ...
-call Msbuild setup\ProductSDK\Product.wixproj /m /t:Build /p:BuildNumber=%BUILD_VERSION% /p:FLAVOR=RTM /clp:verbosity=minimal /flp:verbosity=detailed;LogFile=sdk.log
+call Msbuild setup\ProductSDK\Product.wixproj /m /t:Build /p:BuildNumber=%BUILD_VERSION% /p:FLAVOR=%FLAVOR_SDK% /clp:verbosity=minimal /flp:verbosity=detailed;LogFile=sdk.log
 
 ECHO Building VSIX packages ...
-call Msbuild setup\ProductSDK\VsixPackages.dirproj /t:Build /p:BuildNumber=%BUILD_VERSION% /p:FLAVOR=RTM /clp:verbosity=minimal /flp:verbosity=detailed;LogFile=vsixpkg.log
+call Msbuild setup\ProductSDK\VsixPackages.dirproj /t:Build /p:BuildNumber=%BUILD_VERSION% /p:FLAVOR=%FLAVOR_SDK% /clp:verbosity=minimal /flp:verbosity=detailed;LogFile=vsixpkg.log
 
 SET PORT_BUILD=
 

--- a/build_sdk.cmd
+++ b/build_sdk.cmd
@@ -9,7 +9,7 @@ if "%1" == "-?" goto :ShowUsage
 if /i "%1" == "/h" goto :ShowUsage
 if /i "%1" == "-h" goto :ShowUsage
 
-if "%FLAVOR_SDK%" == "" FLAVOR_SDK=RTM
+if "%FLAVOR_SDK%" == "" set FLAVOR_SDK=RTM
 
 if /i "%VSSDK140Install%"=="" goto :MissingVSSDK
 if NOT EXIST "%VSSDK140Install%" goto :MissingVSSDK

--- a/crypto/readme.md
+++ b/crypto/readme.md
@@ -1,0 +1,8 @@
+### Crypto libraries for .NET Micro Framework
+The source of the crypto libraries owned by Microsoft is not available publicly due to Microsoft security policies regarding Cryptographic technology.
+The available components are not checked into the public repository. Instead they are made available as a separate binary download of pre-compiled
+libraries. Developers can link to the libraries provided without requiring the source or, if they so choose, can replace them with their own private,
+but compatible source implementations if desired. The build support in  the .NET Micro Framework will automatically select the cryptographic stub libraries
+if the binary libraries are not installed.
+ 
+ The latest versions of the libraries are available on the [releases section of the .NET Micro Framework GitHub site](https://github.com/NETMF/netmf-interpreter/releases)


### PR DESCRIPTION
Fixes #387 
- updated VisualBasic Targets file to set required properties
- Updated VB project templates to disable optimization for debug builds so binaries are debuggable
- Updated the VSProject system tp check for explicit mscorlib assembly reference and if not present to add it to the internal list of assemblies for deployment.
- Added use of FLAVOR_SDK environment variable to build_sdk.cmd so that the SDK components can be built for debug configurations. (This helps when debugging the VS integration and MFDeploy)
