### PR TITLE
fixed build_solution.cmd

### DIFF
--- a/build_solution.cmd
+++ b/build_solution.cmd
@@ -1,6 +1,6 @@
 @echo off
 setlocal
-setenv_%1 %2
+call setenv_%1 %2
 cd Solutions\%3
 msbuild /flp:verbosity=detailed /clp:verbosity=minimal
 endlocal


### PR DESCRIPTION
fixed build_solution.cmd so it uses call to call set_env and, therefore continues to the next statement to build the solution
