### PR TITLE
Adds support to use DS5 as Build Tool.

### DIFF
--- a/DeviceCode/Targets/Native/STM32/STM32.settings
+++ b/DeviceCode/Targets/Native/STM32/STM32.settings
@@ -19,7 +19,10 @@
   <PropertyGroup>
     <OEMSystemInfoString>Copyright Oberon microsystems, Inc.</OEMSystemInfoString>
   </PropertyGroup>
-
+  <PropertyGroup Condition="'$(COMPILER_TOOL)'=='DS5'">
+    <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M3</DEVICE_TYPE>
+    <BUILD_TOOL_GUID>{F7823E3C-8BCE-4D9A-AD56-9E06063C47CD}</BUILD_TOOL_GUID>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(COMPILER_TOOL)'=='RVDS'">
     <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M3</DEVICE_TYPE>
     <BUILD_TOOL_GUID>{1942C531-3AAC-4abb-8B4F-C3111012F9D9}</BUILD_TOOL_GUID>

--- a/DeviceCode/Targets/Native/STM32F4/STM32F2.settings
+++ b/DeviceCode/Targets/Native/STM32F4/STM32F2.settings
@@ -22,8 +22,11 @@
     <ItemGroup>
         <CC_CPP_Defines Include="__CORTEX_M3" />
     </ItemGroup>
-
-    <PropertyGroup Condition="'$(COMPILER_TOOL)'=='RVDS'">
+  <PropertyGroup Condition="'$(COMPILER_TOOL)'=='DS5'">
+    <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M3</DEVICE_TYPE>
+    <BUILD_TOOL_GUID>{F7823E3C-8BCE-4D9A-AD56-9E06063C47CD}</BUILD_TOOL_GUID>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(COMPILER_TOOL)'=='RVDS'">
     <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M3</DEVICE_TYPE>
     <BUILD_TOOL_GUID>{1942C531-3AAC-4abb-8B4F-C3111012F9D9}</BUILD_TOOL_GUID>
   </PropertyGroup>

--- a/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
+++ b/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
@@ -20,7 +20,10 @@
         <CC_CPP_Defines Include="__CORTEX_M4F" />
         <CC_CPP_Defines Include="CORTEX_M4" />
     </ItemGroup>
-
+    <PropertyGroup Condition="'$(COMPILER_TOOL)'=='DS5'">
+      <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M4.fp</DEVICE_TYPE>
+      <BUILD_TOOL_GUID>{F7823E3C-8BCE-4D9A-AD56-9E06063C47CD}</BUILD_TOOL_GUID>
+    </PropertyGroup>
     <PropertyGroup Condition="'$(COMPILER_TOOL)'=='RVDS'">
         <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M4.fp</DEVICE_TYPE>
         <BUILD_TOOL_GUID>{00C50096-00DD-00E7-BBA9-7FC84D408562}</BUILD_TOOL_GUID>

--- a/DeviceCode/Targets/Native/Template/Template.settings
+++ b/DeviceCode/Targets/Native/Template/Template.settings
@@ -16,6 +16,11 @@
     <TARGETCODEBASE>TEMPLATE</TARGETCODEBASE>
     <TARGETCODEBASETYPE>Native</TARGETCODEBASETYPE>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(COMPILER_TOOL)'=='DS5'">
+    <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">arm920t</DEVICE_TYPE>
+    <DEVICE_TYPE Condition="'$(INSTRUCTION_SET)'=='thumb2'">Cortex-M3</DEVICE_TYPE>
+    <BUILD_TOOL_GUID>{F7823E3C-8BCE-4D9A-AD56-9E06063C47CD}</BUILD_TOOL_GUID>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(COMPILER_TOOL)'=='RVDS'">
     <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">arm920t</DEVICE_TYPE>
     <DEVICE_TYPE Condition="'$(INSTRUCTION_SET)'=='thumb2'">Cortex-M3</DEVICE_TYPE>

--- a/Framework/Tools/BuildTasks/ScatterFile.cs
+++ b/Framework/Tools/BuildTasks/ScatterFile.cs
@@ -573,7 +573,7 @@ namespace Microsoft.SPOT.Tasks.ScatterFile
             string name = node.Name;
             IParse o    = null;
 
-            if (GetVariable("COMPILER_TOOL").ToUpper() == "RVDS" || GetVariable("COMPILER_TOOL").ToUpper() == "MDK")
+            if (GetVariable("COMPILER_TOOL").ToUpper() == "RVDS" || GetVariable("COMPILER_TOOL").ToUpper() == "MDK" || GetVariable("COMPILER_TOOL").ToUpper() == "DS5")
             {
                 if (name == "ScatterFile")          o = new Group();
                 else if (name == "Set")             o = new Variable();

--- a/Solutions/MCBSTM32F400/MicroBooter/scatterfile_microbooter_ds5.xml
+++ b/Solutions/MCBSTM32F400/MicroBooter/scatterfile_microbooter_ds5.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- Freescale MC9328L, NO SRAM, SDRAM 32M/64M -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+
+    <Set Name="Heap_Begin"      Value="0x08100000"/>
+    <Set Name="Heap_End"        Value="0x084FFFF8"/>
+    <Set Name="Stack_Bottom"    Value="+0"/>
+    <Set Name="Stack_Top"       Value="0x08502000"/>
+
+    
+    <If Name="TARGETLOCATION" In="FLASH">
+
+        <!-- iMXS has 8MB of 32-bit FLASH at 0x10000000 -->
+        <Set Name="Code_BaseAddress" Value="0x10000000"/>
+        <Set Name="Code_Size"        Value="0x00020000"/>
+        <Set Name="RAM_RO_Base"      Value="0x00000000"/>
+        <Set Name="Valid"            Value="true"/>
+
+    </If>
+
+    <If Name="TARGETLOCATION" In="RAM">
+
+        <Set Name="Code_BaseAddress" Value="0x08200000"/> 
+        <Set Name="Code_Size"        Value="0x00030000"/>
+        <Set Name="RAM_RO_Base"      Value="+0"/>
+        <Set Name="Valid"            Value="true"/>
+        
+    </If>
+
+
+    <!-- ################################################################################ -->
+
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <!-- we start at 0x10080000 since PortBooter lives at 0x10000000 -->
+    <!-- the address and sizes for both load regions (LR_*) are chosen to start and completely fill a flash partition in the 28F320W18 flash chip -->
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- we have arbitrarily asigned 0x00080000 offset in FLASH for the CLR code, and size of 0x00080000 -->
+
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+
+            <FileMapping Name="FirstEntry.obj" Options="(+RO, +FIRST)" /> <!-- the entry pointer section goes into this region -->
+
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO)" />
+
+        </ExecRegion>
+
+        <!-- skip vector area -->
+
+        <ExecRegion Name="ER_RAM_RO" Base="%RAM_RO_Base%" Options="ABSOLUTE" Size="">
+
+            <FileMapping Name="VectorsTrampolines.obj" Options="(+RO, +FIRST)" /> <!-- for vector handlers to be far from the vectors -->
+
+            <FileMapping Name="*" Options="(i.IDelayLoop)" Comment="00004a98 24 16 IDelayLoop" />
+            <FileMapping Name="*" Options="(i._Z23Time_Sleep_MicroSecondsj)" Comment="_Z23Time_Sleep_MicroSecondsj" />
+            <FileMapping Name="*" Options="(i._Z40Time_Sleep_MicroSeconds_InterruptEnabledj)" Comment="_Z40Time_Sleep_MicroSeconds_InterruptEnabledj" />
+            <FileMapping Name="*" Options="(i._Z23CPU_MicrosecondsToTicksj)" Comment="_Z23CPU_MicrosecondsToTicksj" />    
+            <FileMapping Name="*" Options="(i._Z17Events_MaskedReadj)" Comment="000070ec 20 20787 Events_MaskedRead__FUi" />
+            <FileMapping Name="*" Options="(i._ZN16MC9328MXL_Driver5PauseEv)" />
+            <FileMapping Name="*" Options="(i._ZN21MC9328MXL_TIME_Driver12CounterValueEv)" Comment="00007840 40 712150 _ZN21MC9328MXL_TIME_Driver12CounterValueEv" />
+            <FileMapping Name="*" Options="(i._ZN21MC9328MXL_AITC_Driver17ActivateInterruptEjjPFvPvES0_h)" Comment="00007604 76 231095 _ZN21MC9328MXL_AITC_Driver17ActivateInterruptEjjPFvPvES0_h" />
+            <FileMapping Name="*" Options="(i._ZN21MC9328MXL_AITC_Driver19DeactivateInterruptEj)" Comment="00007604 76 231095 _ZN21MC9328MXL_AITC_Driver19DeactivateInterruptEj" />
+            <FileMapping Name="*" Options="(i._ZN21MC9328MXL_TIME_Driver15SetCompareValueEy)" Comment="00007868 96 181492 _ZN21MC9328MXL_TIME_Driver15SetCompareValueEy" />
+            <FileMapping Name="*" Options="(i._ZN21MC9328MXL_TIME_Driver11CurrentTimeEv)" Comment="000079d0 88 94500 _ZN21MC9328MXL_TIME_Driver11CurrentTimeEv" />
+            <FileMapping Name="*" Options="(i._ZN25MC9328MXL_WATCHDOG_Driver12ResetCounterEv)" Comment="00007adc 24 22218 _ZN25MC9328MXL_WATCHDOG_Driver12ResetCounterEv" />
+            <FileMapping Name="*" Options="(i._Z18SUPPORT_ComputeCRCPKvij)" Comment="00006654 72 1709347 SUPPORT_ComputeCRC__FPCviUi" />
+            <FileMapping Name="rt_sdiv.o" Options="(+RO)" />
+            <FileMapping Name="rt_memclr.o" Options="(+RO)" />
+            <FileMapping Name="rt_memclr_w.o" Options="(+RO)" />
+            <FileMapping Name="rt_memcpy.o" Options="(+RO)" />
+            <FileMapping Name="rt_memcpy_w.o" Options="(+RO)" />
+            <FileMapping Name="llshl.o" Options="(+RO)" />
+            <FileMapping Name="llsdiv.o" Options="(+RO)" />
+            <FileMapping Name="llushr.o" Options="(+RO)" />
+            <FileMapping Name="lludiv.o" Options="(+RO)" />
+
+            <FileMapping Name="*" Options="(SectionForFlashOperations)" />
+
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RW" Base="+0" Options="ABSOLUTE" Size="">
+
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+
+        </ExecRegion>
+
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_Begin%" Options="ABSOLUTE" Size="UNINIT">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="%Heap_End%" Options="ABSOLUTE" Size="UNINIT">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="%Stack_Bottom%" Options="ABSOLUTE" Size="UNINIT">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+	    
+        <ExecRegion Name="ER_STACK_TOP" Base="%Stack_Top%" Options="ABSOLUTE" Size="UNINIT">
+            <FileMapping Name="*" Options="(SectionForStackTop)" />
+        </ExecRegion>
+
+    </LoadRegion>
+
+</ScatterFile>

