### PR TITLE
Use implicit FPU option for 'cpu'

### DIFF
--- a/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
+++ b/DeviceCode/Targets/Native/STM32F4/STM32F4.settings
@@ -22,11 +22,11 @@
     </ItemGroup>
 
     <PropertyGroup Condition="'$(COMPILER_TOOL)'=='RVDS'">
-        <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M4.fp</DEVICE_TYPE>
+        <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M4.fp.sp</DEVICE_TYPE>
         <BUILD_TOOL_GUID>{00C50096-00DD-00E7-BBA9-7FC84D408562}</BUILD_TOOL_GUID>
     </PropertyGroup>
     <PropertyGroup Condition="'$(COMPILER_TOOL)'=='MDK'">
-        <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M4.fp</DEVICE_TYPE>
+        <DEVICE_TYPE Condition="'$(DEVICE_TYPE)' == ''">Cortex-M4.fp.sp</DEVICE_TYPE>
         <BUILD_TOOL_GUID>{00EC0018-007A-0040-9936-929B39330107}</BUILD_TOOL_GUID>
     </PropertyGroup>
     <PropertyGroup Condition="'$(COMPILER_TOOL)'=='GCC'">

--- a/tools/Targets/Microsoft.Spot.system.mdk.targets
+++ b/tools/Targets/Microsoft.Spot.system.mdk.targets
@@ -114,8 +114,7 @@
     <ARM_TYPE_FLAGS Condition="'$(OLD_STYLE_DEVICE_TYPE_NAME)'!='true' AND '$(DEVICE_TYPE)'!=''">$(SWTC)cpu $(DEVICE_TYPE)</ARM_TYPE_FLAGS>
     <ARM_TYPE_FLAGS Condition="'$(OLD_STYLE_DEVICE_TYPE_NAME)'=='true'">$(SWTC)device $(DEVICE_TYPE)</ARM_TYPE_FLAGS>
 
-    <!-- Use default fpu specification for Cortex-M4F -->
-    <FLOATING_POINT_FLAG Condition="'$(PLATFORM_EMULATED_FLOATINGPOINT)'!='true' AND '$(DEVICE_TYPE)'!='Cortex-M4.fp'"> $(SWTC)fpu softvfp </FLOATING_POINT_FLAG>
+    <!-- Use implicit FPU option for 'cpu', override with 'fpu'' if needed -->
     <FLOATING_POINT_FLAG Condition="'$(PLATFORM_EMULATED_FLOATINGPOINT)'=='true'"> $(SWTC)fpu none </FLOATING_POINT_FLAG>
 
     <AS_CC_CPP_COMMON_FLAGS>$(AS_CC_CPP_COMMON_FLAGS) $(FLOATING_POINT_FLAG) $(ARM_TYPE_FLAGS)</AS_CC_CPP_COMMON_FLAGS>


### PR DESCRIPTION
This is a fix for #498 (as per [4.53 Processors and their implicit Floating-Point Units (FPUs)](http://www.keil.com/support/man/docs/armcc/armcc_chr1359124234797.htm)).
