### PR TITLE
Adding script to get binary tools dependency

### DIFF
--- a/CMSIS/Get-CMSIS.ps1
+++ b/CMSIS/Get-CMSIS.ps1
@@ -8,44 +8,9 @@ Retrieves and extracts the CMSIS pack supported by NETMF from the official GitHu
 Get-CMSIS
 #>
 
-# Function to extract the files contained in a zip file provided as a stream
-Function Extract-PackStream
-{
-    [CmdletBinding()]
-    Param ( [parameter(ValueFromPipeline=$True,Mandatory=$True,ValueFromPipelineByPropertyName=$True)] [System.IO.Stream]$RawContentStream )
-    Begin
-    {
-        [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression") | Out-Null
-        [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
-        $rootPath = Get-Location
-    } 
-    Process
-    {
-        $pack = New-Object -TypeName System.IO.Compression.ZipArchive -ArgumentList $RawContentStream
-        $i = 1
-        Foreach( $entry in $pack.Entries )
-        {
-            $targetPath = [System.IO.Path]::Combine( $rootPath, $entry.FullName )
-            $targetDir = [System.IO.Path]::GetDirectoryName( $targetPath )
-            if( $entry.FullName.EndsWith('/') )
-            {
-                if( -not [System.IO.Directory]::Exists( $targetDir ) )
-                {
-                    [System.IO.Directory]::CreateDirectory( $targetDir )
-                }
-            }
-            else
-            {
-                Write-Progress -Activity "Extracting" -Status $entry.FullName -PercentComplete ( $i / $pack.Entries.Count * 100 )
-                [System.IO.Compression.ZipFileExtensions]::ExtractToFile( $entry, $targetPath, $true )
-            }
-            $i = $i + 1
-        }
-        Write-Host "Done Extracting $i files"
-    }
-}
+Import-Module ..\tools\scripts\Build-netmf.psm1
 
-# officially supported version
+# current officially supported version
 $packVersion = "4.3.0"
 
 # FUll versioned pack file name to download
@@ -55,4 +20,4 @@ $packFileName = "ARM.CMSIS.$packVersion.pack"
 $packSourceURLBase = "https://github.com/ARM-software/CMSIS/releases/download/v$packVersion"
 
 # download the pack and extract the files into the curent directory 
-Invoke-WebRequest -Uri "$packSourceURLBase/$packFileName" | Extract-PackStream
+Invoke-WebRequest -Uri "$packSourceURLBase/$packFileName" | Expand-Stream

--- a/Install-BinTools.ps1
+++ b/Install-BinTools.ps1
@@ -1,0 +1,2 @@
+﻿Import-Module .\tools\scripts\Build-netmf.psm1
+Invoke-WebRequest -Uri "http://netmf.github.io/downloads/build-tools.zip" | Expand-Stream -Destination $SPOROOT

--- a/Install-CMSIS.ps1
+++ b/Install-CMSIS.ps1
@@ -8,7 +8,7 @@ Retrieves and extracts the CMSIS pack supported by NETMF from the official GitHu
 Get-CMSIS
 #>
 
-Import-Module ..\tools\scripts\Build-netmf.psm1
+Import-Module .\tools\scripts\Build-netmf.psm1
 
 # current officially supported version
 $packVersion = "4.3.0"
@@ -20,4 +20,5 @@ $packFileName = "ARM.CMSIS.$packVersion.pack"
 $packSourceURLBase = "https://github.com/ARM-software/CMSIS/releases/download/v$packVersion"
 
 # download the pack and extract the files into the curent directory 
-Invoke-WebRequest -Uri "$packSourceURLBase/$packFileName" | Expand-Stream
+$dstPath = [System.IO.Path]::Combine( $SPOCLIENT, "CMSIS" )
+Invoke-WebRequest -Uri "$packSourceURLBase/$packFileName" | Expand-Stream -Destination $dstPath

--- a/tools/scripts/Build-netmf.psm1
+++ b/tools/scripts/Build-netmf.psm1
@@ -7,7 +7,7 @@ Function to extract the files contained in a zip file provided as a stream typic
 
 Invoke-WebRequest -Uri "$packSourceURLBase/$packFileName" | Expand-Stream
 #>
-# 
+
 Function Expand-Stream
 {
     [CmdletBinding()]
@@ -24,7 +24,13 @@ Function Expand-Stream
         }
         else
         {
-            $rootPath = $Destination
+            $rootPath = [System.IO.Path]::GetFullPath( $Destination )
+        }
+        
+        #ensure the root directory for extraction exists
+        if( -not [System.IO.Directory]::Exists( $rootPath ) )
+        {
+            [System.IO.Directory]::CreateDirectory( $rootPath )
         }
     } 
     Process
@@ -37,6 +43,7 @@ Function Expand-Stream
             $targetDir = [System.IO.Path]::GetDirectoryName( $targetPath )
             if( $entry.FullName.EndsWith('/') )
             {
+                # ensure the destination directory exists
                 if( -not [System.IO.Directory]::Exists( $targetDir ) )
                 {
                     [System.IO.Directory]::CreateDirectory( $targetDir )
@@ -53,4 +60,8 @@ Function Expand-Stream
     }
 }
 
-export-modulemember -function Expand-Stream
+$SPOCLIENT = [System.IO.Path]::GetFullPath( [System.IO.Path]::Combine( $PSScriptRoot, "..","..") )
+$SPOROOT = [System.IO.Path]::GetFullPath( [System.IO.Path]::Combine( $SPOCLIENT, "..") )
+
+Export-ModuleMember -function Expand-Stream
+Export-ModuleMember -Variable ("SPOCLIENT","SPOROOT")

--- a/tools/scripts/Build-netmf.psm1
+++ b/tools/scripts/Build-netmf.psm1
@@ -1,0 +1,56 @@
+﻿<#
+.SYNOPSIS
+
+Function to extract the files contained in a zip file provided as a stream typically from an Invoke-WebRequest
+
+.EXAMPLE
+
+Invoke-WebRequest -Uri "$packSourceURLBase/$packFileName" | Expand-Stream
+#>
+# 
+Function Expand-Stream
+{
+    [CmdletBinding()]
+    Param ( [parameter(ValueFromPipeline=$True,Mandatory=$True,ValueFromPipelineByPropertyName=$True)] [System.IO.Stream]$RawContentStream
+          , [parameter(Mandatory=$False)] [String]$Destination
+          )
+    Begin
+    {
+        [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression") | Out-Null
+        [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
+        if( [String]::IsNullOrWhiteSpace( $Destination ) )
+        {
+            $rootPath = Get-Location
+        }
+        else
+        {
+            $rootPath = $Destination
+        }
+    } 
+    Process
+    {
+        $pack = New-Object -TypeName System.IO.Compression.ZipArchive -ArgumentList $RawContentStream
+        $i = 1
+        Foreach( $entry in $pack.Entries )
+        {
+            $targetPath = [System.IO.Path]::Combine( $rootPath, $entry.FullName )
+            $targetDir = [System.IO.Path]::GetDirectoryName( $targetPath )
+            if( $entry.FullName.EndsWith('/') )
+            {
+                if( -not [System.IO.Directory]::Exists( $targetDir ) )
+                {
+                    [System.IO.Directory]::CreateDirectory( $targetDir )
+                }
+            }
+            else
+            {
+                Write-Progress -Activity "Extracting" -Status $entry.FullName -PercentComplete ( $i / $pack.Entries.Count * 100 )
+                [System.IO.Compression.ZipFileExtensions]::ExtractToFile( $entry, $targetPath, $true )
+            }
+            $i = $i + 1
+        }
+        Write-Host "Done Extracting $i files"
+    }
+}
+
+export-modulemember -function Expand-Stream


### PR DESCRIPTION
This PR creates a new PowerShell module for NETMF that contains the function to Expand the contents of a zip archive as a stream (formerly in the Get-CMSIS.ps1 script) to allow re-use in other scripts. Additionally it adds the Install-BinTools.ps1 script to install the [bin tools](http://netmf.github.io/downloads/build-tools.zip) pre-requisite files to help simplify getting started and to help automated build systems to get the dependencies when doing completely clean builds