--- a/Solutions/MCBSTM32F400/TinyBooter/scatterfile_bootloader_ds5.xml
+++ b/Solutions/MCBSTM32F400/TinyBooter/scatterfile_bootloader_ds5.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- STM32F4 with 1M Flash, 128k SRAM, and 64k DATA CCM -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+
+    <!-- Memory Region base and size values for physical hardware to help clarify the mapping
+         by making Symbolic names available instead of a bunch of numbers. These values are
+         fixed in hardware and therefore, don't change.
+    -->
+    <!-- Internal FLASH -->
+    <Set Name="IFLASH_BaseAddress"      Value="0x08000000"/>
+    <Set Name="IFLASH_Size"             Value="0x00100000"/><!-- 1MB -->
+
+    <!-- Core Coupled Memory (CCM) [D-Bus] -->
+    <Set Name="CCM_BaseAddress"         Value="0x10000000"/>
+    <Set Name="CCM_Size"                Value="0x00010000"/><!-- 64KB -->
+
+    <!-- Internal SRAM -->
+    <Set Name="IRAM_BaseAddress"        Value="0x20000000"/>
+    <Set Name="IRAM_Size"               Value="0x00020000"/><!-- 128KB -->
+
+    <!-- External NOR Flash-->
+    <Set Name="NOR_BaseAddress"         Value="0x60000000"/>
+    <Set Name="NOR_Size"                Value="0x00800000"/><!-- 8MB -->
+
+    <!-- External SRAM -->
+    <Set Name="EXTRAM_BaseAddress"      Value="0x68000000"/>
+    <Set Name="EXTRAM_Size"             Value="0x00200000"/><!-- 2MB -->
+
+    <!-- Solution specific usage settings -->
+    <!-- Internal CCM (D-Bus) -->
+    <!-- Put Stack in CCM for high speed access, reducing overhead of stack usage -->
+    <Set Name="Stack_Bottom"            Value="%CCM_BaseAddress%"/>
+
+    <!-- External SRAM -->
+    <Set Name="Heap_BaseAddress"        Value="%EXTRAM_BaseAddress%"/>
+
+    <!-- External NOR FLASH -->
+    <!-- Configuration section is at base of external NOR flash
+         This needs to be in the same block storage device as the
+         deployment region to enable the MFDeploy to access it.
+         ( Due to device side library implementation limit )
+    -->
+    <Set Name="Config_BaseAddress"      Value="%NOR_BaseAddress%"/>
+    <Set Name="Config_Size"             Value="0x00010000"/><!-- 64KB -->
+
+    <!-- DAT region goes into external NOR Flash -->
+    <Set Name="Data_BaseAddress"        Value="%Config_BaseAddress% + %Config_Size%"/>
+    <Set Name="Data_Size"               Value="0x00040000"/><!-- 256KB -->
+
+    <!-- Deployment fills the rest of external NOR flash... -->
+
+    <!-- Internal FLASH -->
+    <!-- TinyBooter sits at power on Reset vector-->
+    <Set Name="BooterCode_BaseAddress"  Value="%IFLASH_BaseAddress%"/>
+    <Set Name="BooterCode_Size"         Value="0x00010000"/><!-- 64KB -->
+        
+    <If Name="TARGETLOCATION" Value="FLASH">
+        <!-- Internal FLASH -->
+        
+        <!-- Native Code section -->
+        <Set Name="Code_BaseAddress"         Value="%BooterCode_BaseAddress%"/>
+        <Set Name="Code_Size"                Value="%BooterCode_Size%"/>
+
+        <!-- =========================================================== -->
+        <If Name="TARGETTYPE" Value="Release">
+            <!-- ALL of external RAM is enabled for the CLR HEAP -->
+            <Set Name="Heap_Size"               Value="0x00080000"/><!-- 512K -->
+            <Set Name="CustomHeap_Size"         Value="0x00080000"/><!-- 512K -->
+        
+            <Set Name="Valid"                   Value="true"/>
+        </If>
+        <If Name="TARGETTYPE" Value="Debug">
+            <!-- Use only 1MB of external RAM for Debug builds.
+                 Can't use all of external RAM as the address pins overlap
+                 with the SWD pins used for ETM tracing in Debug builds.
+            -->
+            <Set Name="Heap_Size"               Value="0x00100000"/><!--1MB-->
+            <Set Name="CustomHeap_Size"         Value="0x00100000"/><!--1MB-->
+            
+            <Set Name="Valid"               Value="true"/>
+        </If>
+    </If>
+
+    <!-- ################################################################################ -->
+
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- ========= INTERNAL FLASH ============================================ -->
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+            <FileMapping Name="*" Options="(SectionForPowerOnReset, +FIRST)" />
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO-CODE)" />
+            <FileMapping Name="*" Options="(+RO-DATA)" />
+        </ExecRegion>
+
+        <!-- ========= INTERNAL RAM ============================================= -->
+        <!-- Writeable Vector table -->
+        <!-- NOTE:
+             Despite what you might hope for, this CANNOT go into the CCM area as the NVIC does not
+             have access to that space (it sees the AHB layer and below, rather than the core's D-Bus)
+        -->
+        <!-- Alignment for the vector table is important to allow the NVIC to decode the proper locations
+            (See Section 4.4.4 of the ARM Cortex-M4 Generic User Guide [ ARM DUI 0553A (ID121610) ] )
+            Since this starts the SRAM block, it's aligned just fine for any size table.
+        -->
+        <ExecRegion Name="ER_RAM_RW" Base="%IRAM_BaseAddress%" Options="ABSOLUTE" Size="">
+            <FileMapping Name="*" Options="(VectorTable)"/> 
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RO" Base="+0" Options="ABSOLUTE" Size="">
+            <!-- Flash programming from Flash is safe on STM32 -->
+            <!-- No need to place Flash programming code in RAM -->
+            <!-- <FileMapping Name="*" Options="(SectionForFlashOperations)" /> -->
+        </ExecRegion>
+
+        <!-- ========= EXTERNAL RAM ============================================= -->
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_BaseAddress%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="+%Heap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_BEGIN" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+          <FileMapping Name="*" Options="(SectionForCustomHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for the unmanaged SimpleHeap -->
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_END" Base="+%CustomHeap_Size%" Options="ABSOLUTE UNINIT" Size="">
+          <FileMapping Name="*" Options="(SectionForCustomHeapEnd)" />
+        </ExecRegion>
+
+        <!-- ========= Internal CCM ============================================ -->
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="%Stack_Bottom%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+
+        <!-- -8 for the two 32bit values in the SectionForStack* sections, This keeps the region
+             limit from exceeding the size of physical memory.
+        -->
+        <ExecRegion Name="ER_STACK_TOP" Base="AlignExpr(+%CCM_Size% -8, 8 )" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackTop +LAST)" />
+        </ExecRegion>
+    </LoadRegion>
+</ScatterFile>

--- a/Solutions/MCBSTM32F400/TinyCLR/scatterfile_tinyclr_ds5.xml
+++ b/Solutions/MCBSTM32F400/TinyCLR/scatterfile_tinyclr_ds5.xml
@@ -1,0 +1,191 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- STM32F4 with 1M Flash, 128k SRAM, and 64k DATA CCM -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+    <!-- Memory Region base and size values for physical hardware to help clarify the mapping
+         by making Symbolic names available instead of a bunch of numbers. These values are
+         fixed in hardware and therefore, don't change.
+    -->
+    <!-- Internal FLASH -->
+    <Set Name="IFLASH_BaseAddress"      Value="0x08000000"/>
+    <Set Name="IFLASH_Size"             Value="0x00100000"/><!-- 1MB -->
+
+    <!-- Core Coupled Memory (CCM) [D-Bus] -->
+    <Set Name="CCM_BaseAddress"         Value="0x10000000"/>
+    <Set Name="CCM_Size"                Value="0x00010000"/><!-- 64KB -->
+
+    <!-- Internal SRAM -->
+    <Set Name="IRAM_BaseAddress"        Value="0x20000000"/>
+    <Set Name="IRAM_Size"               Value="0x00020000"/><!-- 128KB -->
+
+    <!-- External NOR Flash-->
+    <Set Name="NOR_BaseAddress"         Value="0x60000000"/>
+    <Set Name="NOR_Size"                Value="0x00800000"/><!-- 8MB -->
+
+    <!-- External SRAM -->
+    <Set Name="EXTRAM_BaseAddress"      Value="0x68000000"/>
+    <Set Name="EXTRAM_Size"             Value="0x00200000"/><!-- 2MB -->
+
+    <!-- Solution/Project specific usage settings -->
+    <!-- Internal CCM (D-Bus) -->
+    <!-- Put Stack in CCM for high speed access, reducing overhead of stack usage -->
+    <Set Name="Stack_Bottom"            Value="%CCM_BaseAddress%"/>
+
+    <!-- External SRAM -->
+    <Set Name="Heap_BaseAddress"        Value="%EXTRAM_BaseAddress%"/>
+
+    <!-- External NOR FLASH -->
+    <!-- Configuration section is at base of external NOR flash
+         This needs to be in the same block storage device as the
+         deployment region to enable the MFDeploy to access it.
+         ( Due to device side library implementation limitation )
+    -->
+    <Set Name="Config_BaseAddress"      Value="%NOR_BaseAddress%"/>
+    <Set Name="Config_Size"             Value="0x00010000"/><!-- 64KB -->
+
+    <!-- DAT region goes into external NOR Flash -->
+    <Set Name="Data_BaseAddress"        Value="%Config_BaseAddress% + %Config_Size%"/>
+    <Set Name="Data_Size"               Value="0x00040000"/><!-- 256KB -->
+
+    <!-- [Deployment fills the rest of external NOR flash...] -->
+
+    <!-- Internal FLASH -->
+    <!-- TinyBooter sits at power on Reset vector -->
+    <Set Name="BooterCode_BaseAddress"  Value="%IFLASH_BaseAddress%"/>
+    <Set Name="BooterCode_Size"         Value="0x00010000"/><!-- 64KB -->
+        
+    <If Name="TARGETLOCATION" Value="FLASH">
+        <!-- Internal FLASH -->
+        
+        <!-- Native Code section -->
+        <Set Name="Code_BaseAddress"    Value="%BooterCode_BaseAddress% + %BooterCode_Size%"/>
+        <Set Name="Code_Size"           Value="%IFLASH_Size%-%BooterCode_Size%"/>
+
+        <!-- =========================================================== -->
+        <If Name="TARGETTYPE" Value="Release">
+            <!-- ALL of external RAM is enabled for the CLR HEAP -->
+            <Set Name="Heap_Size"       Value="%EXTRAM_Size%"/>
+            <Set Name="CustomHeap_Size" Value="0"/>
+        
+            <Set Name="Valid"           Value="true"/>
+        </If>
+        <If Name="TARGETTYPE" Value="Debug">
+            <!-- Use only 1MB of external RAM for Debug builds.
+                 Can't use all of external RAM as the address pins overlap
+                 with the SWD pins used for ETM tracing in Debug builds.
+            -->
+            <Set Name="Heap_Size"       Value="0x00100000"/><!--1MB-->
+            <Set Name="CustomHeap_Size" Value="0"/>
+            
+            <Set Name="Valid"           Value="true"/>
+        </If>
+    </If>
+
+    <!-- ################################################################################ -->
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- ========= INTERNAL FLASH ============================================ -->
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+            <FileMapping Name="AppEntry.obj" Options="(+RO, +FIRST)" />
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO-CODE)" />
+            <FileMapping Name="*" Options="(+RO-DATA)" />
+        </ExecRegion>
+
+        <!-- ========= INTERNAL RAM ============================================= -->
+        <!-- Writeable Vector table -->
+        <!-- NOTE:
+             Despite what you might hope for, this CANNOT go into the CCM area as the NVIC does not
+             have access to that space (it sees the AHB layer and below, rather than the core's D-Bus)
+        -->
+        <!-- Alignment for the vector table is important to allow the NVIC to decode the proper locations
+            (See Section 4.4.4 of the ARM Cortex-M4 Generic User Guide [ ARM DUI 0553A (ID121610) ] )
+            Since this starts the SRAM block, it's aligned just fine for any size table.
+        -->
+        <ExecRegion Name="ER_VECTORS" Base="%IRAM_BaseAddress%" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(VectorTable +FIRST)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RW" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+        </ExecRegion>
+
+        <!-- To enable re-initialization of the LWIP stack, which has no built-in support
+             for re-init, all RW and ZI data for the stack is placed into an isolated region
+             and the HAL soft reboot code handles re-initializing the data in this region.
+        -->
+        <ExecRegion Name="ER_LWIP_OS" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+          <FileMapping Name="*sockets_hal_*_LWIP_os.lib" Options="(+RW-DATA +ZI)" />
+          <FileMapping Name="*lwip_1_4_1_os_CMSIS_RTOS.lib" Options="(+RW-DATA +ZI)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RO" Base="+0" Options="ABSOLUTE" Size="">
+            <!-- Flash programming from Flash is safe on STM32 -->
+            <!-- No need to place Flash programming code in RAM -->
+            <!-- <FileMapping Name="*" Options="(SectionForFlashOperations)" /> -->
+        </ExecRegion>
+
+        <!-- ========= EXTERNAL RAM ============================================= -->
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_BaseAddress%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="+%Heap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_BEGIN" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+          <FileMapping Name="*" Options="(SectionForCustomHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for the unmanaged SimpleHeap -->
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_END" Base="+%CustomHeap_Size%" Options="ABSOLUTE UNINIT" Size="">
+          <FileMapping Name="*" Options="(SectionForCustomHeapEnd)" />
+        </ExecRegion>
+
+        <!-- ========= Internal CCM ============================================ -->
+        <!-- Stack allocation pools for the OS, Sizes are set in RTX_Conf_CM.c along with other OS configuration -->
+        <ExecRegion Name="ER_RT_STACK" Base="%Stack_Bottom%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(rtx_stack)" />
+        </ExecRegion>
+
+        <!-- The rest of the CCM is used as a general stack during startup. This can't overlap with the ER_RT_STACK
+             region as the kernel will zero that out during initialization, which would overwrite the stack of the
+             code running the initialization, causing an early FAULT. Size and alignment are critical here. The stack
+             must be aligned on an 8 byte boundary AND the size of this region must not extend it past the end of the
+             actual physical CCM space. The CRT startup code will initialize the region and, if the aligned size
+             puts the end outside of physical memory it will generate an imprecise abort.
+        -->
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="AlignExpr( +0, 8 )" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+        <ExecRegion Name="ER_STACK" Base="+0" Options="ABSOLUTE EMPTY" Size="(AlignExpr(%CCM_Size% - 8 - ImageLength(ER_RT_STACK), 8))" />
+        <ExecRegion Name="ER_STACK_TOP" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackTop +LAST)" />
+        </ExecRegion>
+    </LoadRegion>
+
+        <LoadRegion Name="LR_DAT" Base="%Data_BaseAddress%" Options="ABSOLUTE" Size="%Data_Size%">
+            <ExecRegion Name="ER_DAT" Base="%Data_BaseAddress%" Options="FIXED" Size="%Data_Size%">
+                <FileMapping Name="tinyclr_dat.obj" Options="(+RO)" />
+            </ExecRegion>
+        </LoadRegion>
+
+        <LoadRegion Name="LR_CONFIG" Base="%Config_BaseAddress%" Options="ABSOLUTE" Size="%Config_Size%">
+            <ExecRegion Name="ER_CONFIG" Base="%Config_BaseAddress%" Options="FIXED" Size="%Config_Size%">
+                <FileMapping Name="*" Options="(SectionForConfig)" />
+            </ExecRegion>
+        </LoadRegion>
+</ScatterFile>
+

