### PR TITLE
Fix build_solution to return correct ERRORLEVEL

### DIFF
--- a/build_solution.cmd
+++ b/build_solution.cmd
@@ -3,4 +3,4 @@ setlocal
 call setenv_%1 %2
 cd Solutions\%3
 msbuild /flp:verbosity=detailed /clp:verbosity=minimal %~4
-endlocal
+endlocal&&exit /B %ERRORLEVEL%


### PR DESCRIPTION
updated build_solution.cmd so that correct error level is returned even after endlocal completes. By using `endlocal&&exit /B %ERRORLEVE%` as a single statement the current error level is captured by the parser before the endlocal is executed so that the exit will set the ERRORLEVEL for the script to match the msbuild return outside of the setlocal/endlocal scope.
