### PR TITLE
fixed reconnect to device error

### DIFF
--- a/Framework/CorDebug/CorDebugProcess.cs
+++ b/Framework/CorDebug/CorDebugProcess.cs
@@ -435,7 +435,9 @@ namespace Microsoft.SPOT.Debugger
                     if((retry % 10) == 9) 
                         DetachFromEngine();
 
-                    Thread.Yield();
+// Replaced following line. Need to kill some time for slow devices rebooting.
+//                    Thread.Yield();
+                    Thread.Sleep(10);
                 }
                 catch
                 {
@@ -443,7 +445,9 @@ namespace Microsoft.SPOT.Debugger
 
                     if(!ShuttingDown)
                     {
-                        Thread.Yield();
+// Replaced following line. Need to kill some time for slow devices rebooting.
+//                        Thread.Yield();
+                        Thread.Sleep(10);
                     }
                 }
             }


### PR DESCRIPTION
When restarting the device Thread.Yield
was being used. This caused the attempts to
connect to complete too quickly. A simple
Thread.Sleep(10) fixes the problem.