--- a/Solutions/MCBSTM32F400/TinyCLR_NONET/scatterfile_tinyclr_ds5.xml
+++ b/Solutions/MCBSTM32F400/TinyCLR_NONET/scatterfile_tinyclr_ds5.xml
@@ -1,0 +1,186 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- STM32F4 with 1M Flash, 128k SRAM, and 64k DATA CCM -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+    <!-- Memory Region base and size values for physical hardware to help clarify the mapping
+         by making Symbolic names available instead of a bunch of numbers. These values are
+         fixed in hardware and therefore, don't change.
+    -->
+    <!-- Internal FLASH -->
+    <Set Name="IFLASH_BaseAddress"      Value="0x08000000"/>
+    <Set Name="IFLASH_Size"             Value="0x00100000"/><!-- 1MB -->
+
+    <!-- Core Coupled Memory (CCM) [D-Bus] -->
+    <Set Name="CCM_BaseAddress"         Value="0x10000000"/>
+    <Set Name="CCM_Size"                Value="0x00010000"/><!-- 64KB -->
+
+    <!-- Internal SRAM -->
+    <Set Name="IRAM_BaseAddress"        Value="0x20000000"/>
+    <Set Name="IRAM_Size"               Value="0x00020000"/><!-- 128KB -->
+
+    <!-- External NOR Flash-->
+    <Set Name="NOR_BaseAddress"         Value="0x60000000"/>
+    <Set Name="NOR_Size"                Value="0x00800000"/><!-- 8MB -->
+
+    <!-- External SRAM -->
+    <Set Name="EXTRAM_BaseAddress"      Value="0x68000000"/>
+    <Set Name="EXTRAM_Size"             Value="0x00200000"/><!-- 2MB -->
+
+    <!-- Solution/Project specific usage settings -->
+    <!-- Internal CCM (D-Bus) -->
+    <!-- Put Stack in CCM for high speed access, reducing overhead of stack usage -->
+    <Set Name="Stack_Bottom"            Value="%CCM_BaseAddress%"/>
+
+    <!-- External SRAM -->
+    <Set Name="Heap_BaseAddress"        Value="%EXTRAM_BaseAddress%"/>
+
+    <!-- External NOR FLASH -->
+    <!-- Configuration section is at base of external NOR flash
+         This needs to be in the same block storage device as the
+         deployment region to enable the MFDeploy to access it.
+         ( Due to device side library implementation limit )
+    -->
+    <Set Name="Config_BaseAddress"      Value="%NOR_BaseAddress%"/>
+    <Set Name="Config_Size"             Value="0x00010000"/><!-- 64KB -->
+
+    <!-- DAT region goes into external NOR Flash -->
+    <Set Name="Data_BaseAddress"        Value="%Config_BaseAddress% + %Config_Size%"/>
+    <Set Name="Data_Size"               Value="0x00030000"/><!-- 192KB -->
+    <!-- Deployment fills the rest of external NOR flash... -->
+
+    <!-- Internal FLASH -->
+    <!-- TinyBooter sits at power on Reset vector-->
+    <Set Name="BooterCode_BaseAddress"  Value="%IFLASH_BaseAddress%"/>
+    <Set Name="BooterCode_Size"         Value="0x00010000"/><!-- 64KB -->
+        
+    <If Name="TARGETLOCATION" Value="FLASH">
+        <!-- Internal FLASH -->
+        
+        <!-- Native Code section -->
+        <Set Name="Code_BaseAddress"    Value="%BooterCode_BaseAddress% + %BooterCode_Size%"/>
+        <Set Name="Code_Size"           Value="%IFLASH_Size%-%BooterCode_Size%"/>
+
+        <!-- =========================================================== -->
+        <If Name="TARGETTYPE" Value="Release">
+            <!-- ALL of external RAM is enabled for the CLR HEAP -->
+            <Set Name="Heap_Size"       Value="%EXTRAM_Size%"/>
+            <Set Name="CustomHeap_Size" Value="0"/>
+        
+            <Set Name="Valid"           Value="true"/>
+        </If>
+        <If Name="TARGETTYPE" Value="Debug">
+            <!-- Use only 1MB of external RAM for Debug builds.
+                 Can't use all of external RAM as the address pins overlap
+                 with the SWD pins used for ETM tracing in Debug builds.
+            -->
+            <Set Name="Heap_Size"       Value="0x00100000"/><!--1MB-->
+            <Set Name="CustomHeap_Size" Value="0"/>
+            
+            <Set Name="Valid"           Value="true"/>
+        </If>
+    </If>
+
+    <!-- ################################################################################ -->
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- ========= INTERNAL FLASH ============================================ -->
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+            <FileMapping Name="AppEntry.obj" Options="(+RO, +FIRST)" />
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO-CODE)" />
+            <FileMapping Name="*" Options="(+RO-DATA)" />
+        </ExecRegion>
+
+        <!-- ========= INTERNAL RAM ============================================= -->
+        <!-- Writeable Vector table -->
+        <!-- NOTE:
+             Despite what you might hope for, this CANNOT go into the CCM area as the NVIC does not
+             have access to that space (it sees the AHB layer and below, rather than the core's D-Bus)
+        -->
+        <!-- Alignment for the vector table is important to allow the NVIC to decode the proper locations
+            (See Section 4.4.4 of the ARM Cortex-M4 Generic User Guide [ ARM DUI 0553A (ID121610) ] )
+            Since this starts the SRAM block, it's aligned just fine for any size table.
+        -->
+        <!-- NOTE: Using uncompressed sections as this project uses the NETMF startup code that
+             doesn't know about compressed init regions. Eventually this should be unified so that
+             the normal embedded (Microlib/nanolib) runtime startup is used for all tool chains
+             instead of doing it in the NETMF code base.
+        -->
+        <ExecRegion Name="ER_VECTORS" Base="%IRAM_BaseAddress%" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(VectorTable +FIRST)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RW" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RO" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <!-- Flash programming from Flash is safe on STM32 -->
+            <!-- No need to place Flash programming code in RAM -->
+            <!-- <FileMapping Name="*" Options="(SectionForFlashOperations)" /> -->
+        </ExecRegion>
+
+        <!-- ========= EXTERNAL RAM ============================================= -->
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_BaseAddress%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="+%Heap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_BEGIN" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for the unmanaged SimpleHeap -->
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_END" Base="+%CustomHeap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapEnd)" />
+        </ExecRegion>
+
+        <!-- ========= Internal CCM ============================================ -->
+        <!-- Stack allocation pools for the OS, Sizes are set in RTX_Conf_CM.c along with other OS configuration -->
+        <ExecRegion Name="ER_RT_STACK" Base="%Stack_Bottom%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(rtx_stack)" />
+        </ExecRegion>
+
+        <!-- The rest of the CCM is used as a general stack during startup. This can't overlap with the ER_RT_STACK
+             region as the kernel will zero that out during initialization, which would overwrite the stack of the
+             code running the initialization, causing an early FAULT. Size and alignment are critical here. The stack
+             must be aligned on an 8 byte boundary AND the size of this region must not extend it past the end of the
+             actual physical CCM space. The CRT startup code will initialize the region and, if the aligned size
+             puts the end outside of physical memory it will generate an imprecise abort.
+        -->
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="AlignExpr( +0, 8 )" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+        <ExecRegion Name="ER_STACK" Base="+0" Options="ABSOLUTE EMPTY" Size="(AlignExpr(%CCM_Size% - 8 - ImageLength(ER_RT_STACK), 8))" />
+        <ExecRegion Name="ER_STACK_TOP" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackTop +LAST)" />
+        </ExecRegion>
+    </LoadRegion>
+
+    <LoadRegion Name="LR_DAT" Base="%Data_BaseAddress%" Options="ABSOLUTE" Size="%Data_Size%">
+        <ExecRegion Name="ER_DAT" Base="%Data_BaseAddress%" Options="FIXED" Size="%Data_Size%">
+            <FileMapping Name="tinyclr_dat.obj" Options="(+RO)" />
+        </ExecRegion>
+    </LoadRegion>
+
+    <LoadRegion Name="LR_CONFIG" Base="%Config_BaseAddress%" Options="ABSOLUTE" Size="%Config_Size%">
+        <ExecRegion Name="ER_CONFIG" Base="%Config_BaseAddress%" Options="FIXED" Size="%Config_Size%">
+            <FileMapping Name="*" Options="(SectionForConfig)" />
+        </ExecRegion>
+    </LoadRegion>
+</ScatterFile>
+

--- a/Solutions/MCBSTM32F400/TinyCLR_NONET/scatterfile_tinyclr_nonet_ds5.xml
+++ b/Solutions/MCBSTM32F400/TinyCLR_NONET/scatterfile_tinyclr_nonet_ds5.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- STM32F4 with 1M Flash, 128k SRAM, and 64k DATA CCM -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+    <!-- Memory Region base and size values for physical hardware to help clarify the mapping
+         by making Symbolic names available instead of a bunch of numbers. These values are
+         fixed in hardware and therefore, don't change.
+    -->
+    <!-- Internal FLASH -->
+    <Set Name="IFLASH_BaseAddress"      Value="0x08000000"/>
+    <Set Name="IFLASH_Size"             Value="0x00100000"/><!-- 1MB -->
+
+    <!-- Core Coupled Memory (CCM) [D-Bus] -->
+    <Set Name="CCM_BaseAddress"         Value="0x10000000"/>
+    <Set Name="CCM_Size"                Value="0x00010000"/><!-- 64KB -->
+
+    <!-- Internal SRAM -->
+    <Set Name="IRAM_BaseAddress"        Value="0x20000000"/>
+    <Set Name="IRAM_Size"               Value="0x00020000"/><!-- 128KB -->
+
+    <!-- External NOR Flash-->
+    <Set Name="NOR_BaseAddress"         Value="0x60000000"/>
+    <Set Name="NOR_Size"                Value="0x00800000"/><!-- 8MB -->
+
+    <!-- External SRAM -->
+    <Set Name="EXTRAM_BaseAddress"      Value="0x68000000"/>
+    <Set Name="EXTRAM_Size"             Value="0x00200000"/><!-- 2MB -->
+
+    <!-- Solution/Project specific usage settings -->
+    <!-- Internal CCM (D-Bus) -->
+    <!-- Put Stack in CCM for high speed access, reducing overhead of stack usage -->
+    <Set Name="Stack_Bottom"            Value="%CCM_BaseAddress%"/>
+
+    <!-- External SRAM -->
+    <Set Name="Heap_BaseAddress"        Value="%EXTRAM_BaseAddress%"/>
+
+    <!-- External NOR FLASH -->
+    <!-- Configuration section is at base of external NOR flash
+         This needs to be in the same block storage device as the
+         deployment region to enable the MFDeploy to access it.
+         ( Due to device side library implementation limitation )
+    -->
+    <Set Name="Config_BaseAddress"      Value="%NOR_BaseAddress%"/>
+    <Set Name="Config_Size"             Value="0x00010000"/><!-- 64KB -->
+
+    <!-- DAT region goes into external NOR Flash -->
+    <Set Name="Data_BaseAddress"        Value="%Config_BaseAddress% + %Config_Size%"/>
+    <Set Name="Data_Size"               Value="0x00030000"/><!-- 192KB -->
+
+    <!-- [Deployment fills the rest of external NOR flash...] -->
+
+    <!-- Internal FLASH -->
+    <!-- TinyBooter sits at power on Reset vector -->
+    <Set Name="BooterCode_BaseAddress"  Value="%IFLASH_BaseAddress%"/>
+    <Set Name="BooterCode_Size"         Value="0x00010000"/><!-- 64KB -->
+
+    <If Name="TARGETLOCATION" Value="FLASH">
+        <!-- Internal FLASH -->
+
+        <!-- Native Code section -->
+        <Set Name="Code_BaseAddress"    Value="%BooterCode_BaseAddress% + %BooterCode_Size%"/>
+        <Set Name="Code_Size"           Value="%IFLASH_Size%-%BooterCode_Size%"/>
+
+        <!-- =========================================================== -->
+        <If Name="TARGETTYPE" Value="Release">
+            <!-- ALL of external RAM is enabled for the CLR HEAP -->
+            <Set Name="Heap_Size"       Value="%EXTRAM_Size%"/>
+            <Set Name="CustomHeap_Size" Value="0"/>
+
+            <Set Name="Valid"           Value="true"/>
+        </If>
+        <If Name="TARGETTYPE" Value="Debug">
+            <!-- Use only 1MB of external RAM for Debug builds.
+                 Can't use all of external RAM as the address pins overlap
+                 with the SWD pins used for ETM tracing in Debug builds.
+            -->
+            <Set Name="Heap_Size"       Value="0x00100000"/><!--1MB-->
+            <Set Name="CustomHeap_Size" Value="0"/>
+            
+            <Set Name="Valid"           Value="true"/>
+        </If>
+    </If>
+
+    <!-- ################################################################################ -->
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- ========= INTERNAL FLASH ============================================ -->
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+            <FileMapping Name="AppEntry.obj" Options="(+RO, +FIRST)" />
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO-CODE)" />
+            <FileMapping Name="*" Options="(+RO-DATA)" />
+        </ExecRegion>
+
+        <!-- ========= INTERNAL RAM ============================================= -->
+        <!-- Writeable Vector table -->
+        <!-- NOTE:
+             Despite what you might hope for, this CANNOT go into the CCM area as the NVIC does not
+             have access to that space (it sees the AHB layer and below, rather than the core's D-Bus)
+        -->
+        <!-- Alignment for the vector table is important to allow the NVIC to decode the proper locations
+            (See Section 4.4.4 of the ARM Cortex-M4 Generic User Guide [ ARM DUI 0553A (ID121610) ] )
+            Since this starts the SRAM block, it's aligned just fine for any size table.
+        -->
+        <!-- NOTE: Using uncompressed sections as this project uses the NETMF startup code that
+             doesn't know about compressed init regions. Eventually this should be unified so that
+             the normal embedded (Microlib/nanolib) runtime startup is used for all tool chains
+             instead of doing it in the NETMF code base.
+        -->
+        <ExecRegion Name="ER_VECTORS" Base="%IRAM_BaseAddress%" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(VectorTable +FIRST)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RW" Base="+0" Options="ABSOLUTE" Size="">
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RO" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <!-- Flash programming from Flash is safe on STM32 -->
+            <!-- No need to place Flash programming code in RAM -->
+            <!-- <FileMapping Name="*" Options="(SectionForFlashOperations)" /> -->
+        </ExecRegion>
+
+        <!-- ========= EXTERNAL RAM ============================================= -->
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_BaseAddress%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="+%Heap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_BEGIN" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for the unmanaged SimpleHeap -->
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_END" Base="+%CustomHeap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapEnd)" />
+        </ExecRegion>
+
+        <!-- ========= Internal CCM ============================================ -->
+        <!-- Stack allocation pools for the OS, Sizes are set in RTX_Conf_CM.c along with other OS configuration -->
+        <ExecRegion Name="ER_RT_STACK" Base="%Stack_Bottom%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(rtx_stack)" />
+        </ExecRegion>
+
+        <!-- The rest of the CCM is used as a general stack during startup. This can't overlap with the ER_RT_STACK
+             region as the kernel will zero that out during initialization, which would overwrite the stack of the
+             code running the initialization, causing an early FAULT. Size and alignment are critical here. The stack
+             must be aligned on an 8 byte boundary AND the size of this region must not extend it past the end of the
+             actual physical CCM space. The CRT startup code will initialize the region and, if the aligned size
+             puts the end outside of physical memory it will generate an imprecise abort.
+        -->
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="AlignExpr( +0, 8 )" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+        <ExecRegion Name="ER_STACK" Base="+0" Options="ABSOLUTE EMPTY" Size="(AlignExpr(%CCM_Size% - 8 - ImageLength(ER_RT_STACK), 8))" />
+        <ExecRegion Name="ER_STACK_TOP" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackTop +LAST)" />
+        </ExecRegion>
+    </LoadRegion>
+
+    <LoadRegion Name="LR_DAT" Base="%Data_BaseAddress%" Options="ABSOLUTE" Size="%Data_Size%">
+        <ExecRegion Name="ER_DAT" Base="%Data_BaseAddress%" Options="FIXED" Size="%Data_Size%">
+            <FileMapping Name="tinyclr_dat.obj" Options="(+RO)" />
+        </ExecRegion>
+    </LoadRegion>
+
+    <LoadRegion Name="LR_CONFIG" Base="%Config_BaseAddress%" Options="ABSOLUTE" Size="%Config_Size%">
+        <ExecRegion Name="ER_CONFIG" Base="%Config_BaseAddress%" Options="FIXED" Size="%Config_Size%">
+            <FileMapping Name="*" Options="(SectionForConfig)" />
+        </ExecRegion>
+    </LoadRegion>
+</ScatterFile>
+

