### PR TITLE
Correct code with wrong call to USB_OpenStream

### DIFF
--- a/DeviceCode/pal/COM/ComDirector.cpp
+++ b/DeviceCode/pal/COM/ComDirector.cpp
@@ -16,10 +16,17 @@ BOOL DebuggerPort_Initialize( COM_HANDLE ComPortNum )
             if(USB_CONFIG_ERR_OK != USB_Configure( ConvertCOM_UsbController(ComPortNum), NULL ))
                 return FALSE;
 
-            if(!USB_Initialize( ConvertCOM_UsbController(ComPortNum) ))
-                return FALSE;
-
-            return USB_OpenStream( ConvertCOM_UsbStream(ComPortNum), USB_DEBUG_EP_WRITE, USB_DEBUG_EP_READ );
+            if(USB_Initialize(ConvertCOM_UsbController(ComPortNum)))
+            {
+#if defined(USB_ALLOW_CONFIGURATION_OVERRIDE)
+                // because the call is from a debugger port USB_Initialize has already opened the USB stream  
+                return TRUE;
+#else
+                return USB_OpenStream( ConvertCOM_UsbStream(HalSystemConfig.DebuggerPorts[0]), USB_DEBUG_EP_WRITE, USB_DEBUG_EP_READ );    
+#endif
+                
+            }
+            break;
         
         case SOCKET_TRANSPORT:
             return SOCKETS_Initialize(ConvertCOM_SockPort(ComPortNum));


### PR DESCRIPTION
If USB_ALLOW_CONFIGURATION_OVERRIDE is defined and the call to USB_Initialize has a debugger port in the argument, USB_OpenStream is already called there (@ line 265). After a successful return from Initialize the call to USB_OpenStream will fail because the stream is already opened.

Note: I've stumbled onto this when debugging the CMSIS USB driver I'm working on. The result is that the USB device is enumerated and shows in the device manager but it's not picked up by MFDeploy or VS because after the initial enumeration the USB module is too busy being initialized again and again. This may explain the behaviour reported in issue #376.
The root cause is that the call sequence (...) DebuggerPort_Initialize -> USB_Initialize is repeated over and over from CLR_HW_Hardware::ProcessActivity() because the debugger port never has the chance to initialize. This is not 100% repetible. It seems to occur only if the USB init falis for some reason when sending the initial debug ping message, which call the above sequence. After that the  ProcessActivity() starts calling that sequence again and most likely a race condition occurs with the USB stream.
