### PR TITLE
Avoid signed/unsigned mismatch in ConfigurationSectorManager

### DIFF
--- a/Application/TinyBooter/ConfigurationManager.cpp
+++ b/Application/TinyBooter/ConfigurationManager.cpp
@@ -113,7 +113,7 @@ void ConfigurationSectorManager::WriteConfiguration( UINT32 writeOffset, BYTE *d
     // Validity  write 
     if (checkWrite)
     {
-        for (int i = 0; i<size; i++)
+        for (UINT32 i = 0; i<size; i++)
         {
             if ((~configurationInBytes[ i + writeOffset ]) & data[ i ])
             { 
@@ -137,7 +137,7 @@ void ConfigurationSectorManager::WriteConfiguration( UINT32 writeOffset, BYTE *d
         {
             m_device->Read( m_cfgPhysicalAddress, writeLengthInBytes, configurationInBytes );
             // copy the new data to the configdata.
-            for (int i = 0; i<size; i++)
+            for (UINT32 i = 0; i<size; i++)
             {
                 configurationInBytes[ i + writeOffset ] = data[ i ];
 


### PR DESCRIPTION
Two for loops use int i which triggers a signed/unsigned warning when compared to
the UINT32 size parameter in ConfigurationSectorManager::WriteConfiguration(....)