--- a/Solutions/STM32F4DISCOVERY/TinyBooter/scatterfile_bootloader_ds5.xml
+++ b/Solutions/STM32F4DISCOVERY/TinyBooter/scatterfile_bootloader_ds5.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- STM32F4 with 1M Flash, 128k SRAM, and 64k DATA CCM -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+
+    <!-- Memory Region base and size values for physical hardware to help clarify the mapping
+         by making Symbolic names available instead of a bunch of numbers. These values are
+         fixed in hardware and therefore, don't change.
+    -->
+    <!-- Internal FLASH -->
+    <Set Name="IFLASH_BaseAddress"      Value="0x08000000"/>
+    <Set Name="IFLASH_Size"             Value="0x00100000"/><!-- 1MB -->
+
+    <!-- Internal Core Coupled Memory (CCM) [D-Bus] -->
+    <Set Name="CCM_BaseAddress"         Value="0x10000000"/>
+    <Set Name="CCM_Size"                Value="0x00010000"/><!-- 64KB -->
+
+    <!-- Internal SRAM -->
+    <Set Name="IRAM_BaseAddress"        Value="0x20000000"/>
+    <Set Name="IRAM_Size"               Value="0x00020000"/><!-- 128KB -->
+
+    <!-- Solution specific usage settings -->
+
+    <!-- Internal FLASH -->
+    <!--
+         The flash memory layout must match BlockRange definitions
+         in DeviceCode\Blockstorage\STM32F4\STM32F4_BlConfig.cpp
+    -->
+    <!-- TinyBooter sits at power on Reset vector-->
+    <Set Name="BooterCode_BaseAddress"  Value="%IFLASH_BaseAddress%"/>
+    <Set Name="BooterCode_Size"         Value="0x0000C000"/><!-- 48KB -->
+
+    <Set Name="Code_BaseAddress"        Value="%BooterCode_BaseAddress%"/>
+    <Set Name="Code_Size"               Value="%BooterCode_Size%"/>
+
+    <!-- Internal CCM (D-Bus) -->
+    <!-- Put Stack in CCM for high speed access, reducing overhead of stack usage -->
+    <Set Name="Stack_Bottom"            Value="%CCM_BaseAddress%"/>
+
+    <!-- Internal SRAM -->
+    <!-- FIXME: Dynamically after RAM_RW region, properly aligned. -->
+    <Set Name="Heap_BaseAddress"        Value="0x20008000"/>
+    <Set Name="Heap_Size"               Value="0x00017000"/><!-- 92K -->
+
+    <Set Name="CustomHeap_Size"         Value="0x00001000"/><!--  4K -->
+
+
+    <If Name="TARGETLOCATION" Value="FLASH">
+        <Set Name="Valid"               Value="true"/>
+    </If>
+
+    <!-- ################################################################################ -->
+
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- ========= INTERNAL FLASH ============================================ -->
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+            <FileMapping Name="*" Options="(SectionForPowerOnReset, +FIRST)" />
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO-CODE)" />
+            <FileMapping Name="*" Options="(+RO-DATA)" />
+        </ExecRegion>
+
+        <!-- ========= INTERNAL RAM ============================================= -->
+        <!-- Writeable Vector table -->
+        <!-- NOTE:
+             Despite what you might hope for, this CANNOT go into the CCM area as the NVIC does not
+             have access to that space (it sees the AHB layer and below, rather than the core's D-Bus)
+        -->
+        <!-- Alignment for the vector table is important to allow the NVIC to decode the proper locations
+            (See Section 4.4.4 of the ARM Cortex-M4 Generic User Guide [ ARM DUI 0553A (ID121610) ] )
+            Since this starts the SRAM block, it's aligned just fine for any size table.
+        -->
+        <ExecRegion Name="ER_RAM_RW" Base="%IRAM_BaseAddress%" Options="ABSOLUTE" Size="">
+            <FileMapping Name="*" Options="(VectorTable)"/> 
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RO" Base="+0" Options="ABSOLUTE" Size="">
+            <!-- Flash programming from Flash is safe on STM32 -->
+            <!-- No need to place Flash programming code in RAM -->
+            <!-- <FileMapping Name="*" Options="(SectionForFlashOperations)" /> -->
+        </ExecRegion>
+
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_BaseAddress%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="+%Heap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_BEGIN" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for the unmanaged SimpleHeap -->
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_END" Base="+%CustomHeap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapEnd)" />
+        </ExecRegion>
+
+        <!-- ========= Internal CCM ============================================ -->
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="%Stack_Bottom%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+
+        <!-- -8 for the two 32bit values in the SectionForStack* sections, This keeps the region
+             limit from exceeding the size of physical memory.
+        -->
+        <ExecRegion Name="ER_STACK_TOP" Base="AlignExpr(+%CCM_Size% -8, 8 )" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackTop +LAST)" />
+        </ExecRegion>
+    </LoadRegion>
+</ScatterFile>

--- a/Solutions/STM32F4DISCOVERY/TinyCLR/scatterfile_tinyclr_ds5.xml
+++ b/Solutions/STM32F4DISCOVERY/TinyCLR/scatterfile_tinyclr_ds5.xml
@@ -1,0 +1,147 @@
+<?xml version="1.0"?>
+<ScatterFile xmlns="http://schemas.microsoft.com/netmf/ScatterfileSchema.xsd">
+
+    <!-- STM32F4 with 1M Flash, 128k SRAM, and 64k DATA CCM -->
+
+    <Set Name="Valid" Value="false"/>
+
+    <!-- ################################################################################ -->
+
+    <!-- Memory Region base and size values for physical hardware to help clarify the mapping
+         by making Symbolic names available instead of a bunch of numbers. These values are
+         fixed in hardware and therefore, don't change.
+    -->
+    <!-- Internal FLASH -->
+    <Set Name="IFLASH_BaseAddress"      Value="0x08000000"/>
+    <Set Name="IFLASH_Size"             Value="0x00100000"/><!-- 1MB -->
+
+    <!-- Internal Core Coupled Memory (CCM) [D-Bus] -->
+    <Set Name="CCM_BaseAddress"         Value="0x10000000"/>
+    <Set Name="CCM_Size"                Value="0x00010000"/><!-- 64KB -->
+
+    <!-- Internal SRAM -->
+    <Set Name="IRAM_BaseAddress"        Value="0x20000000"/>
+    <Set Name="IRAM_Size"               Value="0x00020000"/><!-- 128KB -->
+
+    <!-- Solution/Project specific usage settings -->
+
+    <!-- Internal FLASH -->
+    <!--
+         The flash memory layout must match BlockRange definitions
+         in DeviceCode\Blockstorage\STM32F4\STM32F4_BlConfig.cpp
+    -->
+    <!-- TinyBooter sits at power on Reset vector-->
+    <Set Name="BooterCode_BaseAddress"  Value="%IFLASH_BaseAddress%"/>
+    <Set Name="BooterCode_Size"         Value="0x0000C000"/><!-- 48KB -->
+
+    <!-- Configuration section -->
+    <Set Name="Config_BaseAddress"      Value="%BooterCode_BaseAddress% + %BooterCode_Size%"/>
+    <Set Name="Config_Size"             Value="0x00004000"/><!-- 16KB -->
+
+    <!-- Native Code section -->
+    <Set Name="Code_BaseAddress"        Value="%Config_BaseAddress% + %Config_Size%"/>
+    <Set Name="Code_Size"               Value="0x00080000"/><!-- 512KB -->
+
+    <!-- Deployment fills the rest of flash... --><!-- 384KB -->
+
+    <!-- Internal CCM (D-Bus) -->
+    <!-- Put Stack in CCM for high speed access, reducing overhead of stack usage -->
+    <Set Name="Stack_Bottom"            Value="%CCM_BaseAddress%"/>
+    <Set Name="Stack_Size"              Value="%CCM_Size%" />
+
+    <!-- Internal SRAM -->
+    <!-- FIXME: Dynamically after RAM_RW region, properly aligned. -->
+    <Set Name="Heap_BaseAddress"        Value="0x20008000"/>
+    <Set Name="Heap_Size"               Value="0x00017000"/><!-- 92K -->
+
+    <Set Name="CustomHeap_Size"         Value="0x00001000"/><!--  4K -->
+
+
+    <If Name="TARGETLOCATION" Value="FLASH">
+        <Set Name="Valid"               Value="true"/>
+    </If>
+
+    <!-- ################################################################################ -->
+
+    <If Name="Valid" Value="false">
+        <Error Message="Configuration not recognized"/>
+    </If>
+
+    <LoadRegion Name="LR_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="ABSOLUTE" Size="%Code_Size%">
+
+        <!-- ========= INTERNAL FLASH ============================================ -->
+        <ExecRegion Name="ER_%TARGETLOCATION%" Base="%Code_BaseAddress%" Options="FIXED" Size="">
+            <FileMapping Name="AppEntry.obj" Options="(+RO, +FIRST)" />
+            <FileMapping Name="*" Options="(SectionForBootstrapOperations)" />
+            <FileMapping Name="*" Options="(+RO-CODE)" />
+            <FileMapping Name="*" Options="(+RO-DATA)" />
+
+            <!-- There is no special region section for DAT-->
+            <FileMapping Name="tinyclr_dat.obj" Options="(+RO, +LAST)" />
+        </ExecRegion>
+
+        <!-- ========= INTERNAL RAM ============================================= -->
+        <!-- Writeable Vector table -->
+        <!-- NOTE:
+             Despite what you might hope for, this CANNOT go into the CCM area as the NVIC does not
+             have access to that space (it sees the AHB layer and below, rather than the core's D-Bus)
+        -->
+        <!-- Alignment for the vector table is important to allow the NVIC to decode the proper locations
+            (See Section 4.4.4 of the ARM Cortex-M4 Generic User Guide [ ARM DUI 0553A (ID121610) ] )
+            Since this starts the SRAM block, it's aligned just fine for any size table.
+        -->
+        <!-- NOTE: Using uncompressed sections as this project uses the NETMF startup code that
+             doesn't know about compressed init regions. Eventually this should be unified so that
+             the normal embedded (Microlib/nanolib) runtime startup is used for all tool chains
+             instead of doing it in the NETMF code base.
+        -->
+        <ExecRegion Name="ER_VECTORS" Base="%IRAM_BaseAddress%" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(VectorTable +FIRST)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RW" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <FileMapping Name="*" Options="(+RW-DATA, +ZI)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_RAM_RO" Base="+0" Options="ABSOLUTE NOCOMPRESS" Size="">
+            <!-- Flash programming from Flash is safe on STM32 -->
+            <!-- No need to place Flash programming code in RAM -->
+            <!-- <FileMapping Name="*" Options="(SectionForFlashOperations)" /> -->
+        </ExecRegion>
+
+        <ExecRegion Name="ER_HEAP_BEGIN" Base="%Heap_BaseAddress%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for a heap -->
+
+        <ExecRegion Name="ER_HEAP_END" Base="+%Heap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForHeapEnd)" />
+        </ExecRegion>
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_BEGIN" Base="+0" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapBegin)" />
+        </ExecRegion>
+
+        <!-- everything between heapbegin and heapend will be allocated for the unmanaged SimpleHeap -->
+
+        <ExecRegion Name="ER_CUSTOM_HEAP_END" Base="+%CustomHeap_Size%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForCustomHeapEnd)" />
+        </ExecRegion>
+
+        <!-- ========= Internal CCM ============================================ -->
+        <ExecRegion Name="ER_STACK_BOTTOM" Base="%Stack_Bottom%" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackBottom)" />
+        </ExecRegion>
+        <ExecRegion Name="ER_STACK_TOP" Base="AlignExpr(+%CCM_Size% -8, 8 )" Options="ABSOLUTE UNINIT" Size="">
+            <FileMapping Name="*" Options="(SectionForStackTop +LAST)" />
+        </ExecRegion>
+    </LoadRegion>
+
+    <LoadRegion Name="LR_CONFIG" Base="%Config_BaseAddress%" Options="ABSOLUTE" Size="%Config_Size%">
+        <ExecRegion Name="ER_CONFIG" Base="%Config_BaseAddress%" Options="FIXED" Size="%Config_Size%">
+            <FileMapping Name="*" Options="(SectionForConfig)" />
+        </ExecRegion>
+    </LoadRegion>
+</ScatterFile>
+

