### PR TITLE
Reverted change from previous commit that broke GCC builds

### DIFF
--- a/tools/Targets/Microsoft.Spot.system.gcc.targets
+++ b/tools/Targets/Microsoft.Spot.system.gcc.targets
@@ -221,7 +221,7 @@
     <GCCSTDLIBS>-lstdc++ -lsupc++ -lm -lgcc -lc </GCCSTDLIBS>
 
     <!-- Use newlib-nano (default) or newlib -->
-    <LINK_NANO_SPECS Condition="'$(NewlibNano)' != 'false'">-specs="$(GNU_LIBGCC_DIR)\nano.specs" -specs="$(GNU_LIBGCC_DIR)\nosys.specs"  </LINK_NANO_SPECS>
+    <LINK_NANO_SPECS Condition="'$(NewlibNano)' != 'false'">-specs="$(GNU_LIBGCC_DIR)\nano.specs" </LINK_NANO_SPECS>
   </PropertyGroup>
 
   <!-- item group  -->


### PR DESCRIPTION
Removed nosys.specs that caused "undefined reference to 'end'" error in _sbrk function.

This could be considered a minimal-changes hotfix (affects all GCC builds of all solutions and toolchain versions, tested 4.9 to 5.4), until another solution is implemented (e.g. as proposed by @josesimoes in his PRs).
