### PR TITLE
Changed CPU_GPIO_DisablePin AltFunction parameter type to UINT32

### DIFF
--- a/DeviceCode/Drivers/Stubs/Processor/stubs_gpio/stubs_functions_gpio.cpp
+++ b/DeviceCode/Drivers/Stubs/Processor/stubs_gpio/stubs_functions_gpio.cpp
@@ -20,7 +20,7 @@ UINT32 CPU_GPIO_Attributes( GPIO_PIN Pin )
     return GPIO_ATTRIBUTE_NONE;
 }
 
-void CPU_GPIO_DisablePin( GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, GPIO_ALT_MODE AltFunction )
+void CPU_GPIO_DisablePin( GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, UINT32 AltFunction )
 {
 }
 

--- a/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_GPIO/STM32_GPIO_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32/DeviceCode/STM32_GPIO/STM32_GPIO_functions.cpp
@@ -277,7 +277,7 @@ UINT32 CPU_GPIO_Attributes( GPIO_PIN pin )
 }
 
 
-void CPU_GPIO_DisablePin( GPIO_PIN pin, GPIO_RESISTOR resistor, UINT32 output, GPIO_ALT_MODE alternate )
+void CPU_GPIO_DisablePin( GPIO_PIN pin, GPIO_RESISTOR resistor, UINT32 output, UINT32 alternate )
 {
     NATIVE_PROFILE_HAL_PROCESSOR_GPIO();
     if (pin < STM32_Gpio_MaxPins) {

--- a/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_GPIO/STM32F4_GPIO_functions.cpp
+++ b/DeviceCode/Targets/Native/STM32F4/DeviceCode/STM32F4_GPIO/STM32F4_GPIO_functions.cpp
@@ -342,7 +342,7 @@ UINT32 CPU_GPIO_Attributes( GPIO_PIN pin )
  * GPIO_ALT_MODE_3 | AF << 4 | speed << 8: Alternate Function with open drain
  * speed: 0: 2MHZ, 1: 25MHz, 2: 50MHz, 3: 100MHz
  */
-void CPU_GPIO_DisablePin( GPIO_PIN pin, GPIO_RESISTOR resistor, UINT32 output, GPIO_ALT_MODE alternate )
+void CPU_GPIO_DisablePin( GPIO_PIN pin, GPIO_RESISTOR resistor, UINT32 output, UINT32 alternate )
 {
     NATIVE_PROFILE_HAL_PROCESSOR_GPIO( );
     if( pin < STM32F4_Gpio_MaxPins )
@@ -355,7 +355,7 @@ void CPU_GPIO_DisablePin( GPIO_PIN pin, GPIO_RESISTOR resistor, UINT32 output, G
         else if( altMode )
             mode = 2; // alternate pin function
 
-        STM32F4_GPIO_Pin_Config( pin, mode, resistor, ( UINT32 )alternate );
+        STM32F4_GPIO_Pin_Config( pin, mode, resistor, alternate );
         STM32F4_GPIO_Set_Interrupt( pin, NULL, 0, GPIO_INT_NONE, FALSE ); // disable interrupt
     }
 }

--- a/DeviceCode/include/CPU_GPIO_decl.h
+++ b/DeviceCode/include/CPU_GPIO_decl.h
@@ -57,7 +57,7 @@ typedef void (*GPIO_INTERRUPT_SERVICE_ROUTINE)( GPIO_PIN Pin, BOOL PinState, voi
 BOOL   CPU_GPIO_Initialize     ();
 BOOL   CPU_GPIO_Uninitialize   ();
 UINT32 CPU_GPIO_Attributes     ( GPIO_PIN Pin );
-void   CPU_GPIO_DisablePin     ( GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, GPIO_ALT_MODE AltFunction );
+void   CPU_GPIO_DisablePin     ( GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, UINT32 AltFunction );
 void   CPU_GPIO_EnableOutputPin( GPIO_PIN Pin, BOOL InitialState );
 BOOL   CPU_GPIO_EnableInputPin ( GPIO_PIN Pin, BOOL GlitchFilterEnable, GPIO_INTERRUPT_SERVICE_ROUTINE PIN_ISR, GPIO_INT_EDGE IntEdge, GPIO_RESISTOR ResistorState );
 BOOL   CPU_GPIO_EnableInputPin2( GPIO_PIN Pin, BOOL GlitchFilterEnable, GPIO_INTERRUPT_SERVICE_ROUTINE PIN_ISR, void* ISR_Param, GPIO_INT_EDGE IntEdge, GPIO_RESISTOR ResistorState );
@@ -74,6 +74,12 @@ UINT8  CPU_GPIO_GetSupportedInterruptModes(GPIO_PIN pin );
 
 UINT32 CPU_GPIO_GetPinDebounce( GPIO_PIN Pin );
 BOOL   CPU_GPIO_SetPinDebounce( GPIO_PIN Pin, INT64 debounceTimeMilliseconds );
+
+// For backward compatibility
+inline void CPU_GPIO_DisablePin(GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, GPIO_ALT_MODE AltFunction)
+{
+    return CPU_GPIO_DisablePin(Pin, ResistorState, Direction, (UINT32)AltFunction);
+}
 
 #endif // _DRIVERS_GPIO_DECL_H_
 

--- a/Solutions/Windows2/TinyCLR/GPIO.cpp
+++ b/Solutions/Windows2/TinyCLR/GPIO.cpp
@@ -24,7 +24,7 @@ UINT32 CPU_GPIO_Attributes( GPIO_PIN Pin )
     return EmulatorNative::GetIGpioDriver()->Attributes( Pin );
 }
 
-void CPU_GPIO_DisablePin( GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, GPIO_ALT_MODE AltFunction )
+void CPU_GPIO_DisablePin( GPIO_PIN Pin, GPIO_RESISTOR ResistorState, UINT32 Direction, UINT32 AltFunction )
 {
     EmulatorNative::GetIGpioDriver()->DisablePin( Pin, ResistorState, Direction, AltFunction );
 }


### PR DESCRIPTION
As discussed in #464 and #514.

_Note: This change also allows functions that were created to workaround the enum limitation (e.g. `STM32_GPIO_Pin_Config`) to be consolidated and the code can be moved inside `CPU_GPIO_DisablePin(..., UINT32 )`._