--- a/setenv_base.cmd
+++ b/setenv_base.cmd
@@ -96,6 +96,7 @@ rem set tool-chain specific environment variables
 IF /I "%COMPILER_TOOL%"=="VS"       GOTO :SET_VS_VARS 
 IF /I "%COMPILER_TOOL%"=="GCC"      GOTO :SET_GCC_VARS 
 IF /I "%COMPILER_TOOL%"=="MDK"      GOTO :SET_MDK_VARS
+IF /I "%COMPILER_TOOL%"=="DS5"      GOTO :SET_DS5_VARS
 
 IF "%COMPILER_TOOL%"=="" GOTO :ERROR
 
@@ -186,7 +187,32 @@ GOTO :EOF
 @ECHO.
 
 GOTO :EOF
+rem @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+:SET_DS5_VARS
+@ECHO Setting DS5 env var and path for version %COMPILER_TOOL_VERSION%
 
+rem use a default for MDK
+set NO_ADS_WRAPPER=1
+set DOTNETMF_COMPILER=%COMPILER_TOOL_VERSION%
+
+IF "%ARG3%"=="" set ARG3=%SystemDrive%\Program Files\DS-5 v5.22.0\sw\ARMCompiler5.05u2
+IF NOT EXIST "%ARG3%" GOTO :BAD_DS5_ARG
+
+SET DS5_TOOL_PATH=%ARG3%
+SET PATH=%DS5_TOOL_PATH%\bin;%PATH%
+
+SET ARMCC50BIN=%DS5_TOOL_PATH%\BIN
+SET ARMCC50LIB=%DS5_TOOL_PATH%\LIB
+SET ARMCC50INC=%DS5_TOOL_PATH%\INCLUDE
+
+GOTO :EOF
+
+:BAD_DS5_ARG
+@ECHO.
+@ECHO Error - Invalid argument.  Could not find DS5 path %ARG3%.
+@ECHO.
+
+GOTO :EOF
 rem @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 :SET_VS_VARS
 set VSSDK12INSTALLDIR=%SPOROOT%\tools\x86\MicrosoftSDKs\VSSDK\vs12\

--- a/setenv_ds5.cmd
+++ b/setenv_ds5.cmd
@@ -1,0 +1,16 @@
+@echo off
+
+IF NOT ""=="%1" SET DS5_VER=%1
+IF ""=="%DS5_VER%" GOTO :ARG_ERROR
+
+%~dp0\setenv_base.cmd DS5 %DS5_VER% %2 %3 %4 %5
+
+GOTO :EOF
+
+:ARG_ERROR
+@echo.
+@echo ERROR: Invalid version argument.
+@echo USAGE: setenv_ds.cmd DS5_VERSION [DS5_TOOL_PATH]
+@echo        where DS5_VERSION is the version of the compiler contained in the MDK/RVDS/DS5 (e.g for MDK 5.14 ARMCC is 5.05)
+@echo        where DS5_TOOL_PATH is the path to the ARM directory of the DS install (i.e. c:\Keil_v5\Arm)
+@echo.

--- a/tools/Targets/Microsoft.SPOT.CSharp.Targets
+++ b/tools/Targets/Microsoft.SPOT.CSharp.Targets
@@ -26,7 +26,7 @@
     <DefineConstants Condition="'$(TargetFrameworkVersion)'=='v4.4'">$(DefineConstants),MF_FRAMEWORK_VERSION_V4_4</DefineConstants>
  </PropertyGroup>
 
-  <PropertyGroup Condition="Exists('$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Targets') And '$(TargetFrameworkVersion)'!='v4.4'">
+  <PropertyGroup Condition="Exists('$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Targets') And '$(TargetFrameworkVersion)'!='v4.4' And '$(FLAVOR)'=='Debug'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -35,7 +35,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition="Exists('$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Targets') And '$(TargetFrameworkVersion)'!='v4.4'">
+  <PropertyGroup Condition="Exists('$(SPOCLIENT)\tools\Targets\Microsoft.SPOT.CSharp.Targets') And '$(TargetFrameworkVersion)'!='v4.4' And '$(FLAVOR)'!='Debug'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>

--- a/tools/Targets/Microsoft.Spot.system.ds5.settings
+++ b/tools/Targets/Microsoft.Spot.system.ds5.settings
@@ -1,0 +1,32 @@
+<Project  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"  ToolsVersion="4.0">
+
+
+ <!-- base on cpu type, setup compiler-->
+  <PropertyGroup>
+    <SWTC>--</SWTC>
+  </PropertyGroup>
+
+
+  <!-- set up the base DST_DIR path base on different INSTRUCTION_SET -->  
+  <PropertyGroup>
+    <OBJ_EXT>obj</OBJ_EXT>
+    <LIB_EXT>lib</LIB_EXT>
+    <EXE_EXT>axf</EXE_EXT>
+    <SCATTER_EXT>xml</SCATTER_EXT>
+
+    <PLATFORM_INDEPENDENT_DST_DIR>$(SPO_BUILD)\$(INSTRUCTION_SET)\$(DOTNETMF_COMPILER)\$(ENDIANNESS)\ANY_MEDIA\$(OLD_FLAVOR)</PLATFORM_INDEPENDENT_DST_DIR>
+    <DST_DIR>$(SPO_BUILD)\$(INSTRUCTION_SET)\$(COMPILER_TOOL_VERSION)\$(ENDIANNESS)\$(TARGETLOCATION)\$(OLD_FLAVOR)\$(TARGETPLATFORM)</DST_DIR>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <IncludePaths Include="DeviceCode\Cores\arm"/>
+
+
+    <IncludePaths Include="DeviceCode\Cores\arm\Include"/>
+
+
+    <IncludePaths Include="DeviceCode"/>
+    <IncludePaths Include="DeviceCode\Include"/>
+  </ItemGroup>
+
+</Project>

