### PR TITLE
Add additional args support to build_solution.cmd

### DIFF
--- a/build_solution.cmd
+++ b/build_solution.cmd
@@ -2,5 +2,5 @@
 setlocal
 call setenv_%1 %2
 cd Solutions\%3
-msbuild /flp:verbosity=detailed /clp:verbosity=minimal
+msbuild /flp:verbosity=detailed /clp:verbosity=minimal %~4
 endlocal


### PR DESCRIPTION
updated build_solution.cmd to support passing args to msbuild to allow build_solution.cmd to support passing args to msbuild toalowtargetting specific projects in a solution folder. This is needed for the automated build to target tinybooter and or TinyCLR\tinyclr.proj vs Tinyclr_nonet\tinyclr.proj in the MCBSTM32F400 solution with MDK or GCC as needed. 
