### PR TITLE
Import BuildEnv.props into c# Test projects

### DIFF
--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Graphics/Bitmap.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Graphics/Bitmap.csproj
@@ -1,4 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Bitmap</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/EmulateHardware/EmulateHardware.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/EmulateHardware/EmulateHardware.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>EmulateHardware</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/I2C/I2C.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/I2C/I2C.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>I2C</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/LargeBuffer/LargeBuffer.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/LargeBuffer/LargeBuffer.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>LargeBuffer</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/UsbClient/UsbClient.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Hardware/UsbClient/UsbClient.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>UsbClient</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Interop/Interop.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Interop/Interop.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Interop</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Net.Security/ClientServer/Device.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Net.Security/ClientServer/Device.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Test.SslClient</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Net.Security/SslStream/SslStreamTests.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Net.Security/SslStream/SslStreamTests.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.SslStream</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Net/WiFiTests/WiFiTests1/WiFiTests1.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Net/WiFiTests/WiFiTests1/WiFiTests1.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>WiFiTests1</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Net/netInfoTests/netInfoTests.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Net/netInfoTests/netInfoTests.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>NetInfoTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.Time/TimeServiceTests/TimeServiceTests.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.Time/TimeServiceTests/TimeServiceTests.csproj
@@ -1,4 +1,11 @@
-﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.TimeServiceTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Controls/Controls.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Controls/Controls.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Controls</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Media/Media.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Media/Media.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Media</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Presentation/Presentation.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Presentation/Presentation.csproj
@@ -1,4 +1,11 @@
-﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Presentaion</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Shapes/Shapes.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT.TinyCore/Shapes/Shapes.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Shapes</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/Microsoft.SPOT/ExtendedWeakReferenceTests/ExtendedWeakReferenceTests.csproj
+++ b/Test/Platform/Tests/CLR/Microsoft.SPOT/ExtendedWeakReferenceTests/ExtendedWeakReferenceTests.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.ExtendedWeakReferenceTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/Http/HttpTests.csproj
+++ b/Test/Platform/Tests/CLR/System/Http/HttpTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.HttpTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/Directory/DirectoryTests.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/Directory/DirectoryTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IO.DirectoryTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/File/FileTests.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/File/FileTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IO.FileTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/FileStream/FileStreamTests.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/FileStream/FileStreamTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IO.FileStreamTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/IOTests.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/IOTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IOTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/IOTestsHelper/IOTestsHelper.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/IOTestsHelper/IOTestsHelper.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IOTestsHelper</AssemblyName>
     <OutputType>Library</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/MemoryStream/MemoryStreamTests.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/MemoryStream/MemoryStreamTests.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IO.MemoryStreamTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/IO/Path/PathTests.csproj
+++ b/Test/Platform/Tests/CLR/System/IO/Path/PathTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.IO.PathTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/Text/Regexp/RegEx.csproj
+++ b/Test/Platform/Tests/CLR/System/Text/Regexp/RegEx.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.RegExTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/Text/StringBuilder/StringBuilder.csproj
+++ b/Test/Platform/Tests/CLR/System/Text/StringBuilder/StringBuilder.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.StringBuilderTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/System/xmlTests/xmlTests.csproj
+++ b/Test/Platform/Tests/CLR/System/xmlTests/xmlTests.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Xml</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/arrays/arrays.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/arrays/arrays.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Arrays</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/attributes/attributes.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/attributes/attributes.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Attributes</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/basicconcepts/basicconcepts.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/basicconcepts/basicconcepts.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.BasicConcepts</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/bitconverter/bitconverter.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/bitconverter/bitconverter.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.BitConverter</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/classes/classes1/classes1.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/classes/classes1/classes1.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Classes</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/classes/classes2/classes2.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/classes/classes2/classes2.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Classes</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/classes/classes3/classes3.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/classes/classes3/classes3.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Classes</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/collections/collections.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/collections/collections.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Collections</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/conversions/conversions.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/conversions/conversions.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Conversions</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/delegates/delegates.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/delegates/delegates.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Delegates</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/enums/enums.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/enums/enums.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Enums</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/exceptions/CSharp/exceptions.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/exceptions/CSharp/exceptions.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Exceptions</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/exceptions/VB/exceptions_VB.vbproj
+++ b/Test/Platform/Tests/CLR/mscorlib/exceptions/VB/exceptions_VB.vbproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <ProductVersion>9.0.30729</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>