--- a/tools/Targets/Microsoft.Spot.system.ds5.targets
+++ b/tools/Targets/Microsoft.Spot.system.ds5.targets
@@ -1,0 +1,374 @@
+<Project  xmlns="http://schemas.microsoft.com/developer/msbuild/2003"  ToolsVersion="4.0">
+ 
+  <PropertyGroup>
+    <BuildToolName>DS5</BuildToolName>
+    <BuildToolGuid>{F7823E3C-8BCE-4D9A-AD56-9E06063C47CD}</BuildToolGuid>
+    <Documentation></Documentation>
+    <ProcessorTypes>XScale;ARM7TDMI;ARM7TDMI-S;arm920t;arm926EJ-S;Cortex-M3;DARMAT;DARMATS9;Cortex-M4</ProcessorTypes>
+    <ISAs>arm;thumb;thumb2;thumb2fp</ISAs>
+  </PropertyGroup>
+
+ <PropertyGroup>
+    <TARGETCURRENT>$(SPO_BUILD)\$(INSTRUCTION_SET)\$(TARGETLOCATION)\$(OLD_FLAVOR)\$(TARGETPLATFORM)\bin</TARGETCURRENT>
+    <MdkCrtLibLinkSwitch>$(SWTC)libpath "$(DS5_TOOL_PATH)\LIB"</MdkCrtLibLinkSwitch>
+    
+    <!-- DS ARM Tools -->
+     <CC      Condition="'$(COMPILER_TOOL_VERSION)'=='DS55.05'">"$(DS5_TOOL_PATH)\bin\armcc.exe"</CC>
+     <CPP     Condition="'$(COMPILER_TOOL_VERSION)'=='DS55.05'">"$(DS5_TOOL_PATH)\bin\armcc.exe"</CPP>
+     <AS      Condition="'$(COMPILER_TOOL_VERSION)'=='DS55.05'">"$(DS5_TOOL_PATH)\bin\armasm.exe"</AS>
+     <LINK    Condition="'$(COMPILER_TOOL_VERSION)'=='DS55.05'">"$(DS5_TOOL_PATH)\bin\armlink.exe"</LINK>
+     <AR      Condition="'$(COMPILER_TOOL_VERSION)'=='DS55.05'">"$(DS5_TOOL_PATH)\bin\armar.exe"</AR>
+     <FROMELF Condition="'$(COMPILER_TOOL_VERSION)'=='DS55.05'">"$(DS5_TOOL_PATH)\bin\fromelf.exe"</FROMELF>
+     <MdkCrtLibLinkSwitch Condition="'$(COMPILER_TOOL_VERSION)'=='DS5.05'">$(MdkCrtLibLinkSwitch) $(SWTC)libpath "$(DS5_TOOL_PATH)\LIB"</MdkCrtLibLinkSwitch>
+
+ </PropertyGroup>
+  
+  <Import Project="Error: DEVICE_TYPE is not defined" Condition="'$(DEVICE_TYPE)'==''"/>
+  
+  <PropertyGroup>
+
+    <POS_DEPENDENT  ></POS_DEPENDENT>
+    <POS_INDEPENDENT></POS_INDEPENDENT>
+
+    <AS_CC_CPP_COMMON_FLAGS Condition = "'$(INSTRUCTION_SET)'=='arm'"                                    >$(AS_CC_CPP_COMMON_FLAGS) $(SWTC)arm</AS_CC_CPP_COMMON_FLAGS>
+    <AS_CC_CPP_COMMON_FLAGS Condition = "'$(INSTRUCTION_SET)'=='thumb' or '$(INSTRUCTION_SET)'=='thumb2'">$(AS_CC_CPP_COMMON_FLAGS) $(SWTC)thumb</AS_CC_CPP_COMMON_FLAGS>
+    <AS_CC_CPP_COMMON_FLAGS Condition = "'$(INSTRUCTION_SET)'=='thumb' or '$(INSTRUCTION_SET)'=='thumb2'">$(AS_CC_CPP_COMMON_FLAGS) $(SWTC)apcs=interwork </AS_CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) -DARM_V3_1</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) -DDS5_V5_05</CC_CPP_COMMON_FLAGS>
+    
+    <CC_CPP_COMMON_FLAGS Condition="'$(reducesize)'!='true'">$(CC_CPP_COMMON_FLAGS) $(SWTC)feedback $(SPO_SDK)\tools\make\Feedback\$(TARGETPLATFORM)_$(COMPILER_TOOL_VERSION).feedback</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(reducesize)'=='true'">$(CC_CPP_COMMON_FLAGS) $(SWTC)feedback $(SPO_SDK)\tools\make\Feedback\$(TARGETPLATFORM)_$(COMPILER_TOOL_VERSION)_loader.feedback</CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='RTM'"         >$(CC_CPP_TARGETTYPE_FLAGS) $(SWTC)no_debug $(SWTC)dwarf2 $(SWTC)no_debug_macros -O3 $(SWTC)inline -Otime $(SWTC)no_autoinline $(CC_CPP_ASM_INTERLEAVE) </CC_CPP_TARGETTYPE_FLAGS>
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Debug'"       >$(CC_CPP_TARGETTYPE_FLAGS) $(SWTC)debug    $(SWTC)dwarf2 $(SWTC)debug_macros    -O0 $(SWTC)inline                             $(CC_CPP_ASM_INTERLEAVE) </CC_CPP_TARGETTYPE_FLAGS>
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Instrumented'">$(CC_CPP_TARGETTYPE_FLAGS) $(SWTC)debug    $(SWTC)dwarf2 $(SWTC)debug_macros    -O0 $(SWTC)inline                             $(CC_CPP_ASM_INTERLEAVE) </CC_CPP_TARGETTYPE_FLAGS>
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Release'"     >$(CC_CPP_TARGETTYPE_FLAGS) $(SWTC)no_debug $(SWTC)dwarf2 $(SWTC)no_debug_macros -O2 $(SWTC)inline -Otime $(SWTC)no_autoinline $(CC_CPP_ASM_INTERLEAVE) </CC_CPP_TARGETTYPE_FLAGS>
+
+
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)diag_suppress A1658</AS_FLAGS>
+
+    <CC_FLAGS  >$(CC_FLAGS) $(SWTC)c90 $(STRICT) $(SWTC)diag_suppress 2874,111,161,550,C3011,C4052,1295,223 $(SWTC)diag_warning 40,187 $(SWTC)split_sections</CC_FLAGS>
+    <CPP_FLAGS >$(CPP_FLAGS) $(SWTC)cpp $(STRICT) $(SWTC)diag_suppress 2874,111,161,550,C3011,C4052 $(SWTC)diag_suppress 66,161,230,1293 $(SWTC)split_sections</CPP_FLAGS>
+    <LINK_FLAGS>$(LINK_FLAGS) $(SWTC)no_keep_init_arrays $(SWTC)feedback $(BIN_DIR)\$(AssemblyName)_$(TARGETPLATFORM)_$(TARGETLOCATION)_$(FLAVOR)_$(COMPILER_TOOL_VERSION).feedback</LINK_FLAGS>
+
+  </PropertyGroup>
+
+
+  <PropertyGroup>
+    <!--Common flags for Assembler/CC/CPP  -->
+
+    <!-- Find out whether DEVICE_TYPE is an old style ('device' option) name -->
+    <OLD_STYLE_DEVICE_TYPE_NAME Condition="'$(DEVICE_TYPE)'=='DARMAD' OR '$(DEVICE_TYPE)'=='DARMAT' OR '$(DEVICE_TYPE)'=='DARMATS' OR '$(DEVICE_TYPE)'=='DARMMAC7' OR '$(DEVICE_TYPE)'=='DARMO' OR '$(DEVICE_TYPE)'=='DARMP' OR '$(DEVICE_TYPE)'=='DARMS' OR '$(DEVICE_TYPE)'=='DARMSH' OR '$(DEVICE_TYPE)'=='DARMSSC' OR '$(DEVICE_TYPE)'=='DARMST' OR '$(DEVICE_TYPE)'=='DARMTMS' OR '$(DEVICE_TYPE)'=='DARMSSC9' OR '$(DEVICE_TYPE)'=='DARMATS9' OR '$(DEVICE_TYPE)'=='DARMO9' OR '$(DEVICE_TYPE)'=='DARMP3' OR '$(DEVICE_TYPE)'=='DARMP9' OR '$(DEVICE_TYPE)'=='DARMSS9' OR '$(DEVICE_TYPE)'=='DARMST9' OR '$(DEVICE_TYPE)'=='DARMCM1' OR '$(DEVICE_TYPE)'=='DARMCP3' OR '$(DEVICE_TYPE)'=='DLM' OR '$(DEVICE_TYPE)'=='DARMSTM' OR '$(DEVICE_TYPE)'=='DARMSAM3' OR '$(DEVICE_TYPE)'=='DARMP1' OR '$(DEVICE_TYPE)'=='DARMT3' OR '$(DEVICE_TYPE)'=='DARMP0' OR '$(DEVICE_TYPE)'=='DARMTMS5'">true</OLD_STYLE_DEVICE_TYPE_NAME>
+
+    <!-- Use 'cpu' or 'device' option depending on the given name -->
+    <ARM_TYPE_FLAGS Condition="'$(OLD_STYLE_DEVICE_TYPE_NAME)'!='true' AND '$(DEVICE_TYPE)'!=''">$(SWTC)cpu $(DEVICE_TYPE)</ARM_TYPE_FLAGS>
+    <ARM_TYPE_FLAGS Condition="'$(OLD_STYLE_DEVICE_TYPE_NAME)'=='true' AND '$(DEVICE_TYPE)'!=''">$(SWTC)device $(DEVICE_TYPE)</ARM_TYPE_FLAGS>
+
+    <!-- Use default fpu specification for Cortex-M4F -->
+    <FLOATING_POINT_FLAG Condition="'$(PLATFORM_EMULATED_FLOATINGPOINT)'!='true' AND '$(DEVICE_TYPE)'!='Cortex-M4.fp'"> $(SWTC)fpu softvfp </FLOATING_POINT_FLAG>
+    <FLOATING_POINT_FLAG Condition="'$(PLATFORM_EMULATED_FLOATINGPOINT)'!='true' AND '$(DEVICE_TYPE)'=='Cortex-M4.fp'"> $(SWTC)fpu vfpv3 </FLOATING_POINT_FLAG>
+    <FLOATING_POINT_FLAG Condition="'$(PLATFORM_EMULATED_FLOATINGPOINT)'=='true'"> $(SWTC)fpu none </FLOATING_POINT_FLAG>
+
+    <AS_CC_CPP_COMMON_FLAGS>$(AS_CC_CPP_COMMON_FLAGS) $(FLOATING_POINT_FLAG) $(ARM_TYPE_FLAGS)</AS_CC_CPP_COMMON_FLAGS>
+    <AS_CC_CPP_COMMON_FLAGS Condition="'$(ENDIANNESS)'=='le'">$(AS_CC_CPP_COMMON_FLAGS) $(SWTC)littleend</AS_CC_CPP_COMMON_FLAGS>
+    <AS_CC_CPP_COMMON_FLAGS Condition="'$(ENDIANNESS)'=='be'">$(AS_CC_CPP_COMMON_FLAGS) $(SWTC)bigend</AS_CC_CPP_COMMON_FLAGS>
+  </PropertyGroup>
+
+  <!-- Assembler flags -->
+  <PropertyGroup>
+    <AS_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='RTM'"         >$(AS_TARGETTYPE_FLAGS) $(SWTC)PD "BUILD_RTM SETS \"1\"" -g</AS_TARGETTYPE_FLAGS>
+    <AS_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Release'"     >$(AS_TARGETTYPE_FLAGS) $(SWTC)PD "BUILD_RTM SETS \"0\"" -g</AS_TARGETTYPE_FLAGS>
+    <AS_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Instrumented'">$(AS_TARGETTYPE_FLAGS) $(SWTC)PD "BUILD_RTM SETS \"0\"" -g</AS_TARGETTYPE_FLAGS>
+    <AS_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Debug'"       >$(AS_TARGETTYPE_FLAGS) $(SWTC)PD "BUILD_RTM SETS \"0\"" -g</AS_TARGETTYPE_FLAGS>
+
+    <!-- Adjust the compiler/assembler flags according to the settings -->
+    <AS_FLAGS Condition="'$(FLAVOR)'=='Instrumented'">$(AS_FLAGS) $(SWTC)PD "PROFILE_BUILD SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(sampleprof)'=='true'"    >$(AS_FLAGS) $(SWTC)PD "FIQ_SAMPLING_PROFILER SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(latencyprof)'=='true'"   >$(AS_FLAGS) $(SWTC)PD "FIQ_LATENCY_PROFILER SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(INSTRUCTION_SET)'=='arm'"        >$(AS_FLAGS) $(SWTC)PD "COMPILE_ARM SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(INSTRUCTION_SET)'=='thumb'"      >$(AS_FLAGS) $(SWTC)PD "COMPILE_THUMB SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(INSTRUCTION_SET)'=='thumb2'"     >$(AS_FLAGS) $(SWTC)PD "COMPILE_THUMB2 SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(INSTRUCTION_SET)'=='thumb2fp'"   >$(AS_FLAGS) $(SWTC)PD "COMPILE_THUMB2 SETS \"1\""</AS_FLAGS>
+
+    <!-- Assembler flags -->
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)PD "TargetLocation SETS \"$(TARGETLOCATION)\""</AS_FLAGS>
+    <!-- pedantic matching of letter case with old makefiles -->
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)PD "TargetType         SETS \"$(OLD_FLAVOR)\""</AS_FLAGS>
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)PD "TargetModel        SETS \"$(TARGETPLATFORM)\""</AS_FLAGS>
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)PD "TargetPlatformName SETS \"PLATFORM_ARM_$(TARGETPLATFORM)\""</AS_FLAGS>
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)PD "CompilerVersion    SETS \"$(COMPILER_TOOL_VERSION)\""</AS_FLAGS>
+    <AS_FLAGS>$(AS_FLAGS) $(SWTC)PD "TargetPlatformProcessor SETS \"PLATFORM_ARM_$(TARGETPROCESSOR)\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(reducesize)'=='true'">$(AS_FLAGS) $(SWTC)PD "HAL_REDUCESIZE SETS \"1\""</AS_FLAGS>
+    <AS_FLAGS Condition="'$(reducesize)'!='true'">$(AS_FLAGS) $(SWTC)PD "HAL_REDUCESIZE SETS \"0\""</AS_FLAGS>
+
+    <AS_FLAGS>$(AS_FLAGS) @(AS_Defines->'$(SWTC)PD %(filename) SETS \"1\"',' ')</AS_FLAGS>
+
+    <AS_FLAGS>$(AS_FLAGS) $(AS_CC_CPP_COMMON_FLAGS) $(AS_TARGETTYPE_FLAGS) $(AS_INCS) -g $(SWTC)keep</AS_FLAGS>
+
+    <AS_SUBDIR>RVD_S</AS_SUBDIR>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <!-- CPP/CC flags depands on the target build -->
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='RTM'"         >$(CC_CPP_TARGETTYPE_FLAGS) -DBUILD_RTM</CC_CPP_TARGETTYPE_FLAGS>
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Debug'"       >$(CC_CPP_TARGETTYPE_FLAGS) -DDEBUG -D_DEBUG</CC_CPP_TARGETTYPE_FLAGS>
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Instrumented'">$(CC_CPP_TARGETTYPE_FLAGS) -DDEBUG -D_DEBUG</CC_CPP_TARGETTYPE_FLAGS>
+    <CC_CPP_TARGETTYPE_FLAGS Condition="'$(FLAVOR)'=='Release'"     >$(CC_CPP_TARGETTYPE_FLAGS) -DNDEBUG</CC_CPP_TARGETTYPE_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS Condition="'$(TCP_IP_STACK)'=='LWIP'">$(CC_CPP_COMMON_FLAGS) -DTCPIP_LWIP</CC_CPP_COMMON_FLAGS>
+	  <CC_CPP_COMMON_FLAGS Condition="'$(TCP_IP_STACK)'=='LWIP_1_4_1_OS'">$(CC_CPP_COMMON_FLAGS) -DTCPIP_LWIP_OS</CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS Condition="'$(reducesize)'=='true'" >$(CC_CPP_COMMON_FLAGS) -DHAL_REDUCESIZE</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(timewarp)'=='true'"   >$(CC_CPP_COMMON_FLAGS) -DHAL_TIMEWARP</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(profile)'=='true'"    >$(CC_CPP_COMMON_FLAGS) -DARM_PROFILE_ACTIVE</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(FLAVOR)'!='RTM'"      >$(CC_CPP_COMMON_FLAGS) -DTINYCLR_ENABLE_SOURCELEVELDEBUGGING </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(FLAVOR)'=='Instrumented'">$(CC_CPP_COMMON_FLAGS) -DTINYCLR_PROFILE_NEW -DTINYCLR_PROFILE_NEW_CALLS -DTINYCLR_PROFILE_NEW_ALLOCATIONS -DTINYCLR_PROFILE_HANDLER -DPROFILE_BUILD</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(sampleprof)'=='true'" >$(CC_CPP_COMMON_FLAGS) -DFIQ_SAMPLING_PROFILER </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(latencyprof)'=='true'">$(CC_CPP_COMMON_FLAGS) -DFIQ_LATENCY_PROFILER </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(INSTRUCTION_SET)'=='arm'"     >$(CC_CPP_COMMON_FLAGS) -DCOMPILE_ARM </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(INSTRUCTION_SET)'=='thumb'"   >$(CC_CPP_COMMON_FLAGS) -DCOMPILE_THUMB </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(INSTRUCTION_SET)'=='thumb2'"  >$(CC_CPP_COMMON_FLAGS) -DCOMPILE_THUMB2 </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(INSTRUCTION_SET)'=='thumb2fp'">$(CC_CPP_COMMON_FLAGS) -DCOMPILE_THUMB2 </CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS Condition="'$(FLAVOR)'=='Instrumented' and '$(NATIVE_PROFILE_CLR)'!=''">$(CC_CPP_COMMON_FLAGS) -DNATIVE_PROFILE_CLR=$(NATIVE_PROFILE_CLR)</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(FLAVOR)'=='Instrumented' and '$(NATIVE_PROFILE_PAL)'!=''">$(CC_CPP_COMMON_FLAGS) -DNATIVE_PROFILE_PAL=$(NATIVE_PROFILE_PAL)</CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(FLAVOR)'=='Instrumented' and '$(NATIVE_PROFILE_HAL)'!=''">$(CC_CPP_COMMON_FLAGS) -DNATIVE_PROFILE_HAL=$(NATIVE_PROFILE_HAL)</CC_CPP_COMMON_FLAGS>
+
+    <!-- BUILD VERSIONS -->
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) -DVERSION_MAJOR=$(MajorVersion) -DVERSION_MINOR=$(MinorVersion) -DVERSION_BUILD=$(BuildNumber) -DVERSION_REVISION=$(RevisionNumber) -DOEMSYSTEMINFOSTRING="\"$(OemSystemInfoString)\""</CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) -DPLATFORM_ARM_$(TARGETPLATFORM) </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) -DTARGETLOCATION_$(TARGETLOCATION) </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(ENDIANNESS)'=='le'">$(CC_CPP_COMMON_FLAGS) -DLITTLE_ENDIAN </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(ENDIANNESS)'=='be'">$(CC_CPP_COMMON_FLAGS) -DBIG_ENDIAN </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(PATCH_BUILD)'=='Active'">$(CC_CPP_COMMON_FLAGS) -DPATCH_BUILD </CC_CPP_COMMON_FLAGS>
+    <CC_CPP_COMMON_FLAGS Condition="'$(OS_PLATFORM)'=='true'"  >$(CC_CPP_COMMON_FLAGS) -DPLATFORM_ARM_OS_PORT </CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) @(TinyCLR_Defines->'-D%(filename)',' ')</CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) @(CC_CPP_Defines->'-D%(filename)',' ')</CC_CPP_COMMON_FLAGS>
+
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(CLRROOT)\$(Directory)</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\DeviceCode\include</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\DeviceCode\Cores\arm</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\Support\Include  </CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\crypto\inc </CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Include</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\CorLib</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\SPOT</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\SPOT_Hardware</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\SPOT_Graphics</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\SPOT_Net</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I$(SPO_SDK)\CLR\Libraries\SPOT_Net_Security</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) @(IncludePaths->'-I$(CLRROOT)\%(relativedir)%(filename)',' ')</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) @(DirectIncludePaths->'-I%(FullPath)',' ')</CC_CPP_INCS>
+    <CC_CPP_INCS>$(CC_CPP_INCS) -I"$(DS5_TOOL_PATH)\INCLUDE"</CC_CPP_INCS>
+
+
+    <CC_CPP_COMMON_FLAGS>$(CC_CPP_COMMON_FLAGS) $(AS_CC_CPP_COMMON_FLAGS) $(CC_CPP_TARGETTYPE_FLAGS) $(CC_CPP_INCS) $(ExtraFlags)</CC_CPP_COMMON_FLAGS>
+  </PropertyGroup>
+
+  <!-- CC flags -->
+  <PropertyGroup>
+    <CC_FLAGS>$(CC_FLAGS) $(CC_CPP_COMMON_FLAGS) $(ExtraCCFlags)</CC_FLAGS>
+  </PropertyGroup>
+
+
+  <!-- CPP flags -->
+  <PropertyGroup>
+    <CPP_FLAGS>$(CPP_FLAGS) $(CC_CPP_COMMON_FLAGS) $(ExtraCPPFlags)</CPP_FLAGS>
+  </PropertyGroup>
+
+<!-- other flags -->
+  <PropertyGroup>
+    <ARFLAGS>$(ARFLAGS) $(SWTC)create -c -r</ARFLAGS>
+
+    <LINK_TARGETTYPE_FLAGS>$(LINK_TARGETTYPE_FLAGS) $(SWTC)debug</LINK_TARGETTYPE_FLAGS>
+    <LINK_FLAGS>$(LINK_FLAGS) $(LINK_TARGETTYPE_FLAGS) $(SWTC)remove $(SWTC)unmangled $(SWTC)info sizes,totals,veneers,unused,libraries $(SWTC)map  $(SWTC)xref $(SWTC)symbols $(SWTC)callgraph</LINK_FLAGS>
+
+    <LINK_FLAGS>$(LINK_FLAGS) $(SWTC)userlibpath $(LIB_DIR) $(SWTC)userlibpath "$(PLATFORM_INDEPENDENT_LIB_DIR)" $(MdkCrtLibLinkSwitch) $(ExtraLinkFlags)</LINK_FLAGS>
+
+    <LINK_FLAGS Condition="'$(OutputType)'=='Executable' and '$(LINK_ENTRY_SET)'!='true'">$(LINK_FLAGS) $(SWTC)entry EntryPoint $(ExtraLinkFlags)</LINK_FLAGS>
+
+    <SCATTER_FLAG Condition="'$(OutputType)'=='Executable'">$(SWTC)scatter</SCATTER_FLAG>
+
+    <EXEName>$(BIN_DIR)\$(AssemblyName)</EXEName>
+
+    <TargetRule Condition="'$(OutputType)'=='Library'"   >ArmBuildLib</TargetRule>
+    <TargetRule Condition="'$(OutputType)'=='Executable'">BuildAXF</TargetRule>
+
+  </PropertyGroup>
+
+
+<!-- item group  -->
+
+  <ItemGroup>
+    <MakeAXFInputs Include="$(MakeAXFInputs)"/>
+    <FastCompileFile Condition="'$(ENABLE_FASTCOMPILE)'=='true'" Include="@(FastCompileCFile)"/>
+    <FastCompileFile Condition="'$(ENABLE_FASTCOMPILE)'=='true'" Include="@(FastCompileCPPFile)"/>
+  </ItemGroup>
+
+
+  <ItemGroup Condition="'$(OutputType)'=='Executable'">
+    <EXEScatterFileDefinition Condition="'$(EXEScatterFileDefinition)'!=''" Include="$(EXEScatterFileDefinition)"/>
+
+    <EXEScatterFile Include="$(BIN_DIR)\$(AssemblyName)_scatterfile.txt"/>
+    <EXEIncludePaths Include="$(ARMINC)"/>
+  </ItemGroup>
+
+
+<!-- target group for compile,assembler,linker, librarian, loader -->
+
+
+  <Target Name="ArmCompileCPP" Condition="'@(CPPFiles)'!='' or '@(FastCompileCPPFile)'!=''" Inputs="@(FastCompileCPPFile);@(CPPFiles);@(HFiles)" Outputs="@(ObjFiles)">
+<!--
+    <ADSCompileCPP Tool="WrappedTool="$(CPP)" InputFiles="@(CPPFiles->'%(FullPath)')" OutputPath="$(OBJ_DIR)" Flags="$(CPP_FLAGS) $(POS_DEPENDENT)" IncludePaths="@(IncludeDirs)"/>
+-->
+   <Message Text="$(CPP) $(CPP_FLAGS) $(POS_DEPENDENT) -o $(OBJ_DIR)\%(CPPFiles.Filename).$(OBJ_EXT) -c %(CPPFiles.FullPath)"/>
+   <Exec Condition="Exists('%(FastCompileCPPFile.FullPath)') and '@(FastCompileCPPFile)'!='' and '$(ENABLE_FASTCOMPILE)'=='true'" Command="$(CPP) $(CPP_FLAGS) $(POS_DEPENDENT) -o $(OBJ_DIR)\%(FastCompileCPPFile.Filename).$(OBJ_EXT) -c %(FastCompileCPPFile.FullPath) "/>
+   <Exec Condition="Exists('%(CPPFiles.FullPath)') and '@(CPPFiles)'!=''and ('$(ENABLE_FASTCOMPILE)'!='true' or '@(FastCompileCPPFile)'=='')" Command="$(CPP) $(CPP_FLAGS) $(POS_DEPENDENT) -o $(OBJ_DIR)\%(CPPFiles.Filename).$(OBJ_EXT) -c %(CPPFiles.FullPath)  "/>
+  </Target>
+
+
+  <Target Name="ArmCompileC" Condition="'@(CFiles)'!='' or '@(FastCompileCFile)'==''" Inputs="@(FastCompileCFile);@(CFiles);@(HFiles)" Outputs="@(CFiles->'$(OBJ_DIR)\%(filename).$(OBJ_EXT)')">
+<!--
+    <ADSCompileCC Tool="WrappedTool="$(CC)" InputFiles="@(CFiles->'%(FullPath)')" OutputPath="$(OBJ_DIR)" Flags="$(CC_FLAGS) $(POS_DEPENDENT)" IncludePaths="@(IncludeDirs)"/>
+-->
+    <Message Text="$(CC) $(CC_FLAGS) $(POS_DEPENDENT) -o$(OBJ_DIR)\%(CFiles.Filename).$(OBJ_EXT) -c %(CFiles.FullPath)"/>
+    <Exec Condition="Exists('%(FastCompileCFile.FullPath)') and  '@(FastCompileCFile)'!='' and '$(ENABLE_FASTCOMPILE)'=='true'" Command="$(CC) $(CC_FLAGS) $(POS_DEPENDENT) -o$(OBJ_DIR)\%(FastCompileCFile.Filename).$(OBJ_EXT) -c %(FastCompileCFile.FullPath) "/>
+    <Exec Condition="Exists('%(CFiles.FullPath)') and  '@(CFiles)'!=''and ('$(ENABLE_FASTCOMPILE)'!='true' or '@(FastCompileCFile)'=='')" Command="$(CC) $(CC_FLAGS) $(POS_DEPENDENT) -o$(OBJ_DIR)\%(CFiles.Filename).$(OBJ_EXT) -c %(CFiles.FullPath) "/>
+  </Target>
+
+  <Target Name="ArmAssemble" Condition="'@(AssemblyFiles)'!=''" Inputs="@(AssemblyFiles);@(HFiles)" Outputs="@(AssemblyFiles->'$(OBJ_DIR)\%(FileName).$(OBJ_EXT)')">
+    <!-- has to delete the obj manually, as the armas won't delete the old one -->
+    <Delete Condition="Exists('$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)')" Files="$(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT)" ContinueOnError="true" />
+    <Exec Condition="Exists('%(AssemblyFiles.FullPath)')" Command="$(AS) $(AS_PLATFORM_FLAGS) $(AS_FLAGS) $(SWTC)LIST $(OBJ_DIR)\%(AssemblyFiles.Filename).txt $(SWTC)xref -o $(OBJ_DIR)\%(AssemblyFiles.Filename).$(OBJ_EXT) %(AssemblyFiles.FullPath)"/>
+  </Target>
+
+  <Target Name="DelBuildLib" Condition="'$(OutputType)'=='Library'" Inputs="@(FastCompileCPPFile);@(CPPFiles);@(FastCompileCFile);@(CFiles);@(AssemblyFiles);@(HFiles)" Outputs="@(TargetLib)">
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath)', ' '))" Files="@(TargetLib->'%(FullPath)', ' ')" ContinueOnError="true" />
+    <Delete Condition="EXISTS(@(TargetLib->'%(FullPath).manifest', ' '))" Files="@(TargetLib->'%(FullPath).manifest', ' ')" ContinueOnError="true" />
+  </Target>
+
+  <Target Name="ArmBuildLib" Condition="'$(OutputType)'=='Library'" DependsOnTargets="FindCompileFilesExistence;FindFastCompileFilesExistence;DelBuildLib;ArmCompileC;ArmCompileCPP;ArmAssemble;CreateLibManifest;$(ExtraTargets);" Inputs="@(ObjFiles);@(LIB_FIRSTENTRY_OBJ);@(OEM_TARGETS);@(OEM_TARGETS_OBJ);@(PlatformIndependentLibs->'$(PLATFORM_INDEPENDENT_LIB_DIR)\%(FileName)%(Extension)')" Outputs="@(TargetLib);@(TargetLib->'%(FullPath).manifest')">
+    <Exec WorkingDirectory="$(OBJ_DIR)" Condition="'@(FilesExist)'!='' " Command="$(AR) $(ARFLAGS) @(TargetLib) @(ObjFiles->'%(FileName)%(Extension)',' ') @(LIB_FIRSTENTRY_OBJ,' ') @(OEM_TARGETS,' ') @(OEM_TARGETS_OBJ,' ') @(DriverLibs->'$(LIB_DIR)\%(FileName)%(Extension)',' ') @(PlatformIndependentLibs->'$(PLATFORM_INDEPENDENT_LIB_DIR)\%(FileName)%(Extension)', ' ')"/>
+  </Target>
+
+  <Target Name="BuildAXF" Condition="'$(OutputType)'=='Executable'" DependsOnTargets="ArmCompileCPP;ArmCompileC;ArmAssemble;$(ExtraEXETargets);BuildScatterfile;" Inputs="@(EXEInputs);@(InputLibs);@(PlatformIndependentLibs->'$(PLATFORM_INDEPENDENT_LIB_DIR)\%(FileName)%(Extension)');@(DriverLibs->'$(LIB_DIR)\%(FileName)%(Extension)');@(EXEScatterFile)" Outputs="@(EXEOutput)">
+    <!-- Uncomment to print build inputs to the console
+       <Message Text="~~~~BuildAXF Inputs: @(EXEInputs,' ') @(InputLibs,' ') @(DriverLibs,' ') @(EXEScatterFile,' ') @(PlatformIndependentLibs->'$(PLATFORM_INDEPENDENT_LIB_DIR)\%(FileName)%(Extension)',' ') @(DriverLibs->'$(LIB_DIR)\%(FileName)%(Extension)',' ')" />
+    -->
+
+    <!-- TOO MANY INPUTS FOR LINKER/COMMAND WINDOW, SO BREAK THE LINKER STAGE UP BY ARCHIVING ALL DRIVER FILES INTO ONE LIB THEN LINKING CLR LIBS AND COMBINED DRIVER LIB -->
+    <Exec WorkingDirectory="$(PLATFORM_INDEPENDENT_LIB_DIR)" Command="$(AR) $(ARFLAGS) $(LIB_DIR)\tmp_$(AssemblyName).$(LIB_EXT) @(PlatformIndependentLibs->'%(FileName)%(Extension)',' ')"/>
+    <Exec Command="$(LINK) $(LINK_FLAGS) $(SWTC)symdefs $(EXEName).symdefs $(SWTC)list $(EXEName).map $(SWTC)output @(EXEOutput) $(SCATTER_FLAG) @(EXEScatterFile,' ') @(EXEInputs,' ') @(InputLibs,' ') @(DriverLibs, ' ') $(LIB_DIR)\tmp_$(AssemblyName).$(LIB_EXT)" />
+    <Exec Command="del /q $(LIB_DIR)\tmp_$(AssemblyName).$(LIB_EXT)"/>
+    <Exec Command="$(FROMELF) $(FROMELF_FLAGS) $(SWTC)text -c -o $(EXEName).axfdump @(EXEOutput)" />
+    <Exec Command="$(FROMELF) $(FROMELF_FLAGS) $(SWTC)bin  -o $(EXEName).bin     @(EXEOutput)" />
+    <Exec Command="$(FROMELF) $(FROMELF_FLAGS) $(SWTC)m32  -o $(EXEName).hex     @(EXEOutput)" />
+    <!-- generating intel hex fromat -->
+    <Exec  Condition="$(IntelHexFormat)=='true'" Command="$(FROMELF) $(FROMELF_FLAGS) $(SWTC)i32  -o $(EXEName).ihex     @(EXEOutput)" />
+
+    <!--     echo adding LOAD_IMAGE_CRC value to $*.symdefs -->
+    <Exec Condition="'$(ADD_LOAD_IMAGE_CRC)'=='true'" Command="$(TOOLS_DIR)\BuildHelper -hashBuild $(EXEName).bin$(ImageLocation) $(EXEName).symdefs" />
+
+    <Exec Condition="'$(AssemblyName)'=='TinyCLR'"    Command="copy /Y &quot;$(BIN_DIR)\$(AssemblyName)_$(TARGETPLATFORM)_$(TARGETLOCATION)_$(FLAVOR)_$(COMPILER_TOOL_VERSION).feedback&quot; &quot;$(SPO_SDK)\tools\make\Feedback\$(TARGETPLATFORM)_$(COMPILER_TOOL_VERSION).feedback&quot;" ContinueOnError="true"/>
+    <Exec Condition="'$(AssemblyName)'=='TinyBooter'" Command="copy /Y &quot;$(BIN_DIR)\$(AssemblyName)_$(TARGETPLATFORM)_$(TARGETLOCATION)_$(FLAVOR)_$(COMPILER_TOOL_VERSION).feedback&quot; &quot;$(SPO_SDK)\tools\make\Feedback\$(TARGETPLATFORM)_$(COMPILER_TOOL_VERSION)_loader.feedback&quot;" ContinueOnError="true"/>
+  </Target>
+
+  <Target Name="FindBinFilesForSig">
+    <!-- create signature files-->
+    <CreateItem
+            Include="$(EXEName).bin\*"
+            AdditionalMetadata="OutputDir=$(EXEName).hex\" >
+           <Output
+               TaskParameter="Include"
+               ItemName="SigFilesInHexDir"/>
+    </CreateItem>
+
+    <CreateItem
+            Include="$(EXEName).bin"
+            Condition="'@(SigFilesInHexDir)'==''"
+            AdditionalMetadata="OutputDir=$(BIN_DIR)\" >
+           <Output
+               TaskParameter="Include"
+               ItemName="SigFiles"/>
+    </CreateItem>
+
+    <CreateItem
+            Include="@(SigFilesInHexDir);@(SigFiles)">
+           <Output
+               TaskParameter="Include"
+               ItemName="AllSigFiles"/>
+    </CreateItem>
+
+    <Exec Command="del /q $(EXEName).sig"       Condition="Exists('$(EXEName).sig')" ContinueOnError="true"/>
+    <Exec Command="del /q $(EXEName).hex\*.sig" Condition="'@(SigFilesInHexDir)'!=''"   ContinueOnError="true"/>
+
+    <Message Text="file selected @(SigFilesInHexDir)"/>
+    <Message Text="file selected @(SigFiles)"/>
+    <Message Text="file selected @(AllSigFiles)"/>
+
+
+  </Target>
+
+  <Target Name="CompressBin" Inputs="@(CompressBinAsm);@(CompressBinFile);@(CompressBinFile->'%(RootDir)%(Directory)%(FileName).symdefs')" Outputs="@(CompressBinOutput);@(CompressBinComp)" >
+    <Message Text="Compressing @(CompressBinFile)"/>
+    <Exec Command="$(TOOLS_DIR)\buildhelper -symdef @(CompressBinFile->'%(RootDir)%(Directory)%(FileName).symdefs') EntryPoint -compress @(CompressBinFile) @(CompressBinComp)"/>
+    <Exec Command="$(AS) $(AS_FLAGS) -I$(OBJ_DIR) $(POS_DEPENDENT) $(SWTC)list @(CompressBinOutput->'%(RootDir)%(Directory)%(FileName).txt') $(SWTC)xref -o @(CompressBinOutput) @(CompressBinAsm)"/>
+    <Exec Command="del /q @(CompressBinFile->'%(RootDir)%(Directory)%(FileName).hex')" ContinueOnError="true"/>
+  </Target>
+
+  <Target Name="BuildSigFiles"
+            Inputs="@(AllSigFiles)"
+            Outputs="@(AllSigFiles->'%(OutputDir)%(FileName).sig')"
+            DependsOnTargets="FindBinFilesForSig"
+            Condition="EXISTS('$(SPO_SDK)\crypto\lib\x86\dll\crypto.dll')" >
+
+    <Message Text="Create Signature files for @(AllSigFiles)"/>
+    <Exec Command="$(PRG_MMP) -sign_file %(RelativeDir)%(AllSigFiles.Filename)%(Extension) $(SPO_SDK)\tools\bin\tinybooter_private_key.bin %(AllSigFiles.Outputdir)%(AllSigFiles.Filename).sig"/>
+  </Target>
+
+  <ItemGroup>
+    <BuildScatterFileProperties Include="SPOCLIENT=$(SPOCLIENT)" />
+    <BuildScatterFileProperties Include="PROFILE_BUILD=$(TRUE)" Condition="'$(sampleprof)'=='true'" />
+    <BuildScatterFileProperties Include="PLATFORM=$(PLATFORM)" />
+    <BuildScatterFileProperties Include="TARGETCODEBASE=$(TARGETCODEBASE)" />
+    <BuildScatterFileProperties Include="TARGETCODEBASETYPE=$(TARGETCODEBASETYPE)" />
+    <BuildScatterFileProperties Include="TARGETPLATFORM=$(TARGETPLATFORM)" />
+    <BuildScatterFileProperties Include="TARGETLOCATION=$(TARGETLOCATION)" />
+    <BuildScatterFileProperties Include="TARGETTYPE=$(FLAVOR)" />
+    <BuildScatterFileProperties Include="TARGETPROCESSOR=$(TARGETPROCESSOR)" />
+    <BuildScatterFileProperties Include="ALTERNATEFLASHLOCATION=$(ALTERNATEFLASHLOCATION)" />
+    <BuildScatterFileProperties Include="COMPILER_TOOL_VERSION=$(COMPILER_TOOL_VERSION)" />
+    <BuildScatterFileProperties Include="COMPILER_TOOL=$(COMPILER_TOOL)" />
+    <BuildScatterFileProperties Include="PROFILE_BUILD=$TRUE" Condition="'$(FLAVOR)'=='Instrumented'" />
+  </ItemGroup>
+
+  <Target Name="BuildScatterfile" Condition="'$(DEPEND)'!='ACTIVE'" Inputs="@(EXEScatterFileDefinition);@(ScatterFileReferences)" Outputs="@(EXEScatterFile)">
+    <Message Text="..."/>
+    <ProcessScatterFile
+        Properties="@(BuildScatterFileProperties)"
+        DefinitionFile="@(EXEScatterfileDefinition)"
+        OutputFile="@(EXEScatterFile)"
+        />
+  </Target>
+
+  <Target Name="TinyClrDat" Inputs="$(BIN_DIR)\$(AssemblyName).dat;$(AS_SUBDIR)\$(AssemblyName)_dat.s" Outputs="$(OBJ_DIR)\$(AssemblyName)_dat.$(OBJ_EXT)">
+    <Message                               Text="***************************************************************************************************"/>
+    <Message Text="Target: TinyClrDat with outputs $(OBJ_DIR)\$(AssemblyName)_dat.$(OBJ_EXT)"/>
+    <Message Condition="'$(FORCEDAT)'!=''" Text="Building $(AssemblyName).dat from $(BUILD_TREE_CLIENT)\dat\$(ENDIANNESS)\$(AssemblyName)_$(FORCEDAT).dat"/>
+    <Message Condition="'$(FORCEDAT)'==''" Text="Building $(AssemblyName).dat from the features specified in the $(AssemblyName).proj file"/>
+    <Exec Condition="'$(FORCEDAT)'!='' AND EXISTS('$(BUILD_TREE_CLIENT)\dat\$(ENDIANNESS)\$(AssemblyName)_$(FORCEDAT).dat')" Command="copy /y &quot;$(BUILD_TREE_CLIENT)\dat\$(ENDIANNESS)\$(AssemblyName)_$(FORCEDAT).dat&quot; &quot;$(BIN_DIR)\$(AssemblyName).dat&quot;" />
+    <Exec Command="$(ADS_WRAPPER) $(AS) -I$(BIN_DIR) $(AS_FLAGS) $(POS_DEPENDENT) $(SWTC)LIST $(OBJ_DIR)\$(AssemblyName)_dat.txt $(SWTC)xref -o $(OBJ_DIR)\$(AssemblyName)_dat.$(OBJ_EXT) $(AS_SUBDIR)\$(AssemblyName)_dat.s"/>
+    <Message                               Text="========== Database file content:"/>    
+    <Exec Command="$(PRG_MMP) -dump_dat $(BIN_DIR)\$(AssemblyName).dat" />
+    <Message                               Text="========== End of Database file content"/>    
+    <Message                               Text="***************************************************************************************************"/>
+    <Exec Command="copy /BVY &quot;$(BIN_DIR)\$(AssemblyName).dat&quot; &quot;$(BIN_DIR)\$(AssemblyName).dat.fromlastbuildrun&quot;" />
+    <Exec Command="del  /Q /F $(BIN_DIR)\$(AssemblyName).dat"/>
+  </Target>
+
+</Project>
+

--- a/tools/scripts/init.cmd
+++ b/tools/scripts/init.cmd
@@ -1,5 +1,5 @@
 @rem
-@rem Set some basic vars based on the path of this script
+@rem Set some basic vars based on the path of this script 
 @rem
 set TEMPTOOLPATH=%~dp0
 @rem Sometimes cmd leaves the trailing backslash on - remove it.


### PR DESCRIPTION
Adds support to use ARM DS5 tool chain. Mostly a simple rework of the existing MDK support. (e.g. scatter files are the same)

This PR is a reworked version of #273 that isolates the changes to DS5 tooling only and relative to the current dev branch. 

The SDK and solutions build without error. Not testing on physical hardware as I don't have either evaluation kit. I could purchase the DISCOVERY board if that is required. I am using the ARM tools (RVDS 4.1 currently) to build a pre MF 4.3 version of .Net MF and that runs fine. Hope to move to MF4.3+ once current product is shipping. 
