### PR TITLE
qualify path to CreateCLRDefines.proj

### DIFF
--- a/Framework/Tools/CreateCLRDefines.proj
+++ b/Framework/Tools/CreateCLRDefines.proj
@@ -3,7 +3,7 @@
   <Import Project="$(SPOCLIENT)\tools\targets\Microsoft.SPOT.System.Settings" />
 
   <PropertyGroup>
-    <Directory>Framework\tools</Directory>
+    <Directory>$(SPOCLIENT)\Framework\tools</Directory>
     <PreBuildDependsOn>$(PreBuildDependsOn);BuildClrDefines</PreBuildDependsOn>
     <InCLRDefines>True</InCLRDefines>
   </PropertyGroup>


### PR DESCRIPTION
ensure the correct path is used to reference the project file by adding `$(SPOCLIENT)` to the path defined in the Directory Property. 
