### PR TITLE
TinyBooter explicitly uses crypto stubs

### DIFF
--- a/Solutions/STM32F429IDISCOVERY/TinyBooter/TinyBooter.proj
+++ b/Solutions/STM32F429IDISCOVERY/TinyBooter/TinyBooter.proj
@@ -39,8 +39,8 @@
         <RequiredProjects Include="$(SPOCLIENT)\Application\TinyBooter\TinyBooterLib.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Crypto.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\Crypto\dotNetMF.proj" />
+        <DriverLibs Include="Crypto_stub.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\Crypto\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="GlobalLock_hal_Cortex.$(LIB_EXT)" />

--- a/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
+++ b/Solutions/STM32F4DISCOVERY/TinyBooter/TinyBooter.proj
@@ -38,8 +38,8 @@
         <RequiredProjects Include="$(SPOCLIENT)\Application\TinyBooter\TinyBooterLib.proj" />
     </ItemGroup>
     <ItemGroup>
-        <DriverLibs Include="Crypto.$(LIB_EXT)" />
-        <RequiredProjects Include="$(SPOCLIENT)\Crypto\dotNetMF.proj" />
+        <DriverLibs Include="Crypto_stub.$(LIB_EXT)" />
+        <RequiredProjects Include="$(SPOCLIENT)\Crypto\stubs\dotNetMF.proj" />
     </ItemGroup>
     <ItemGroup>
         <DriverLibs Include="GlobalLock_hal_Cortex.$(LIB_EXT)" />


### PR DESCRIPTION
This is a fix for a few issues with the legacy crypto libraries that popped out in @josesimoes PR #475 (also related to #341).

Explicitly referencing crypto_stub.lib ensures that crypto\dotnetmf.proj does not automagically select either crypto.lib or crypto_stub.lib based solely on the presence of lib...\crypto.lib, which requires a manual installation; and also so it does not force GCC to use binaries built with ARM/Keil which results in linker warnings (VFP mismatch) or errors (when using newlib-nano).

(It also makes TinyBooter considerably smaller, just under 32 KB, for both MDK and GCC 5.3+ builds).

In case there is any solution based on these two DISCO implementations that require crypto functionality, I would recommend to fix the build steps in crypto\dotnetmf.proj (and provide proper binary for GCC; I guess none of which will happen due to the plan to completely abandon this).
