### PR TITLE
Change OneWire API to use a logical port number 

### DIFF
--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native.h
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native.h
@@ -9,7 +9,7 @@
 struct Library_spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire
 {
     static const int FIELD___pin = 1;
-
+    static const int FIELD___logicalPort = 2;
     TINYCLR_NATIVE_DECLARE(TouchReset___I4);
     TINYCLR_NATIVE_DECLARE(TouchBit___I4__I4);
     TINYCLR_NATIVE_DECLARE(TouchByte___I4__I4);

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire.cpp
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire.cpp
@@ -11,80 +11,81 @@ using namespace Microsoft::SPOT::Hardware;
 INT32 OneWire::TouchReset( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owTouchReset(pin);
+ 	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owTouchReset(pin);
   return retVal;
 }
 
 INT32 OneWire::TouchBit( CLR_RT_HeapBlock* pMngObj, INT32 param0, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owTouchBit(pin, param0);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owTouchBit(pin, param0);
   return retVal;
 }
 
 INT32 OneWire::TouchByte( CLR_RT_HeapBlock* pMngObj, INT32 param0, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owTouchByte(pin, param0);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owTouchByte(pin, param0);
   return retVal;
 }
 
 INT32 OneWire::WriteByte( CLR_RT_HeapBlock* pMngObj, INT32 param0, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owWriteByte(pin, param0);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owWriteByte(pin, param0);
   return retVal;
 }
 
 INT32 OneWire::ReadByte( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owReadByte(pin);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owReadByte(pin);
   return retVal;
 }
 
 INT32 OneWire::AcquireEx( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-  retVal = owAcquire(pin, "\\\\OneWire\\");
+	UINT32 pin = Get__pin(pMngObj); 
+	UINT32 logicalPort = Get__logicalPort(pMngObj);
+  retVal = owAcquire(logicalPort, pin);
   return retVal;
 }
 
 INT32 OneWire::Release( CLR_RT_HeapBlock* pMngObj, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    owRelease(pin);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	owRelease(pin);
   return retVal;
 }
 
 INT32 OneWire::First( CLR_RT_HeapBlock* pMngObj, INT8 param0, INT8 param1, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owFirst(pin, param0, param1);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owFirst(pin, param0, param1);
   return retVal;
 }
 
 INT32 OneWire::Next( CLR_RT_HeapBlock* pMngObj, INT8 param0, INT8 param1, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    retVal = owNext(pin, param0, param1);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	retVal = owNext(pin, param0, param1);
   return retVal;
 }
 
 INT32 OneWire::SerialNum( CLR_RT_HeapBlock* pMngObj, CLR_RT_TypedArray_UINT8 param0, INT8 param1, HRESULT &hr )
 {
   INT32 retVal = 0; 
-    UINT32 pin = Get__pin(pMngObj); 
-    owSerialNum(pin, param0.GetBuffer(), param1);
+	UINT32 pin = Get__logicalPort(pMngObj); 
+	owSerialNum(pin, param0.GetBuffer(), param1);
   return retVal;
 }
 

--- a/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire.h
+++ b/CLR/Libraries/SPOT_Hardware/SPOT_OneWire/spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire.h
@@ -14,7 +14,8 @@ namespace Microsoft
              struct OneWire
              {
                  // Helper Functions to access fields of managed object
-                     static UINT32& Get__pin( CLR_RT_HeapBlock* pMngObj )    { return Interop_Marshal_GetField_UINT32( pMngObj, Library_spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire::FIELD___pin ); }
+                 static UINT32& Get__pin( CLR_RT_HeapBlock* pMngObj )    { return Interop_Marshal_GetField_UINT32( pMngObj, Library_spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire::FIELD___pin ); }
+                 static UINT32& Get__logicalPort( CLR_RT_HeapBlock* pMngObj )    { return Interop_Marshal_GetField_UINT32( pMngObj, Library_spot_hardware_onewire_native_Microsoft_SPOT_Hardware_OneWire::FIELD___logicalPort ); }
      
                  // Declaration of stubs. These functions are implemented by Interop code developers
                  static INT32 TouchReset( CLR_RT_HeapBlock* pMngObj, HRESULT &hr );

--- a/DeviceCode/pal/OneWire/DallasSemi/crcutil.cpp
+++ b/DeviceCode/pal/OneWire/DallasSemi/crcutil.cpp
@@ -59,7 +59,7 @@ static uchar dscrc_table[] = {
 //
 void setcrc16(int portnum, ushort reset)
 {
-   utilcrc16[portnum&0x0FF] = reset;
+	if((portnum < MAX_PORTNUM) && (portnum >= 0) ) utilcrc16[portnum&0x0FF] = reset;
    return;
 }
 
@@ -72,7 +72,7 @@ void setcrc16(int portnum, ushort reset)
 //
 void setcrc8(int portnum, uchar reset)
 {
-   utilcrc8[portnum&0x0FF] = reset;
+   if((portnum < MAX_PORTNUM) && (portnum >= 0) ) utilcrc8[portnum&0x0FF] = reset;
    return;
 }
 
@@ -88,6 +88,8 @@ void setcrc8(int portnum, uchar reset)
 //
 ushort docrc16(int portnum, ushort cdata)
 {
+   if((portnum >= MAX_PORTNUM) || (portnum < 0)) return 0;
+  
    cdata = (cdata ^ (utilcrc16[portnum&0x0FF] & 0xff)) & 0xff;
    utilcrc16[portnum&0x0FF] >>= 8;
 
@@ -114,6 +116,8 @@ ushort docrc16(int portnum, ushort cdata)
 //
 uchar docrc8(int portnum, uchar x)
 {
+	if((portnum >= MAX_PORTNUM) || (portnum < 0)) return 0;
+	
    utilcrc8[portnum&0x0FF] = dscrc_table[utilcrc8[portnum&0x0FF] ^ x];
    return utilcrc8[portnum&0x0FF];
 }

--- a/DeviceCode/pal/OneWire/DallasSemi/ownet.cpp
+++ b/DeviceCode/pal/OneWire/DallasSemi/ownet.cpp
@@ -45,10 +45,11 @@
 SMALLINT bitacc(SMALLINT,SMALLINT,SMALLINT,uchar *);
 
 // global variables for this module to hold search state information
-static SMALLINT LastDiscrepancy[MAX_PORTNUM];
-static SMALLINT LastFamilyDiscrepancy[MAX_PORTNUM];
-static SMALLINT LastDevice[MAX_PORTNUM];
-uchar SerialNum[MAX_PORTNUM][8];
+static SMALLINT LastDiscrepancy[MAX_PORTNUM] = { 0 };
+static SMALLINT LastFamilyDiscrepancy[MAX_PORTNUM] = { 0 };
+static SMALLINT LastDevice[MAX_PORTNUM] = { 0 };
+SMALLINT owPortPin[MAX_PORTNUM] = { 0 };
+uchar SerialNum[MAX_PORTNUM][8] = { 0 };
 
 //--------------------------------------------------------------------------
 // The 'owFirst' finds the first device on the 1-Wire Net  This function
@@ -109,6 +110,8 @@ SMALLINT owNext(int portnum, SMALLINT do_reset, SMALLINT alarm_only)
   uchar serial_byte_mask;
   uchar lastcrc8;
 
+  if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
+	 
   // initialize for search
   lastcrc8=0;
   bit_number = 1;
@@ -262,7 +265,11 @@ SMALLINT owNext(int portnum, SMALLINT do_reset, SMALLINT alarm_only)
 void owSerialNum(int portnum, uchar *serialnum_buf, SMALLINT do_read)
 {
   uchar i;
-
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) 
+   {
+		if (serialnum_buf != NULL) *serialnum_buf=0;
+		return;
+   }
   // read the internal buffer and place in 'serialnum_buf'
   if (do_read)
   {
@@ -289,6 +296,8 @@ void owSerialNum(int portnum, uchar *serialnum_buf, SMALLINT do_read)
 void owFamilySearchSetup(int portnum, SMALLINT search_family)
 {
   uchar i;
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return;
+
 
   // set the search state to find SearchFamily type devices
   SerialNum[portnum][0] = search_family;
@@ -306,6 +315,8 @@ void owFamilySearchSetup(int portnum, SMALLINT search_family)
 //
 void owSkipFamily(int portnum)
 {
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return;
+
   // set the Last discrepancy to last family discrepancy
   LastDiscrepancy[portnum] = LastFamilyDiscrepancy[portnum];
   LastFamilyDiscrepancy[portnum] = 0;
@@ -333,6 +344,7 @@ SMALLINT owAccess(int portnum)
 {
   uchar sendpacket[9];
   uchar i;
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return FALSE;
 
   // reset the 1-wire
   if (owTouchReset(portnum))
@@ -396,7 +408,7 @@ SMALLINT owVerify(int portnum, SMALLINT alarm_only)
 {
   uchar i,sendlen=0,goodbits=0,cnt=0,s,tst;
   uchar sendpacket[50];
-
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return FALSE;
   // construct the search
   if (alarm_only)
     sendpacket[sendlen++] = 0xEC; // issue the alarming search command
@@ -460,7 +472,7 @@ SMALLINT owOverdriveAccess(int portnum)
 {
   uchar sendpacket[8];
   uchar i, bad_echo = FALSE;
-
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return FALSE;
   // make sure normal level
   owLevel(portnum,MODE_NORMAL);
 

--- a/DeviceCode/pal/OneWire/DallasSemi/ownet.h
+++ b/DeviceCode/pal/OneWire/DallasSemi/ownet.h
@@ -375,10 +375,10 @@ SMALLINT  owVerify(int portnum, SMALLINT alarm_only);
 SMALLINT  owOverdriveAccess(int portnum);
 
 
-// external One Wire functions defined in owsesu.c
- SMALLINT owAcquire(int portnum, char *port_zstr);
- int      owAcquireEx(char *port_zstr);
- void     owRelease(int portnum);
+// external One Wire functions defined in OneWireLinkLevelSession.cpp
+SMALLINT owAcquire(int portnum, int pin);
+//int      owAcquireEx(char *port_zstr);
+void     owRelease(int portnum);
 
 // external One Wire functions defined in findtype.c
 // SMALLINT FindDevices(int,uchar FamilySN[][8],SMALLINT,int);
@@ -432,5 +432,7 @@ void setcrc16(int portnum, ushort reset);
 ushort docrc16(int portnum, ushort cdata);
 void setcrc8(int portnum, uchar reset);
 uchar docrc8(int portnum, uchar x);
+
+extern SMALLINT owPortPin[MAX_PORTNUM];
 
 #endif //OWNET_H

--- a/DeviceCode/pal/OneWire/OneWireLinkLevelDriver.cpp
+++ b/DeviceCode/pal/OneWire/OneWireLinkLevelDriver.cpp
@@ -56,7 +56,9 @@ static SMALLINT ULevel; // current 1-Wire Net level
 SMALLINT owTouchReset(int portnum)
 {
    uchar result;
-   UINT32 pin = (UINT32)portnum; 
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
+   
+   UINT32 pin = (UINT32)owPortPin[portnum]; 
 	
    // Code from appnote 126.
    CPU_GPIO_EnableOutputPin( pin, false );  // impulse start OW_PORT = 0; // drive bus low.
@@ -94,7 +96,10 @@ SMALLINT owTouchReset(int portnum)
 SMALLINT owTouchBit(int portnum, SMALLINT sendbit)
 {
    unsigned char result=0;
-   UINT32 pin = (UINT32)portnum; 
+   
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0) ) return 0;
+   
+   UINT32 pin = (UINT32)owPortPin[portnum];  
 
    //timing critical, so I'll disable interrupts here
    GLOBAL_LOCK(irq); //EA = 0;
@@ -156,6 +161,8 @@ SMALLINT owTouchByte(int portnum, SMALLINT sendbyte)
    uchar i;
    uchar result = 0;
 
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
+
    for (i = 0; i < 8; i++)
    {
        result |= (owTouchBit(portnum,sendbyte & 1) << i);
@@ -179,6 +186,8 @@ SMALLINT owTouchByte(int portnum, SMALLINT sendbyte)
 //
 SMALLINT owWriteByte(int portnum, SMALLINT sendbyte)
 {
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
+   
    return (owTouchByte(portnum,sendbyte) == sendbyte) ? TRUE : FALSE;
 }
 
@@ -193,6 +202,7 @@ SMALLINT owWriteByte(int portnum, SMALLINT sendbyte)
 //
 SMALLINT owReadByte(int portnum)
 {
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
    return owTouchByte(portnum,0xFF);
 }
 
@@ -209,7 +219,7 @@ SMALLINT owReadByte(int portnum)
 //
 SMALLINT owSpeed(int portnum, SMALLINT new_speed)
 {
-   portnum = 0;
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
 
    USpeed = new_speed;
    // not supported yet
@@ -236,7 +246,7 @@ SMALLINT owSpeed(int portnum, SMALLINT new_speed)
 // Note: Strong and Program not supported on 520 target.
 SMALLINT owLevel(int portnum, SMALLINT new_level)
 {
-   portnum = 0;
+   if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] ==0)) return 0;
    
    UINT32 pin = (UINT32)portnum; 
    
@@ -268,7 +278,7 @@ SMALLINT owLevel(int portnum, SMALLINT new_level)
 //
 SMALLINT owProgramPulse(int portnum)
 {
-   portnum = 0;
+   //portnum = 0;
    // Not supported
    return 0;
 }

--- a/DeviceCode/pal/OneWire/OneWireLinkLevelSession.cpp
+++ b/DeviceCode/pal/OneWire/OneWireLinkLevelSession.cpp
@@ -38,8 +38,8 @@
 //extern void usDelay(int);
 
 // local function prototypes
-SMALLINT owAcquire(int,char *);
-void     owRelease(int);
+//SMALLINT owAcquire(int,int);
+//void     owRelease(int);
 
 //---------------------------------------------------------------------------
 // Attempt to acquire a 1-Wire net
@@ -50,12 +50,12 @@ void     owRelease(int);
 //
 // Returns: TRUE - success, port opened
 //
-SMALLINT owAcquire(int portnum, char *port_zstr)
+SMALLINT owAcquire(int portnum, int pin)
 {
-  port_zstr = 0;
+  if((portnum >= MAX_PORTNUM) || (portnum < 0) || (owPortPin[portnum] != 0)) return FALSE; // already in use
 
   //portnum = 0;
-  UINT32 pin = (UINT32)portnum; 
+  //UINT32 pin = (UINT32)atoi(port_zstr); 
    
   // drive bus high.
   CPU_GPIO_EnableOutputPin( pin, true );     
@@ -65,9 +65,17 @@ SMALLINT owAcquire(int portnum, char *port_zstr)
 
    // checks to make sure the line is idling high.
   CPU_GPIO_EnableInputPin( pin, false, NULL, GPIO_INT_EDGE_HIGH, RESISTOR_PULLUP );
-  return (CPU_GPIO_GetPinState(pin) ==1 ? TRUE : FALSE);
+  
+  if (CPU_GPIO_GetPinState(pin)==1)
+  {
+	owPortPin[portnum] = pin;
+	return TRUE;
+  }
+  else
+  {
+	return FALSE;
+  }
 }
-
 //---------------------------------------------------------------------------
 // Release the previously acquired a 1-Wire net.
 //
@@ -76,7 +84,14 @@ SMALLINT owAcquire(int portnum, char *port_zstr)
 //
 void owRelease(int portnum)
 {
-   portnum = 0;
+   if((portnum < MAX_PORTNUM) && (portnum >= 0) ) 
+   {
+		UINT32 pin = (UINT32)owPortPin[portnum]; 
+				
+		CPU_GPIO_EnableInputPin( pin, false, NULL, GPIO_INT_NONE, RESISTOR_PULLUP );
+		
+		owPortPin[portnum] = 0;
+   }
 }
 
 

--- a/DeviceCode/pal/OneWire/Stubs/OneWireLinkLevelSession_stubs.cpp
+++ b/DeviceCode/pal/OneWire/Stubs/OneWireLinkLevelSession_stubs.cpp
@@ -47,7 +47,7 @@
 //
 // Returns: FALSE - failed
 //
-SMALLINT owAcquire(int portnum, char *port_zstr)
+SMALLINT owAcquire(int portnum, int pin)
 {
   return (FALSE);
 }

--- a/DeviceCode/pal/dotNetMF.proj
+++ b/DeviceCode/pal/dotNetMF.proj
@@ -29,6 +29,7 @@
     <SubDirectories Include="timeservice"/>
     <SubDirectories Include="tinycrt"/>
     <SubDirectories Include="TouchPanel"/>
+    <SubDirectories Include="OneWire"/>    
   </ItemGroup>
 
   <ItemGroup>

--- a/Framework/Core/Native_Hardware/Native_OneWire/Core_Native_Hardware_OneWire.cs
+++ b/Framework/Core/Native_Hardware/Native_OneWire/Core_Native_Hardware_OneWire.cs
@@ -42,10 +42,9 @@ namespace Microsoft.SPOT.Hardware
         public ArrayList FindAllDevices()
         {
             int rslt;
-            int portnum = 0;
  
             // attempt to acquire the 1-Wire Net
-            if ((portnum = AcquireEx()) < 0)
+            if ((rslt = AcquireEx()) < 0)
             {
                 //OWERROR_DUMP(stdout);
 
@@ -75,13 +74,16 @@ namespace Microsoft.SPOT.Hardware
             Release();
 
             return serialNumbers;
-        }        
+        }
 
-        uint _pin; // The native code only needs pin number
+        uint _pin; 						// The native code only needs pin number
+        uint _logicalPort; 				// Handle used for subsequent calls. 
+		const uint MAX_PORTNUM  = 16;	// Must be the same as defined in "DeviceCode\pal\OneWire\DallasSemi\ownet.h"
 
-        public OneWire(OutputPort port)
+        public OneWire(uint logicalPort, OutputPort port)
         {
-            _pin = (uint)port.Id; // the pin number is enough to identify the port on the native side
+            _pin = (uint)port.Id; 		// the pin number is enough to identify the port on the native side
+			_logicalPort = logicalPort; // 0 .. MAX_PORTNUM    (default .NetMF is 16 logical ports)
         }
     }
 }

--- a/Framework/Features/OneWire_PAL.libcatproj
+++ b/Framework/Features/OneWire_PAL.libcatproj
@@ -50,7 +50,7 @@
     </VersionDependency>
     <ComponentType>Feature</ComponentType>
   </FeatureAssociations>
-  <IsTranport xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">true</IsTranport>
+  <IsTransport xmlns="http://schemas.microsoft.com/netmf/InventoryFormat.xsd">true</IsTransport>
 </LibraryCategory></PKUI_LibraryCategory>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
OneWire constructor extended to accept both a logical port number in the range 0..MAX_PORTNUM-1, and a physical IO Port. 

Physical I/O Output pin number stored in an internal array indexed by the logical port number. 
Logical port number checked to be in range. Further calls to OneWire API expect logical port number, which is used to look up physical I/O port number. 

Fixes issue noted in NetMF Codeplex: 
- https://netmf.codeplex.com/workitem/1884
- https://netmf.codeplex.com/workitem/1891