--- a/Test/Platform/Tests/CLR/mscorlib/expressions/expressions1/expressions1.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/expressions/expressions1/expressions1.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Expressions</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/expressions/expressions2/expressions2.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/expressions/expressions2/expressions2.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Expressions</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/interfaces/interfaces.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/interfaces/interfaces.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Interfaces</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/lexical/lexical.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/lexical/lexical.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Lexical</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/namespaces/namespaces.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/namespaces/namespaces.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Namespaces</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/statements/statements.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/statements/statements.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Statements</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/structs/structs.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/structs/structs.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Structs</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Systemlib</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib1/systemlib1.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib1/systemlib1.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Systemlib1</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/systemlib2.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/systemlib/systemlib2/systemlib2.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Systemlib2</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/threads/threads1/threads1.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/threads/threads1/threads1.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Threads1</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/threads/threads2/threads2.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/threads/threads2/threads2.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Threads2</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/threads/threads3/threads3.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/threads/threads3/threads3.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Threads3</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/types/types.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/types/types.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Types</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/CLR/mscorlib/variables/variables.csproj
+++ b/Test/Platform/Tests/CLR/mscorlib/variables/variables.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Variables</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Native_MathMethods/Math/Math/MathTests.csproj
+++ b/Test/Platform/Tests/Native_MathMethods/Math/Math/MathTests.csproj
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>System.Math.Tests.MathTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/ProfilerTests/ProfilerCollectionsTests/ProfilerCollectionsTests.csproj
+++ b/Test/Platform/Tests/Performance/ProfilerTests/ProfilerCollectionsTests/ProfilerCollectionsTests.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>ProfilerCollectionsTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/ProfilerTests/ProfilerStringTests/ProfilerStringTests.csproj
+++ b/Test/Platform/Tests/Performance/ProfilerTests/ProfilerStringTests/ProfilerStringTests.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>ProfilerStringTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/ProfilerTests/ProfilerThreadTests/ProfilerThreadTests.csproj
+++ b/Test/Platform/Tests/Performance/ProfilerTests/ProfilerThreadTests/ProfilerThreadTests.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>ProfilerThreadTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/ProfilerTests/ProfilerXmlTests/ProfilerXmlTests.csproj
+++ b/Test/Platform/Tests/Performance/ProfilerTests/ProfilerXmlTests/ProfilerXmlTests.csproj
@@ -1,4 +1,10 @@
 ﻿<Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>ProfilerXmlTests</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/Sockets/Sockets.csproj
+++ b/Test/Platform/Tests/Performance/Sockets/Sockets.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Performance.Sockets</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/Stress/Sockets/Loopback/Loopback.csproj
+++ b/Test/Platform/Tests/Performance/Stress/Sockets/Loopback/Loopback.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Loopback</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/Stress/Sockets/MultiThreadStress/MultiThreadStress.csproj
+++ b/Test/Platform/Tests/Performance/Stress/Sockets/MultiThreadStress/MultiThreadStress.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>MultiThreadStress</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/Stress/Sockets/NormalMode/SocketClient/SocketClientTest.csproj
+++ b/Test/Platform/Tests/Performance/Stress/Sockets/NormalMode/SocketClient/SocketClientTest.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>9.0.21022</ProductVersion>

--- a/Test/Platform/Tests/Performance/Stress/Sockets/NormalMode/SocketServer/SocketServerTest.csproj
+++ b/Test/Platform/Tests/Performance/Stress/Sockets/NormalMode/SocketServer/SocketServerTest.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>SocketServerTest</AssemblyName>
     <OutputType>Exe</OutputType>

--- a/Test/Platform/Tests/Performance/Strings/Strings.csproj
+++ b/Test/Platform/Tests/Performance/Strings/Strings.csproj
@@ -1,4 +1,10 @@
 <Project DefaultTargets="TinyCLR_Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="4.0">
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props" Condition="Exists('$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), BuildEnv.props))\BuildEnv.props')" />
+  <PropertyGroup>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Microsoft.SPOT.Platform.Tests.Performance.Strings</AssemblyName>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
This pull request implements the suggestion in #269 to import BuilEnv.props into the Test project files. I great suggestion that makes the Unit Tests far more accessible and user friendly. Hopefully more people will now use them and extend them. 

By importing the BuildEnv.props into the C# projects, it is possible to open the solution file directly by double clicking on the .sln file in Windows File Explorer, and then build and Run or Debug the test(s) in the emulator or on native Hardware. 

Unit testing by running RunTests.exe with test lists etc remains the same and one can target the emulator or a device as we currently do. 

It is possible to open the MFTestSystem.sln file and run it directly too. Modify the command line parameters in the project settings to specify the device to run the tests on. It is possible to single step and debug MFTestSystem. 

There is one caveat. Currently I cannot open MFTestSystem.sln and specify the Emulator as the test target and successfully run working unit tests. Specifying a device as a target works as expected with the test deployed to the target device and executed. However, if the Emulator is specified, then the test does not run correctly. It is as is the emulator process terminates early and incomplete XML test results are received, and the test is reported as failed  There must be a simple fix for this that I cannot see given RunTests.exe can specify the emulator when run from the command line with the correct behavior against the emulator. .
